### PR TITLE
Set JSON content type for POST in http service

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,7 +804,7 @@ Each target has five parameters:
 2. The URL, which is transformed if possible (transformation errors are ignored)
 3. `None` or a dict of parameters. Each individual parameter value is transformed.
 4. `None` or a list of username/password e.g. `( 'username', 'password')`
-5. `None` or True to force the transformation of the third parameter to a json object
+5. `None` or True to force the transformation of the third parameter to a json object and to send the HTTP header `Content-Type` with a value of `application/json` when using `post`
 
 ```ini
 [config:http]

--- a/services/http.py
+++ b/services/http.py
@@ -90,6 +90,7 @@ def plugin(srv, item):
             if params is not None:
                 if tojson is not None:
                     encoded_params = json.dumps(params)
+                    request.add_header('Content-Type', 'application/json')
                 else:
                     encoded_params = urllib.urlencode(params)
             else:


### PR DESCRIPTION
Services like IFTTT insist that POST requests carry an HTTP header indicating the content type, e.g. for JSON:
`Content-Type: application/json`

This change adds that header.

Previously there was no indication of content type, so the change should hopefully not affect anyone negatively.
