### PR TITLE
Add service aliasing with module option

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The `functions` option specifies the path to a Python file containing functions 
 
 ### `launch`
 
-In the `launch` option you specify which _services_ (of those available in the `services/` directory of _mqttwarn_) you want to be able to use in target definitions.
+In the `launch` option you specify which _services_ (of those available in the `services/` directory of _mqttwarn_ or using the `module` option, see the following paragraphs) you want to be able to use in target definitions. 
 
 ## The `[config:xxx]` sections
 
@@ -200,7 +200,8 @@ has a mandatory option called `targets`, which is a dictionary of target names, 
 pointing to an array of "addresses". Address formats depend on the particular service.
 
 A service section may have an option called `module`, which refers to the name
-of the actual service module to use. As such, a service called `filetruncate`
+of the actual service module to use. A service called `filetruncate` - and 
+referenced as such in the `launch` option -
 may have `module = file`, in which case the service works like a regular `file`
 service, with its own distinct set of service options. It is thus possible to
 have several different service configurations for the same underlying service,

--- a/README.md
+++ b/README.md
@@ -199,6 +199,14 @@ Sections called `[config:xxx]` configure settings for a service _xxx_. Each of t
 has a mandatory option called `targets`, which is a dictionary of target names, each
 pointing to an array of "addresses". Address formats depend on the particular service.
 
+A service section may have an option called `module`, which refers to the name
+of the actual service module to use. As such, a service called `filetruncate`
+may have `module = file`, in which case the service works like a regular `file`
+service, with its own distinct set of service options. It is thus possible to
+have several different service configurations for the same underlying service,
+with different configurations, e.g. one for files that should have notifications
+appended, and one for files that should get truncated before writes.
+
 ## The `[failover]` section
 
 There is a special section (optional) for defining a target (or targets) for internal error conditions. Currently there is only one error handled by this logic, broker disconnection.
@@ -309,7 +317,7 @@ The path to the configuration file (which must be valid Python) is obtained from
 
 ## Configuration of service plugins
 
-Service plugins are configured in the main `mqttwarn.ini` file. Each service has a mandatory _section_ named `[config:_service_]`, where _service_ is the name of the service. This section _may_ have some settings which are required for a particular service. One mandatory option is called `targets`. This defines individual "service points" for a particular service, e.g. different paths for the `file` service, distinct database tables for `mysql`, etc.
+Service plugins are configured in the main `mqttwarn.ini` file. Each service has a mandatory _section_ named `[config:xxx]`, where `xxx` is the name of the service. This section _may_ have some settings which are required for a particular service, and all services have an rarely used option called `module` (see [The config:xxx sections](#the-configxxx-sections)) and one mandatory option called `targets`. This defines individual "service points" for a particular service, e.g. different paths for the `file` service, distinct database tables for `mysql`, etc.
 
 We term the array for each target an "address list" for the particular service. These may be path names (in the case of the `file` service), topic names (for outgoing `mqtt` publishes), hostname/port number combinations for `xbmc`, etc.
 

--- a/mqttwarn.py
+++ b/mqttwarn.py
@@ -184,7 +184,7 @@ class Config(RawConfigParser):
         d = None
         if self.has_section(section):
             d = dict((key, self.g(section, key))
-                for (key) in self.options(section) if key not in ['targets'])
+                for (key) in self.options(section) if key not in ['targets', 'module'])
         return d
 
     def datamap(self, name, topic):
@@ -953,16 +953,7 @@ def load_module(path):
 
 def load_services(services):
     for service in services:
-        modulefile = 'services/%s.py' % service
-
         service_plugins[service] = {}
-
-        try:
-            service_plugins[service]['module'] = load_module(modulefile)
-            logging.debug("Service %s loaded" % (service))
-        except Exception, e:
-            logging.error("Can't load %s service (%s): %s" % (service, modulefile, str(e)))
-            sys.exit(1)
 
         try:
             service_config = cf.config('config:' + service)
@@ -971,6 +962,16 @@ def load_services(services):
             sys.exit(1)
 
         service_plugins[service]['config'] = service_config
+
+        module = service_config.get('module', service)
+        modulefile = 'services/%s.py' % module
+
+        try:
+            service_plugins[service]['module'] = load_module(modulefile)
+            logging.debug("Service %s loaded" % (service))
+        except Exception, e:
+            logging.error("Can't load %s service (%s): %s" % (service, modulefile, str(e)))
+            sys.exit(1)
 
 def connect():
     """

--- a/mqttwarn.py
+++ b/mqttwarn.py
@@ -955,15 +955,14 @@ def load_services(services):
     for service in services:
         service_plugins[service] = {}
 
-        try:
-            service_config = cf.config('config:' + service)
-        except Exception, e:
-            logging.error("Service `%s' has no config section: %s" % (service, str(e)))
+        service_config = cf.config('config:' + service)
+        if service_config is None:
+            logging.error("Service `%s' has no config section" % service)
             sys.exit(1)
 
         service_plugins[service]['config'] = service_config
 
-        module = service_config.get('module', service)
+        module = cf.g('config:' + service, 'module', service)
         modulefile = 'services/%s.py' % module
 
         try:


### PR DESCRIPTION
Sometimes it'd be nice (or necessary) to have two versions of a specific service, e.g. for notifying two different MySQL servers or to have one file appended to and another one truncated.

For this reason I have added a non-mandatory option to service configurations, to essentially allow aliasing of service names as used in `launch` and `targets` options and in `config:xxx` sections: The option `module` in a `config:xxx` section names the real service (module file) to use, allowing for both of e.g. `file` and `appendfile`, the last of which then needs to have `module = file`.

I have checked all current services, none of which use an option called `module`. Also, the option is excluded from the service configuration dictionary, like `targets`.

The README is updated, although I'm sure it could be improved.
