### PR TITLE
transformation data can be used in filename

### DIFF
--- a/services/file.py
+++ b/services/file.py
@@ -15,7 +15,7 @@ def plugin(srv, item):
     # addrs is a list[] associated with a particular target.
     # While it may contain more than one item (e.g. pushover)
     # the `file' service carries one only, i.e. a path name
-    filename = item.addrs[0]
+    filename = item.addrs[0].format(**item.data).encode('utf-8')
 
     # If the incoming payload has been transformed, use that,
     # else the original payload


### PR DESCRIPTION
Allows the use of transformation data form a datamap to specify filename. resolves #82
