### PR TITLE
Example data loss sensor with notifications based on periodic tasks

### DIFF
--- a/examples/hiveeyes/hiveeyes.ini
+++ b/examples/hiveeyes/hiveeyes.ini
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # hiveeyes-schwarmalarm configuration file for mqttwarn
-
+# https://hiveeyes.org/docs/system/schwarmalarm-mqttwarn.html
 
 ; ========
 ; Synopsis
@@ -72,13 +72,17 @@ format   = Alarm from beehive {node}@{gateway}: {payload}
 template = hiveeyes-alert.j2
 title    = Alarm from beehive {node}@{gateway}
 
+[cron]
+; Monitor all seen devices for data loss events.
+hiveeyes_dataloss_monitor = 60.0; now=true
+
+
 
 ; ===============
 ; Target services
 ; ===============
 
 [config:xmpp]
-; TODO: Deliver notifications to beekeepers
 sender   = 'hiveeyes@xmpp.beekeepersclub.org'
 password = 'yourcatsname'
 targets  = {

--- a/examples/hiveeyes/hiveeyes.py
+++ b/examples/hiveeyes/hiveeyes.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
-# hiveeyes-schwarmalarm function extensions
+# hiveeyes-schwarmalarm function extensions for mqttwarn
+# https://hiveeyes.org/docs/system/schwarmalarm-mqttwarn.html
 import re
 import json
+from datetime import datetime
 from pprint import pformat
 
 
@@ -40,6 +42,10 @@ monitoring_rules = {
     'second': 0.5,
     }
 
+# Trigger a data-loss event when not receiving any fresh
+# data after 20 minutes from a device already seen before.
+data_loss_timeout = 20 * 60
+
 
 # ------------------------------------------
 #                   Main
@@ -47,8 +53,11 @@ monitoring_rules = {
 
 # A dictionary for remembering measurement values
 # across a window of two value elements.
+# TODO: Add "network/gateway" information to all bookkeeping data to enable multi-tenancy
 history = dict()
 history_before = dict()
+last_measurement_times = {}
+data_loss_state = {}
 
 
 def format_passthrough(data):
@@ -62,7 +71,7 @@ def format_passthrough(data):
 def hiveeyes_topic_to_topology(topic):
     """
     Split Hiveeyes MQTT topic path into segments for
-    enriching transient message payload inside mqttwarn.
+    enriching transformation data inside mqttwarn.
     """
     if type(topic) == str:
         try:
@@ -78,8 +87,7 @@ def hiveeyes_topic_to_topology(topic):
 
 def hiveeyes_more_data(topic, data, srv):
     """
-    Add more data to object, used later
-    when formatting the outgoing message.
+    Add more data to transformation data object, used later when formatting the outgoing message.
     """
     more_data = {
         'current': pformat(json.loads(data['payload'])),
@@ -92,13 +100,20 @@ def hiveeyes_schwarmalarm_filter(topic, message):
     """
     Custom filter function to compare two consecutive values
     to trigger notification only if delta is greater threshold.
+    Also, perform data-loss bookkeeping.
     """
     global history, history_before
 
     if not topic.endswith('message-json'):
         return True
 
+    # Decode message
     data = dict(json.loads(message).items())
+    data.update(hiveeyes_topic_to_topology(topic))
+
+    # Data-loss bookkeeping
+    origin = '{realm}/{network}/{gateway}/{node}'.format(**data)
+    last_measurement_times[origin] = datetime.utcnow()
 
     # Remember current history data for later access from hiveeyes_more_data
     history_before = history.copy()
@@ -129,6 +144,65 @@ def hiveeyes_schwarmalarm_filter(topic, message):
     # be suppressed, or False if the message should be processed.
     #return False
     return not alarm
+
+
+def hiveeyes_dataloss_monitor(srv):
+    """
+    Periodic thread monitoring all seen devices for data loss events.
+    Will submit appropriate data loss notifications using mqttwarn services.
+    """
+
+    # Get hold of our own PeriodicThread object to read "period" value
+    periodic_threads = srv.mwcore['ptlist']
+    me = periodic_threads['hiveeyes_dataloss_monitor']
+    interval = me.period
+
+    # Inform operator about this activity
+    srv.logging.info('Checking for data-loss (each {interval} seconds)'.format(**locals()))
+
+    # Get hold of mqttwarn method to dispatch notification messages on data loss events
+    send_to_targets = srv.mwcore['send_to_targets']
+
+    now = datetime.utcnow()
+
+    # List of all seen data origins (devices).
+    # The identifiers are made of essential parts of the MQTT topic.
+    origins = last_measurement_times.keys()
+
+    # Iterate all seen devices
+    for origin in origins:
+
+        # Signal no data loss as a default
+        data_loss_state.setdefault(origin, False)
+
+        # Get timestamp of last valid measurement
+        last_measurement_time = last_measurement_times[origin]
+
+        # Compute duration since last valid measurement
+        delta = now - last_measurement_time
+
+        # Check if duration is longer than user-defined threshold
+        if delta.total_seconds() >= data_loss_timeout:
+
+            # Only act if not already being in state of data loss
+            if not data_loss_state[origin]:
+
+                # Set data loss state
+                data_loss_state[origin] = True
+
+                # Send out data loss notification
+                data = {'description': 'Detected data loss'}
+                send_to_targets(
+                    section = 'hiveeyes-schwarmalarm',
+                    topic   = '{origin}/message-json'.format(origin=origin),
+                    payload = json.dumps(data))
+
+        else:
+            # Reset data loss state
+            data_loss_state[origin] = False
+
+    # TODO: Republish data loss notification to MQTT bus
+    #srv.mqttc.publish('data-loss-topic'.format(**locals()), 'data-loss')
 
 
 # ------------------------------------------

--- a/mqttwarn.py
+++ b/mqttwarn.py
@@ -358,9 +358,19 @@ ptlist = {}         # List of PeriodicThread() objects
 # and its global instantiation
 class Service(object):
     def __init__(self, mqttc, logging):
+
+        # Reference to MQTT client object
         self.mqttc    = mqttc
+
+        # Reference to all mqttwarn globals, for using its machinery from plugins
+        self.mwcore   = globals()
+
+        # Reference to logging object
         self.logging  = logging
+
+        # Name of self ("mqttwarn", mostly)
         self.SCRIPTNAME = SCRIPTNAME
+
 srv = Service(None, None)
 
 service_plugins = {}

--- a/templates/hiveeyes-alert.j2
+++ b/templates/hiveeyes-alert.j2
@@ -2,6 +2,7 @@
     Hiveeyes alert template
 #}
 Alarm from beehive {{node}}.
+{{description}}
 
 {% print '-' * 42 %}
 


### PR DESCRIPTION
Dear @jpmens and @sumnerboy12,

thanks again for merging our little example for mqttwarn so quickly. While we have to move on to other features still lingering, we added another sensor to the Hiveeyes mqttwarn subsystem, which is important  to us: We also want to get notified on data loss events, i.e. if a sensor node suddenly stops sending data through any cause, as a matter of fact mostly originating from drained batteries.

The behavior of the implementation of the added `hiveeyes_dataloss_monitor` tries to reach DWIM, i.e.:
- It will just fire a notification once and not each and every time when checking against the configured data loss timeout during each check interval
- It also does not have to be configured in any significant way as it automatically watches all sensor nodes ever seen on the bus
 
This time, just a minor improvement to *mqttwarn* has been made: The `Service` object now enables plugins to use *mqttwarn*'s internal infrastructure (don't tell anybody! ;]). The `hiveeyes_dataloss_monitor` is now able to reach out to *mqttwarn*'s `send_to_targets` routine for actually sending data loss notifications to our beekeepers.

Cheers,
Andreas on behalf of the Hiveeyes Developers.