### PR TITLE
Add feature "dynamic topic targets"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/.idea
+/.venv*
 *.pyc
 *.confc
 .DS_Store

--- a/mqttwarn.ini.sample
+++ b/mqttwarn.ini.sample
@@ -62,3 +62,17 @@ targets = log:info, file:f01
 datamap = OwnTracksTopic2Data()
 filter  = OwnTracksBattFilter()
 format  = {username}'s phone battery is getting low ({batt}%)
+
+[robustness-1]
+; even if "foo" is considered an invalid service or
+; "log:baz" is considered an invalid service target,
+; mqttwarn should keep calm and carry on
+topic   = test/robustness-1
+targets = foo:bar, log:baz
+
+[topic-targets-dynamic]
+; interpolate transformation data values into topic target, example:
+; mosquitto_pub -t test/topic-targets-dynamic -m '{"loglevel": "crit", "message": "Nur Döner macht schöner!"}'
+topic   = test/topic-targets-dynamic
+format  = Something {loglevel} happened! {message}
+targets = log:{loglevel}

--- a/mqttwarn.py
+++ b/mqttwarn.py
@@ -583,7 +583,17 @@ def send_to_targets(section, topic, payload):
             return
 
     # interpolate transformation data values into topic targets
-    targetlist = [t.format(**data) for t in targetlist]
+    # be graceful if interpolation fails, but log a meaningful message
+    targetlist_resolved = []
+    for target in targetlist:
+        try:
+            target = target.format(**data)
+            targetlist_resolved.append(target)
+        except Exception as ex:
+            error = repr(ex)
+            logging.error('Cannot interpolate transformation data into topic target "{target}": {error}. ' \
+                          'section={section}, topic={topic}, payload={payload}, data={data}'.format(**locals()))
+    targetlist = targetlist_resolved
 
     for t in targetlist:
         logging.debug("Message on %s going to %s" % (topic, t))


### PR DESCRIPTION
Dear Jan-Piet and Ben,

first things first: Thanks for sharing this great project!

We tried to enhance _mqttwarn_ to add functionality we need for our Hiveeyes bee monitoring project. The feature was implemented as generic as possible to provide added value to the _mqttwarn_ infrastructure in general. Kudos go to @einsiedlerkrebs for conceiving it and making this possible.

A short overview over the changes made:
- Interpolate transformation data into topic targets
- Improve overall robustness and address #27, this was essential for implementing the feature

Please get back to us if you have further questions or suggestions.

With kind regards,
Andreas.