### PR TITLE
Support urls in osxnotify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1519,9 +1519,11 @@ Requires:
 
 * Requires Mac ;-) and [pync](https://github.com/setem/pync) which uses the binary [terminal-notifier](https://github.com/alloy/terminal-notifier) created by Eloy Durán. Note: upon first launch, `pync` will download and extract `https://github.com/downloads/alloy/terminal-notifier/terminal-notifier_1.4.2.zip` into a directory `vendor/`.
 
-| Topic option  |  M/O   | Description                            |
-| ------------- | :----: | -------------------------------------- |
-| `title`       |   O    | application title (dflt: topic name)   |
+| Topic option  |  M/O   | Description                                     |
+| ------------- | :----: | ----------------------------------------------- |
+| `title`       |   O    | application title (dflt: topic name)            |
+
+It `url` is defined in items.data, it's value is passed to the notification, so that the URL is opened when the notification is clicked.
 
 ![osxnotify](assets/osxnotify.jpg)
 

--- a/services/osxnotify.py
+++ b/services/osxnotify.py
@@ -15,8 +15,14 @@ def plugin(srv, item):
     text = item.message
     application_name = item.get('title', item.topic)
 
+    # If item.data contains a URL field, use it as a target for the notification
+    url = None
+    extra_data = item.data
+    if extra_data is not None:
+        url = extra_data.get('url', None)
+
     try:
-        Notifier.notify(text,  title=application_name)
+        Notifier.notify(text,  title=application_name, open=url)
     except Exception, e:
         srv.logging.warning("Cannot invoke Notifier to osx: %s" % (str(e)))
         return False


### PR DESCRIPTION
When using osx desktop notification, it can be useful to have a
URL associated to the notification, so that it may be clicked to
open a web page with further details.

I'm using this with Firehose from OpenStack when listening to gerrit
topics, to open the corresponding change in gerrit. The url can be
set on the item using payload transformation functions.