### PR TITLE
Use functions for computing topic targets

### DIFF
--- a/mqttwarn.ini.sample
+++ b/mqttwarn.ini.sample
@@ -50,6 +50,9 @@ targets = log:error, file:mqttwarn
 targets = log:info
 format = u'{name}: {number} => {_dthhmm}'
 
+[hello/2]
+targets = TopicTargetList()
+
 [owntracks-location]
 topic = owntracks/+/+
 targets = log:info, file:f01

--- a/mqttwarn.ini.sample
+++ b/mqttwarn.ini.sample
@@ -36,6 +36,7 @@ targets = {
     
 [config:log]
 targets = {
+    'debug'  : [ 'debug' ],
     'info'   : [ 'info' ],
     'warn'   : [ 'warn' ],
     'crit'   : [ 'crit' ],
@@ -49,9 +50,6 @@ targets = log:error, file:mqttwarn
 [hello/1]
 targets = log:info
 format = u'{name}: {number} => {_dthhmm}'
-
-[hello/2]
-targets = TopicTargetList()
 
 [owntracks-location]
 topic = owntracks/+/+
@@ -79,3 +77,11 @@ targets = foo:bar, log:baz
 topic   = test/topic-targets-dynamic
 format  = Something {loglevel} happened! {message}
 targets = log:{loglevel}
+
+[topic-targets-func]
+; use functions for computing topic targets, example:
+; mosquitto_pub -t test/topic-targets-func -m '{"condition": "sunny", "remark": "This should go to a file"}'
+; mosquitto_pub -t test/topic-targets-func -m '{"condition": "rainy", "remark": "This should go to the log"}'
+topic   = test/topic-targets-func
+format  = Weather conditions changed: It's {condition}. Remark: {remark}
+targets = TopicTargetList()

--- a/mqttwarn.py
+++ b/mqttwarn.py
@@ -459,8 +459,10 @@ def get_topic_targets(section, topic, data):
         name = get_function_name(cf.get(section, 'targets'))
         try:
             return cf.topic_target_list(name, topic, data)
-        except Exception, e:
-            logging.warn("Cannot invoke topic targets function %s defined in %s: %s" % (name, section, str(e)))
+        except Exception as ex:
+            error = repr(ex)
+            logging.warn('Error invoking topic targets function "{name}" ' \
+                         'defined in section "{section}": {error}'.format(**locals()))
     return None
 
 class Job(object):
@@ -581,6 +583,12 @@ def send_to_targets(section, topic, payload):
 
     if function_name is not None:
         targetlist = get_topic_targets(section, topic, data)
+        targetlist_type = type(targetlist)
+        if targetlist_type is not types.ListType:
+            logging.error('Topic target definition by function "{function_name}" ' \
+                          'in section "{section}" is empty or incorrect. ' \
+                          'targetlist={targetlist}, type={targetlist_type}'.format(**locals()))
+            return
 
     elif type(dispatcher_dict) == dict:
         def get_key(item):

--- a/samplefuncs.py
+++ b/samplefuncs.py
@@ -37,3 +37,21 @@ def OwnTracksBattFilter(topic, message):
             return int(data['batt']) > 20
     
     return True     # Suppress message because no 'batt'
+
+def TopicTargetList(topic=None, payload=None, data=None, srv=None):
+    """
+    Custom function to compute list of topic subscription
+    targets based on topic and/or transformation data.
+    Pass MQTT topic, transformation data, service object
+    and optionally raw message payload.
+    """
+    if srv is not None:
+        srv.logging.debug('topic={topic}, payload={payload}, data={data}, srv={srv}'.format(**locals()))
+
+    # Use a fixed list of topic subscription targets for demonstration purposes.
+    # In the real world, you would look up proper targets based on information
+    # derived from transformation data, which in turn might have been enriched
+    # by ``datamap`` or ``alldata`` transformation functions before.
+    targets = ['foo:bar', 'log:info', 'file:mqttwarn']
+
+    return targets

--- a/samplefuncs.py
+++ b/samplefuncs.py
@@ -38,20 +38,29 @@ def OwnTracksBattFilter(topic, message):
     
     return True     # Suppress message because no 'batt'
 
-def TopicTargetList(topic=None, payload=None, data=None, srv=None):
+def TopicTargetList(topic=None, data=None, srv=None):
     """
-    Custom function to compute list of topic subscription
-    targets based on topic and/or transformation data.
-    Pass MQTT topic, transformation data, service object
-    and optionally raw message payload.
+    Custom function to compute list of topic targets based on MQTT topic and/or transformation data.
+    Obtains MQTT topic, transformation data and service object.
+    Returns list of topic target identifiers.
     """
-    if srv is not None:
-        srv.logging.debug('topic={topic}, payload={payload}, data={data}, srv={srv}'.format(**locals()))
 
-    # Use a fixed list of topic subscription targets for demonstration purposes.
-    # In the real world, you would look up proper targets based on information
+    # optional debug logger
+    if srv is not None:
+        srv.logging.debug('topic={topic}, data={data}, srv={srv}'.format(**locals()))
+
+    # Use a fixed list of topic targets for demonstration purposes.
+    targets = ['log:debug']
+
+    # In the real world, you would compute proper topic targets based on information
     # derived from transformation data, which in turn might have been enriched
-    # by ``datamap`` or ``alldata`` transformation functions before.
-    targets = ['foo:bar', 'log:info', 'file:mqttwarn']
+    # by ``datamap`` or ``alldata`` transformation functions before, like that:
+    if 'condition' in data:
+
+        if data['condition'] == 'sunny':
+            targets.append('file:mqttwarn')
+
+        elif data['condition'] == 'rainy':
+            targets.append('log:warn')
 
     return targets


### PR DESCRIPTION
Good morning Jan-Piet,

we have another improvement on top of the "dynamic topic targets" feature #169. With this patch, _mqttwarn_ users will be able to compute topic targets by python functions, in the same style of the `datamap` / `alldata` machinery.

@einsiedlerkrebs already is working on the documentation part to outline an advanced scenario. This will take some time though.

Best,
Andreas.
