### PR TITLE
Example for routing Homie-style MQTT sensor value publications to check_mk spool files

### DIFF
--- a/examples/homie/homie.ini
+++ b/examples/homie/homie.ini
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# Demonstrate Homie function extensions for mqttwarn
+
+; ========
+; Synopsis
+; ========
+;
+; Run mqttwarn::
+;
+;   export MQTTWARNINI=examples/homie/homie.ini
+;   ./mqttwarn.py
+;
+; Send some homie-like data::
+;
+;   mosquitto_pub -t homie/bee1/weight/value -m 42.42
+
+
+; ==================
+; Base configuration
+; ==================
+
+[defaults]
+hostname     = 'localhost'
+clientid     = 'mqttwarn'
+
+; logging
+logformat = '%(asctime)-15s %(levelname)-5s [%(module)s] %(message)s'
+logfile   = stream://sys.stderr
+
+; one of: CRITICAL, DEBUG, ERROR, INFO, WARN
+#loglevel  = INFO
+loglevel  = DEBUG
+
+; enable service providers
+launch    = log, file
+
+; number of notification dispatcher threads
+num_workers = 3
+
+; path to file containing self-defined functions
+functions = 'examples.homie.homie'
+
+
+; ================
+; check_mk routing
+; ================
+
+; See also https://github.com/jpmens/mqttwarn/wiki/Incorporating-topic-names#incorporate-topic-names-into-topic-targets
+
+[check_mk_universal]
+topic   = homie/+/+/value
+datamap = decode_homie_topic()
+targets = file:cmk_spool
+format  = <<<<{device}>>>>\n<<<local>>>\n 0 {node} {node}={payload} {node}: {payload}
+
+[config:file]
+append_newline = True
+overwrite = True
+targets = {
+    'cmk_spool': ['/var/lib/check_mk_agent/spool/300{device}-{node}'],
+    }
+
+
+; ===============
+; Regular logging
+; ===============
+
+[homie-logging]
+; Just log all incoming messages
+topic   = homie/#
+targets = log:info
+
+[config:log]
+targets = {
+    'debug'  : [ 'debug' ],
+    'info'   : [ 'info' ],
+    'warn'   : [ 'warn' ],
+    'crit'   : [ 'crit' ],
+    'error'  : [ 'error' ]
+    }
+

--- a/examples/homie/homie.py
+++ b/examples/homie/homie.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Homie function extensions for mqttwarn
+import re
+
+
+# ------------------------------------------
+#                  Synopsis
+# ------------------------------------------
+#
+# Run mqttwarn::
+#
+#   export MQTTWARNINI=examples/homie/homie.ini
+#   ./mqttwarn.py
+#
+# Send some homie-like data::
+#
+#   mosquitto_pub -t homie/bee1/weight/value -m 42.42
+
+
+def decode_homie_topic(topic):
+    """
+    Split Homie-style MQTT topic path into segments for
+    enriching transformation data inside mqttwarn.
+    """
+    if type(topic) == str:
+        try:
+            pattern = r'^(?P<realm>.+?)/(?P<device>.+?)/(?P<node>.+?)/(?P<property>.+?)$'
+            p = re.compile(pattern)
+            m = p.match(topic)
+            topology = m.groupdict()
+        except:
+            topology = {}
+        return topology
+    return None
+


### PR DESCRIPTION
Dear Jan-Piet,

some people from the beekeeper community are monitoring their hives with ESP8266 MCUs using Homie. To support [them](https://www.imker-nettetal.de/esp8266-beescale-erste-eindruecke/), we provided a little example ready for decoding Homie-style MQTT sensor value publications into the mqttwarn transformation dict.

In this case, the information is then routed into a [check_mk](https://mathias-kettner.de/check_mk.html) [spool file](https://mathias-kettner.de/check_mk_werks.php?werk_id=0016) using a basic file service target, intensively using the provided interpolation mechanics along the line.

With kind regards,
Andreas.
