### PR TITLE
Add celery plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ _mqttwarn_ supports a number of services (listed alphabetically below):
 * [apns](#apns)
 * [asterisk](#asterisk)
 * [carbon](#carbon)
+* [celery](#celery)
 * [dbus](#dbus)
 * [dnsupdate](#dnsupdate)
 * [emoncms](#emoncms)
@@ -483,6 +484,32 @@ In other words, the following payloads are valid:
 room.living 15				metric name and value
 room.living 15 1405014635		metric name, value, and timestamp
 ```
+
+### `celery`
+
+The `celery` service sends messages to celery which celery workers can consume.
+
+```ini
+[config:celery]
+broker_url = 'redis://localhost:6379/5'
+app_name = 'celery'
+celery_serializer = 'json'
+targets = {
+   'hello': [
+      {
+        'task': 'myapp.hello',
+        'message_format': 'json'
+        }
+      ],
+  }
+
+[hello/#]
+targets = celery:hello
+```
+Broker url can be any broker supported by celery. Celery serializer is usually json or pickle. Json is recommended for security.
+Targets are selected by task name. Message_format can be either "json" or "text". If it is json, the message will be sent as a json payload rather than a string.
+In this configuration, all messages that match hello/ will be sent to the celery task "myapp.hello". The first argument of the celery task will be the message from mqtt.
+
 
 ### `dbus`
 

--- a/services/celery.py
+++ b/services/celery.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+__author__    = 'Orhan Hirsch <orhanhenrik()gmail.com>'
+__copyright__ = 'Copyright 2017 Orhan Hirsch'
+__license__   = """Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)"""
+
+HAVE_CELERY=True
+try:
+    import celery
+    import json
+except ImportError:
+    HAVE_CELERY=False
+
+def plugin(srv, item):
+    srv.logging.debug("*** MODULE=%s: service=%s, target=%s", __file__, item.service, item.target)
+    if not HAVE_CELERY:
+        srv.logging.error("'celery' or 'json' module not installed")
+        return False
+
+    config = item.config
+
+    app = celery.Celery(
+        config['app_name'],
+        broker=config['broker_url']
+    )
+
+    for target in item.addrs:
+        message = item.message
+        try:
+            if target['message_format'] == 'json':
+                message = json.loads(message)
+            app.send_task(target['task'], [item.message])
+        except Exception, e:
+            srv.logging.warning("Error: %s" % str(e))
+            return False
+
+    return True


### PR DESCRIPTION
Celery is a python task queue. This plugin allows mqttwarn to send messages from topics to the task queue so workers can consume them. This can be useful because many people already use celery and can simply reuse the same queue to process messages from MQTT.

Please let me know if I should add more docs to the code or readme.