### PR TITLE
Supplement _dtiso with _ltiso for local time

### DIFF
--- a/mqttwarn.py
+++ b/mqttwarn.py
@@ -741,6 +741,7 @@ def builtin_transform_data(topic, payload):
     tdata['payload']    = payload
     tdata['_dtepoch']   = int(time.time())          # 1392628581
     tdata['_dtiso']     = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ") # 2014-02-17T10:38:43.910691Z
+    tdata['_ltiso']     = datetime.now().isoformat() #local time in iso format
     tdata['_dthhmm']    = dt.strftime('%H:%M')      # 10:16
     tdata['_dthhmmss']  = dt.strftime('%H:%M:%S')   # hhmmss=10:16:21
 


### PR DESCRIPTION
Add to mqttwarn.py
`tdata['_ltiso']     = datetime.now().isoformat() #local time in iso format`
Provides local time in ISO format for templating. (See _dtiso)

If pull request accepted update Wiki [Transformation data](https://github.com/jpmens/mqttwarn/wiki/Transformation-data)