### PR TITLE
Added special failover target for error conditions

### DIFF
--- a/mqttwarn.ini.sample
+++ b/mqttwarn.ini.sample
@@ -46,6 +46,9 @@ targets = {
     'shell' : [ None ],
    }
 
+; special config for 'failover' events
+[failover]
+targets = osxnotify
 
 [hello/1]
 targets = log:info


### PR DESCRIPTION
@jpmens this is an attempt at #19. Currently there is just one 'failover' event, broker disconnection. But it shouldn't be too hard to add others. Just have to be careful we don't get into a recursive loop if we try to send failover messages inside the processing loop, which fail as well...

Tested locally and I now get a nice notification whenever my broker connection goes down. Actually get the same notification every 5s until the broker comes back up! That retry period might be worth making configurable?

Let me know your thoughts.
