### PR TITLE
Fix inconsistent whitespace in serial.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1588,10 +1588,12 @@ The `serial` plugin sends out received messages to the serial port. Message payl
 [config:serial]
 append_newline = False
 targets = {
-    'serialport1'  : ['hwgrep:///dev/ttyUSB0',  '115200'],
-    'some-device' : ['hwgrep://COM3', '9600']
+    'serialport1'  : ['/dev/ttyUSB0',  '115200'],
+    'some-device' : ['socket://192.168.1.100:2323', '9600']
     }
 ```
+First parameter in target config can be a portname or an [url handler](https://pythonhosted.org/pyserial/url_handlers.html).
+Second parameter is the baudrate for the port.
 If `append_newline` is True, a newline character is unconditionally appended to the string written to the serialport. 
 
 Requires the pyserial bindings available with `pip install pyserial`.

--- a/services/serial.py
+++ b/services/serial.py
@@ -31,13 +31,13 @@ def plugin(srv, item):
     text = item.message
 
     # If message specifies the hex keyword try to transform bytes from hex
-	# else send string as it is
+    # else send string as it is
     test = text[:5]
     if test == ":HEX:":
         text = bytes(bytearray.fromhex(text[5:]))
 
-	# Append newline if config option is set
-	if type(config) == dict and 'append_newline' in config and config['append_newline']:
+    # Append newline if config option is set
+    if type(config) == dict and 'append_newline' in config and config['append_newline']:
         text = text + "\n"
 
     try:
@@ -45,7 +45,7 @@ def plugin(srv, item):
             _serialport.is_open
             srv.logging.debug("%s already open", comName)
         except:
-			#Open port for first use
+            #Open port for first use
             srv.logging.debug("Open %s with %d baud", comName,comBaudRate)
             _serialport = serial.serial_for_url(comName)
             _serialport.baudrate = comBaudRate 


### PR DESCRIPTION
Used wrong editor for comments.
Add link to explain url handlers from pyserial to README