### PR TITLE
trouble with gmails spam filter

### DIFF
--- a/services/smtp.py
+++ b/services/smtp.py
@@ -21,6 +21,7 @@ def plugin(srv, item):
     password    = item.config['password']
 
     msg = MIMEText(item.message)
+    msg['To']           =  ', '.join( smtp_addresses )
     msg['Subject']      = item.get('title', "%s notification" % (srv.SCRIPTNAME))
     msg['From']         = sender
     msg['X-Mailer']     = srv.SCRIPTNAME


### PR DESCRIPTION
Not sure if this is a common problem. But all emails i was sending to my gmail account kept ending up in the spam folder.

Adding this seems to of fixed it for ME. 

However I believe it will show all email addresses in the TO: field now.

Might need someone else to test this.
