### PR TITLE
Add systemd unit configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2392,6 +2392,11 @@ You'll need at least the following components:
 
 I recommend you use [Supervisor](http://jpmens.net/2014/02/13/in-my-toolbox-supervisord/) for running this.
 
+Alternatively, a systemd-based installation using a Python virtualenv might be handy,
+see [systemd unit configuration file for mqttwarn](https://github.com/jpmens/mqttwarn/blob/master/etc/mqttwarn.service)
+for step-by-step instructions about doing this.
+
+
 ## Press
 
 * [MQTTwarn: Ein Rundum-Sorglos-Notifier](http://jaxenter.de/news/MQTTwarn-Ein-Rundum-Sorglos-Notifier-171312), article in German at JAXenter.

--- a/etc/mqttwarn.default
+++ b/etc/mqttwarn.default
@@ -1,2 +1,7 @@
+# For systemd-based systems (used by mqttwarn.service)
+MQTTWARNINI="/etc/mqttwarn/mqttwarn.ini"
+MQTTWARN_OPTIONS=""
+
+# For init-based systems (used by mqttwarn.init)
 START_DAEMON=true
 VERBOSE=true

--- a/etc/mqttwarn.init
+++ b/etc/mqttwarn.init
@@ -49,7 +49,7 @@ do_start()
 	start-stop-daemon -b --start --quiet -m --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
 		|| return 1
 	start-stop-daemon -b --start --quiet -m --pidfile $PIDFILE --exec $DAEMON -- \
-		$OPTIONS \
+		$MQTTWARN_OPTIONS \
 		|| return 2
 }
 

--- a/etc/mqttwarn.logrotate
+++ b/etc/mqttwarn.logrotate
@@ -1,0 +1,11 @@
+/var/log/mqttwarn/*.log {
+    rotate 7
+    daily
+    compress
+    size 2M
+    nocreate
+    missingok
+    postrotate
+        /bin/systemctl restart mqttwarn
+    endscript
+}

--- a/etc/mqttwarn.service
+++ b/etc/mqttwarn.service
@@ -1,0 +1,72 @@
+# ----------------------------------------------
+#  systemd unit configuration file for mqttwarn
+# ----------------------------------------------
+#
+# Intro
+# -----
+# This systemd script assumes you are running mqttwarn
+# from /opt/mqttwarn using a Python virtualenv inside.
+#
+# Setup
+# -----
+# Basic setup::
+#
+#   cd /opt
+#   git clone https://github.com/jpmens/mqttwarn
+#   cd mqttwarn
+#   virtualenv .venv27
+#   ./.venv27/bin/pip install paho-mqtt==1.1
+#
+# Prepare and enable the systemd service::
+#
+#   useradd --create-home --shell /bin/bash mqttwarn
+#   cp etc/mqttwarn.default /etc/default/mqttwarn
+#   cp etc/mqttwarn.service /usr/lib/systemd/system/
+#   mkdir /var/log/mqttwarn; chown mqttwarn:mqttwarn /var/log/mqttwarn
+#   systemctl enable mqttwarn
+#
+# Configuration
+# -------------
+# The configuration file is located at /etc/mqttwarn/mqttwarn.ini,
+# but the default setting can be changed by amending the
+# MQTTWARNINI environment variable defined in /etc/default/mqttwarn.
+#
+# Setup example configuration::
+#
+#   mkdir /etc/mqttwarn
+#   cp mqttwarn.ini.sample /etc/mqttwarn/mqttwarn.ini
+#
+# Start
+# -----
+# ::
+#
+#   systemctl start mqttwarn
+#
+# Appendix
+# --------
+# For installing further Python modules into the virtualenv
+# of the mqttwarn installation by using pip, just issue e.g.::
+#
+#   /opt/mqttwarn/.venv27/bin/pip install xmpppy==0.5.0rc1 jinja2==2.8
+#
+
+[Unit]
+Description=mqttwarn pluggable mqtt notification service
+Documentation=https://github.com/jpmens/mqttwarn
+After=network.target
+
+[Service]
+User=mqttwarn
+Group=mqttwarn
+LimitNOFILE=65536
+Environment='STDOUT=/var/log/mqttwarn/mqttwarn.log'
+Environment='STDERR=/var/log/mqttwarn/mqttwarn.log'
+EnvironmentFile=-/etc/default/mqttwarn
+WorkingDirectory=/opt/mqttwarn
+ExecStart=/bin/sh -c "/opt/mqttwarn/.venv27/bin/python /opt/mqttwarn/mqttwarn.py ${MQTTWARN_OPTIONS} >>${STDOUT} 2>>${STDERR}"
+KillMode=control-group
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+Alias=mqttwarn.service

--- a/etc/mqttwarn.service
+++ b/etc/mqttwarn.service
@@ -22,6 +22,7 @@
 #   useradd --create-home --shell /bin/bash mqttwarn
 #   cp etc/mqttwarn.default /etc/default/mqttwarn
 #   cp etc/mqttwarn.service /usr/lib/systemd/system/
+#   cp etc/mqttwarn.logrotate /etc/logrotate.d/mqttwarn
 #   mkdir /var/log/mqttwarn; chown mqttwarn:mqttwarn /var/log/mqttwarn
 #   systemctl enable mqttwarn
 #


### PR DESCRIPTION
Dear Jan-Piet and Ben,

we installed *mqttwarn* as a system daemon on the Hiveeyes data collection server, please find the systemd unit and logrotate configuration files in this PR. They could be useful to others as well.

Using a Python virtualenv for isolating the installation from the system Python reflects the way we are currently running *mqttwarn* on our machines, adapting this to other flavors by amending the `WorkingDirectory ` and `ExecStart` directives in `mqttwarn.service` should be easy for everyone to do.

With kind regards,
Andreas.
