### PR TITLE
Improve examples

### DIFF
--- a/examples/hiveeyes/hiveeyes.py
+++ b/examples/hiveeyes/hiveeyes.py
@@ -22,8 +22,8 @@ from collections import deque, defaultdict
 #
 # Trigger an alarm by simulating a weight loss event::
 #
-#   echo '{"wght2": 43.0}' | mosquitto_pub -t hiveeyes/demo/area-42/beehive-1/message-json -l
-#   echo '{"wght2": 42.0}' | mosquitto_pub -t hiveeyes/demo/area-42/beehive-1/message-json -l
+#   echo '{"wght2": 43.0}' | mosquitto_pub -t hiveeyes/demo/area-42/beehive-1/data.json -l
+#   echo '{"wght2": 42.0}' | mosquitto_pub -t hiveeyes/demo/area-42/beehive-1/data.json -l
 
 
 # ------------------------------------------
@@ -115,7 +115,7 @@ def hiveeyes_more_data(topic, data, srv):
     Add more data to transformation data object, used later when formatting the outgoing message.
     """
 
-    if not topic.endswith('message-json'):
+    if not (topic.endswith('data.json') or topic.endswith('message-json')):
         return
 
     message = data['payload']
@@ -183,7 +183,7 @@ def hiveeyes_schwarmalarm_filter(topic, message):
     Also, perform data-loss bookkeeping.
     """
 
-    if not topic.endswith('message-json'):
+    if not (topic.endswith('data.json') or topic.endswith('message-json')):
         return True
 
     # Decode message (redundant with "hiveeyes_more_data")
@@ -297,7 +297,7 @@ def hiveeyes_dataloss_monitor(srv):
                 data = {'description': 'Detected data loss.'}
                 send_to_targets(
                     section = 'hiveeyes-schwarmalarm',
-                    topic   = '{origin}/message-json'.format(origin=origin),
+                    topic   = '{origin}/notification.json'.format(origin=origin),
                     payload = json.dumps(data))
 
         else:

--- a/samplefuncs.py
+++ b/samplefuncs.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # mqttwarn example function extensions
 import time
+import copy
 
 try:
     import json
@@ -22,6 +23,9 @@ def OwnTracksTopic2Data(topic):
 
 def OwnTracksConvert(data):
     if type(data) == dict:
+        # Better safe than sorry: Clone transformation dictionary to prevent leaking local modifications
+        # See also https://github.com/jpmens/mqttwarn/issues/219#issuecomment-271815495
+        data = copy.copy(data)
         tst = data.get('tst', int(time.time()))
         data['tst'] = time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(int(tst)))
         # Remove these elements to eliminate warnings
@@ -37,7 +41,7 @@ def OwnTracksBattFilter(topic, message):
     if 'batt' in data:
         if data['batt'] is not None:
             return int(data['batt']) > 20
-    
+
     return True     # Suppress message because no 'batt'
 
 def TopicTargetList(topic=None, data=None, srv=None):


### PR DESCRIPTION
Dear Jan-Piet,

we just pushed some very minor updates to the example section of mqttwarn. One change is deduced from issue #219 regarding the `OwnTracksConvert` function, the other one is related to slight MQTT topic changes in the [backend machinery](https://getkotori.org/) of our [Hiveeyes](https://hiveeyes.org/) project.

The background of the latter change might spark your interest: With [Kotori version 0.11.0](https://getkotori.org/docs/changes.html#kotori-0-11-0), we introduced a thing called [MQTT content type signalling](https://hiveeyes.org/docs/system/vendor/hiveeyes-one/topology.html#feature-content-type-signalling). As we all know the MQTT bus has content-type agnostic messages and there's no way to indicate the transport format, we introduced a mimetype-based signalling scheme on the very last (suffix) part of the bus topic.

This actually isn't rocket science, but we are happy to see it implemented and just want to spread the word about it.

With kind regards,
Andreas.