### PR TITLE
Rewrite Telegram service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1677,11 +1677,14 @@ Apr 22 12:42:42 mqttest019 mqttwarn[9484]: Disk utilization: 94%
 
 This is to send messages as a Bot to a [Telegram](https://telegram.org) chat. First set up a Bot and obtain its authentication token which you add to _mqttwarn_'s configuration. You'll also need to start a chat with this bot so it can be able to communicate with particular user.
 
+Optional you can specify `parse_mode` which will be used during message sending. Please, check [docs](https://core.telegram.org/bots/api#formatting-options) for additional information.
+
 Configure the `telegram` service:
 
 ```ini
 [config:telegram]
 timeout = 60
+parse_mode = 'Markdown'
 token = 'mmmmmmmmm:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
 targets = {
    #        First Name or @username

--- a/README.md
+++ b/README.md
@@ -1684,13 +1684,13 @@ Configure the `telegram` service:
 timeout = 60
 token = 'mmmmmmmmm:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
 targets = {
-   #        First Name or @username,      token
+   #        First Name or @username
    'j01' : [ 'First Name' ],
    'j02' : [ '@username' ]
 }
 ```
 Possible issue:
-    Current realisation uses [getUpdates](https://core.telegram.org/bots/api#getupdates) call to get `chat_id` but call return only last 100 messages.
+    Current realisation uses [getUpdates](https://core.telegram.org/bots/api#getupdates) call to get `chat_id` but this call returns only last 100 messages.
 
 ![Telegram](assets/telegram.png)
 

--- a/README.md
+++ b/README.md
@@ -1675,22 +1675,22 @@ Apr 22 12:42:42 mqttest019 mqttwarn[9484]: Disk utilization: 94%
 
 ### `telegram`
 
-This is to send messages as a Bot to a [Telegram](https://telegram.org) chat. First set up a Bot and obtain its authentication token which you add to _mqttwarn_'s configuration. You'll also need a _chat_id_ to talk to a particular user. This seems to be the hardest thing to obtain; what we did is to talk once to our bot (from within Telegram) and then get the messages with this _curl_ invocation; the sender's _id_ is shown within the returned JSON:
-
-```bash
-curl 'https://api.telegram.org/botnnnnnnnnn:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/getUpdates'
-```
+This is to send messages as a Bot to a [Telegram](https://telegram.org) chat. First set up a Bot and obtain its authentication token which you add to _mqttwarn_'s configuration. You'll also need to start a chat with this bot so it can be able to communicate with particular user.
 
 Configure the `telegram` service:
 
 ```ini
 [config:telegram]
 timeout = 60
+token = 'mmmmmmmmm:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
 targets = {
-   #        chat_id,      token
-   'j01' : ['nnnnnnnnn', 'mmmmmmmmm:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' ],
+   #        First Name or @username,      token
+   'j01' : [ 'First Name' ],
+   'j02' : [ '@username' ]
 }
 ```
+Possible issue:
+    Current realisation uses [getUpdates](https://core.telegram.org/bots/api#getupdates) call to get `chat_id` but call return only last 100 messages.
 
 ![Telegram](assets/telegram.png)
 

--- a/services/telegram.py
+++ b/services/telegram.py
@@ -1,53 +1,109 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__author__    = 'Jan-Piet Mens <jpmens@gmail.com>'
-__copyright__ = 'Copyright 2016 JP Mens'
-__license__   = """Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)"""
-
-import urllib2
+import requests
 try:
     import json
 except ImportError:
     import simplejson as json
 
-def plugin(srv, item):
-    ''' addrs: (chat_id, token, text) '''
+__author__    = 'Artem Alexandrov <qk4l@tem4uk.ru>'
+__copyright__ = 'Copyright 2016 Artem Alexandrov'
+__license__   = """Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)"""
 
+
+def plugin(srv, item):
+    """
+    addrs: (tg_contact, token, text)
+    """
     srv.logging.debug("*** MODULE=%s: service=%s, target=%s", __file__, item.service, item.target)
 
-    chat_id, token = item.addrs
+    token = item.config['token']
+    tg_contact = item.addrs[0]
 
-    data = {
-        'chat_id':              chat_id,
-        'parse_mode':           'Markdown',
-        'disable_notification': False,
-        'text':                 item.message,
-    }
+    class TelegramAPI():
+        def __init__(self, token):
+            self.token = token
+            self.disable_notification = False
+            self.tg_url_bot_general = "https://api.telegram.org/bot"
+
+        def http_get(self, url):
+            res = requests.get(url)
+            answer = res.text
+            answer_json = json.loads(answer.decode('utf8'))
+            return answer_json
+
+        def get_updates(self):
+            """
+            Get updates
+            :return: Dict of last bot update
+            """
+            url = self.tg_url_bot_general + self.token + "/getUpdates"
+            srv.logging.debug(url)
+            updates = self.http_get(url)
+            #rv.logging.debug("Content of /getUpdates: %s" % updates)
+            if not updates["ok"]:
+                srv.logging.warn(updates)
+                return False
+            else:
+                return updates
+
+        def get_uid(self, name):
+            """
+            Get chat_id for specific user
+            :param name: First Name or @username of user
+            :return: string
+            """
+            uid = 0
+            srv.logging.debug("Getting uid from /getUpdates...")
+            updates = self.get_updates()
+            for msg in updates["result"]:
+                chat = msg["message"]["chat"]
+                srv.logging.debug(chat)
+                if name.startswith('@'):
+                    name_type = 'username'
+                else:
+                    name_type = 'first_name'
+                if name_type in chat:
+                    if chat[name_type] == name:
+                        uid = chat["id"]
+                        break
+            srv.logging.debug("For user {name} follow chat_id was found: {chat_id}".format(chat_id=uid,
+                                                                                           name=name))
+            return uid
+
+        def send_message(self, chat_id, message):
+            """
+            Send message to chat_id
+            :param chat_id: int
+            :param message: string
+            :return: Boolean
+            """
+            url = self.tg_url_bot_general + self.token + "/sendMessage"
+            params = {"chat_id": chat_id, "text": message, "disable_notification": self.disable_notification}
+            srv.logging.debug("Trying to /sendMessage: {url}".format(url=url))
+            srv.logging.debug("post params: " + str(params))
+            res = requests.post(url, params=params)
+            answer = res.text
+            answer_json = json.loads(answer.decode('utf8'))
+            if not answer_json["ok"]:
+                srv.logging.warn(answer_json)
+                return False
+            else:
+                return answer_json
 
     try:
-        method = "POST"
-        endpoint = "https://api.telegram.org/bot%s/sendMessage" % (token)
-
-        handler = urllib2.HTTPHandler()
-        opener = urllib2.build_opener(handler)
-
-        request = urllib2.Request(endpoint, data=json.dumps(data))
-        request.add_header("Content-Type",'application/json')
-
-        connection = opener.open(request,timeout=5)
-
-        reply = str(connection.read())
+        tg = TelegramAPI(token)
+        # uid = tg.get_uid(tg_contact)
+        # if uid == 0:
+        #     srv.logging.warn("Cannot get chat_id for user %s" % tg_contact)
+        #     return False
+        uid = tg_contact
+        reply = tg.send_message(uid, item.message)
         srv.logging.debug("Telegram reply: %s" % reply)
-
-        r = json.loads(reply)
-        if 'ok' in r and r['ok']:
+        if 'ok' in reply and reply['ok']:
             return True
-
         return False
-
-    except urllib2.HTTPError, e:
-        srv.logging.warn("Failed to send POST request to Telegram using %s: %s" % (endpoint, str(e.read())))
+    except:
+        srv.logging.warn("Failed to send request to Telegram")
         return False
-
-    return True

--- a/services/telegram.py
+++ b/services/telegram.py
@@ -19,12 +19,15 @@ def plugin(srv, item):
     srv.logging.debug("*** MODULE=%s: service=%s, target=%s", __file__, item.service, item.target)
 
     token = item.config['token']
+    if 'parse_mode' in item.config:
+        parse_mode = item.config['parse_mode']
     tg_contact = item.addrs[0]
 
     class TelegramAPI():
-        def __init__(self, token):
+        def __init__(self, token, parse_mode=None):
             self.token = token
             self.disable_notification = False
+            self.parse_mode = parse_mode
             self.tg_url_bot_general = "https://api.telegram.org/bot"
 
         def http_get(self, url):
@@ -80,7 +83,8 @@ def plugin(srv, item):
             :return: Boolean
             """
             url = self.tg_url_bot_general + self.token + "/sendMessage"
-            params = {"chat_id": chat_id, "text": message, "disable_notification": self.disable_notification}
+            params = {"chat_id": chat_id, "text": message,
+                      "parse_mode": self.parse_mode, "disable_notification": self.disable_notification}
             srv.logging.debug("Trying to /sendMessage: {url}".format(url=url))
             srv.logging.debug("post params: " + str(params))
             res = requests.post(url, params=params)
@@ -93,7 +97,7 @@ def plugin(srv, item):
                 return answer_json
 
     try:
-        tg = TelegramAPI(token)
+        tg = TelegramAPI(token, parse_mode)
         uid = tg.get_uid(tg_contact)
         if uid == 0:
             srv.logging.warn("Cannot get chat_id for user %s" % tg_contact)

--- a/services/telegram.py
+++ b/services/telegram.py
@@ -94,11 +94,10 @@ def plugin(srv, item):
 
     try:
         tg = TelegramAPI(token)
-        # uid = tg.get_uid(tg_contact)
-        # if uid == 0:
-        #     srv.logging.warn("Cannot get chat_id for user %s" % tg_contact)
-        #     return False
-        uid = tg_contact
+        uid = tg.get_uid(tg_contact)
+        if uid == 0:
+            srv.logging.warn("Cannot get chat_id for user %s" % tg_contact)
+            return False
         reply = tg.send_message(uid, item.message)
         srv.logging.debug("Telegram reply: %s" % reply)
         if 'ok' in reply and reply['ok']:

--- a/services/telegram.py
+++ b/services/telegram.py
@@ -60,13 +60,13 @@ def plugin(srv, item):
             uid = 0
             srv.logging.debug("Getting uid from /getUpdates...")
             updates = self.get_updates()
+            if name.startswith('@'):
+                name = name[1:]
+                name_type = 'username'
+            else:
+                name_type = 'first_name'
             for msg in updates["result"]:
                 chat = msg["message"]["chat"]
-                srv.logging.debug(chat)
-                if name.startswith('@'):
-                    name_type = 'username'
-                else:
-                    name_type = 'first_name'
                 if name_type in chat:
                     if chat[name_type] == name:
                         uid = chat["id"]


### PR DESCRIPTION
Hi, 
I've  rewritten telegram service. Now it does not require to hardcode `chat_id` but it still can fail if a lot of targets will be used, because [getUpdates](https://core.telegram.org/bots/api#getupdates) which is used to obtain `chat_id` returns only last 100 messages.