### PR TITLE
Pushbullet - send notes to email/device/etc 

### DIFF
--- a/services/pushbullet.py
+++ b/services/pushbullet.py
@@ -22,11 +22,15 @@ def plugin(srv, item):
         srv.logging.warn("pushbullet is not installed")
         return False
 
+	recipient_type = "device_iden"
     try:
         apikey, device_id = item.addrs
     except:
-        srv.logging.warn("pushbullet target is incorrectly configured")
-        return False
+		try:
+			apikey, device_id, recipient_type = item.addrs
+		except:
+			srv.logging.warn("pushbullet target is incorrectly configured")
+			return False
 
     text = item.message
     title = item.get('title', srv.SCRIPTNAME)
@@ -34,7 +38,7 @@ def plugin(srv, item):
     try:
         srv.logging.debug("Sending pushbullet notification to %s..." % (item.target))
         pb = PushBullet(apikey)
-        pb.pushNote(device_id, title, text)
+        pb.pushNote(device_id, title, text, recipient_type)
         srv.logging.debug("Successfully sent pushbullet notification")
     except Exception, e:
         srv.logging.warning("Cannot notify pushbullet: %s" % (str(e)))

--- a/services/pushbullet.py
+++ b/services/pushbullet.py
@@ -26,11 +26,11 @@ def plugin(srv, item):
     try:
         apikey, device_id = item.addrs
     except:
-		try:
-			apikey, device_id, recipient_type = item.addrs
-		except:
-			srv.logging.warn("pushbullet target is incorrectly configured")
-			return False
+        try:
+            apikey, device_id, recipient_type = item.addrs
+        except:
+            srv.logging.warn("pushbullet target is incorrectly configured")
+            return False
 
     text = item.message
     title = item.get('title', srv.SCRIPTNAME)


### PR DESCRIPTION
Now next format for Pushbullet target is supported (recipient_type is optional):
'warnme' : [ 'API_KEY', 'receipient', 'recipient_type']
where recipient_type describes type of receipient
Could be one of:
device_iden (default)
email 
channel 
client