### PR TITLE
Support using templates with influxdb service

### DIFF
--- a/services/influxdb.py
+++ b/services/influxdb.py
@@ -24,7 +24,7 @@ def plugin(srv, item):
 
     measurement = item.addrs[0]
     tag         = "topic=" + item.topic.replace('/', '_')
-    value       = item.payload
+    value       = item.message
     
     try:
         url = "http://%s:%d/write?db=%s" % (host, port, database)


### PR DESCRIPTION
Payload seems to always contain the original value, even after "templating", so we should use item.message here