### PR TITLE
Add as_user option to slack service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1717,14 +1717,20 @@ The `slack` plugin posts messages to channels in or users of the [slack.com](htt
 [config:slack]
 token = 'xxxx-1234567890-1234567890-1234567890-1234a1'
 targets = {
-              #  #channel/@user   username, icon
-   'jpmens'  : [ '@jpmens',       "Alerter",   ':door:' ],
-   'general'  : [ '#general',     "mqttwarn",   ':syringe:' ],
+             #   #channel/@user   username,    icon,        as_user
+   'jpmens'  : [ '@jpmens',       "Alerter",   ':door:'             ],
+   'general' : [ '#general',      "mqttwarn",  ':syringe:'          ],
+   'test'    : [ '#test',         "BotUser",   ':unused:',  True    ]
   }
 ```
 
 Each target defines the name of an existing channel (`#channelname`) or a user (`@username`) to be
 addressed, the name of the sending user as well as an [emoji icon](http://www.emoji-cheat-sheet.com) to use.
+
+Optionally, a target can define the message to get posted as a user, per 
+[Slack Authorship documentation](https://api.slack.com/methods/chat.postMessage#authorship).
+Note that posting as a user in a channel is only possible, if the user has 
+joined the channel.
 
 ![Slack](assets/slack.png)
 

--- a/services/slack.py
+++ b/services/slack.py
@@ -25,9 +25,9 @@ def plugin(srv, item):
         return False
 
     try:
-        channel, username, icon = item.addrs
-    except:
-        srv.logging.error("Incorrect target configuration")
+        channel, username, icon, as_user = ( item.addrs + [False] )[:4]
+    except Exception, e:
+        srv.logging.error("Incorrect target configuration for target=%s: %s", item.target, str(e))
         return False
 
     # If the incoming payload has been transformed, use that,
@@ -36,9 +36,9 @@ def plugin(srv, item):
 
     try:
         slack = Slacker(token)
-        slack.chat.post_message(channel, text, username=username, icon_emoji=icon)
+        slack.chat.post_message(channel, text, as_user=as_user, username=username, icon_emoji=icon)
     except Exception, e:
-        srv.logging.warning("Cannot post to slack: %s" % (str(e)))
+        srv.logging.warning("Cannot post to slack %s: %s" % (channel, str(e)))
         return False
 
     return True


### PR DESCRIPTION
To allow for better control of message appearance in Slack, I have added the 'as_user' option from the Slack API to the target configuration.

The default value is False, which is also the current (intended) behaviour.