### PR TITLE
Fix function loading

### DIFF
--- a/mqttwarn.ini.sample
+++ b/mqttwarn.ini.sample
@@ -27,8 +27,7 @@ logfile   = 'mqttwarn.log'
 loglevel  = DEBUG
 
 ; path to file containing self-defined functions for formatmap and datamap
-; omit the '.py' extension
-functions = 'samplefuncs'
+functions = 'samplefuncs.py'
 
 ; name the service providers you will be using.
 launch    = file, log


### PR DESCRIPTION
@jpmens this is a breaking change unfortunately but was necessary to allow specifying an absolute path for a `functions` file. The reason for this was I wanted to move my `mqttwarn` config into a separate git repo for version management etc, this included `functions.py`. However specifying the full path to the new `functions.py` location in `mqttwarn.ini` was not working.

The change in this PR allows for any path to be specified for `cf.functions`, but the `.py` extension must be included - i.e. it must be the full filename.

Have a look and see what you think. Understand if you don't want to merge, if so I will just run this locally.