### PR TITLE
decode JSON data from message

### DIFF
--- a/services/xbmc.py
+++ b/services/xbmc.py
@@ -25,9 +25,13 @@ def plugin(srv, item):
         xbmcusername = item.addrs[1]
         xbmcpassword = item.addrs[2]
 
-    title    = item.title
-    message  = item.message
-    image    = item.image
+    jmessage = json.loads(item.message)
+    title   = jmessage['title']
+    message = jmessage['message']
+    if jmessage.has_key('image'):
+        image = jmessage['image']
+    else:
+        image = ''
 
     jsonparams = {
         "jsonrpc" : "2.0",


### PR DESCRIPTION
I don't have much experience with MQTT or with mqttwarn, so I'd be happy to learn that I'm doing something wrong and this pull isn't necessary. However, it works for me. :-)

I configured an XBMC target in mqttwarn.ini. I want to send a message with a title and an image, as shown in #53 (got my home phone system to talk MQTT, by the way):

`mosquitto_pub -t xbmc/command/notify -m '{"message": "Call from <number>", "title": "Phone is ringing!", "image": "/storage/phone-icon.png"}'`

XBMC shows a notification, but the message text contains the undecoded JSON data. In xbmc.py, this data is delivered in item.message, so I wrote these few lines to decode it.

Again: this works for me. I didn't find another way, I'd like to see a working example.