### PR TITLE
Optional LWT; fix for pyserial with isOpen

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,15 +825,19 @@ You should first create an application and respective event following the [tutor
 
 Afterward you will find your Application ID and Application Secret in the "Basic Info" of your application.
 
-Each target corresponds to an event in your instapush application, you can define as many trackers as you wish as long as it's a JSON object.
+Each _mqttwarn_ target corresponds to an event in your Instapush application.
 
-for the ini example I've setup:
+The "trackers" in Instapush correspond to JSON values in the _mqttwarn_ `config:instapush` section or from the message payload. You can define as many trackers as you wish.
+
+Consider the following event created in Instapush:
 
 | Field          | Value                |
 | -------------- | -------------------- |
 | `Event title`  | alerts               |
 | `Trackers`     | object, action       |
 | `Push Message` | {object} just {action} |
+
+To always send the same `object` and `action` tracker values, set them as constants in the event of the target:
 
 ```ini
 [config:instapush]
@@ -847,7 +851,7 @@ targets = {
 
 ![instapush](assets/instapush.png)
 
-Note: if your "targets" has a list with only 1 element, that will be considered the "event" and the "trackers" will be the mqtt payload
+To send tracker values based on the message payload, leave out the the tracker element of the target definition in the `config:instapush` section: If your target is a list with only 1 element, that element will be considered the "event" and the "trackers" will be taken from the mqtt payload, which must have all tracker fields present.
 
 ### `irccat`
 

--- a/mqttwarn.py
+++ b/mqttwarn.py
@@ -553,7 +553,8 @@ def on_connect(mosq, userdata, result_code):
             mqttc.subscribe(str(topic), qos)
             subscribed.append(topic)
 
-        mqttc.publish(cf.lwt, LWTALIVE, qos=0, retain=True)
+        if cf.lwt is not None:
+            mqttc.publish(cf.lwt, LWTALIVE, qos=0, retain=True)
 
     elif result_code == 1:
         logging.info("Connection refused - unacceptable protocol version")
@@ -978,8 +979,9 @@ def connect():
         mqttc.username_pw_set(cf.username, cf.password)
 
     # set the lwt before connecting
-    logging.debug("Setting LWT to %s..." % (cf.lwt))
-    mqttc.will_set(cf.lwt, payload=LWTDEAD, qos=0, retain=True)
+    if cf.lwt is not None:
+        logging.debug("Setting LWT to %s..." % (cf.lwt))
+        mqttc.will_set(cf.lwt, payload=LWTDEAD, qos=0, retain=True)
 
     # Delays will be: 3, 6, 12, 24, 30, 30, ...
     # mqttc.reconnect_delay_set(delay=3, delay_max=30, exponential_backoff=True)
@@ -1047,7 +1049,8 @@ def cleanup(signum=None, frame=None):
         ptlist[ptname].cancel()
 
     logging.debug("Disconnecting from MQTT broker...")
-    mqttc.publish(cf.lwt, LWTDEAD, qos=0, retain=True)
+    if cf.lwt is not None:
+        mqttc.publish(cf.lwt, LWTDEAD, qos=0, retain=True)
     mqttc.loop_stop()
     mqttc.disconnect()
 

--- a/services/serial.py
+++ b/services/serial.py
@@ -43,6 +43,10 @@ def plugin(srv, item):
     try:
         try:
             _serialport.is_open
+            if callable(getattr(_serialport, "is_open", None)):
+                _serialport.is_open
+            else:
+                _serialport.isOpen
             srv.logging.debug("%s already open", comName)
         except:
             #Open port for first use


### PR DESCRIPTION
Hi,

My version of pyserial (2.6 with python 2.7.9) doesn't have is_open, as required by the serial module. It does however have isOpen.

Also, I made LWT optional, by setting the topic in the configuration file to "None".