### PR TITLE
Boxcar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ pastebin.py
 .vs/ProjectSettings.json
 .vs/slnx.sqlite
 f.01
+.vs/VSWorkspaceState.json

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ pastebin.py
 *.sln
 *.suo
 *.pyproj
+.vs/ProjectSettings.json
+.vs/slnx.sqlite
+f.01

--- a/README.md
+++ b/README.md
@@ -742,7 +742,7 @@ Requires
 
 The `boxcar` service will use the boxcar notification service to send messages.  It was one of the first IOS notification services..
 
-The paylod (message) of the mqtt topic, can use the "|" seperator to contain a notification title, a long message and a url.  
+The payload  of the MQTT message, can use the "|" seperator to contain a notification title, a long message and a url.  
 Urls can go in the long message with an <a href> tag.  Most other html tags will work also.
 To get the message to open a url, use the 3rd section for a url.
 

--- a/README.md
+++ b/README.md
@@ -738,6 +738,65 @@ Requires
 * [Asterisk](http://www.asterisk.org/) with configured AMI interface (manager.conf)
 * pyst2 -  powerful Python abstraction of the various Asterisk APIs (pip install pyst2)
 
+## `boxcar`
+
+The `boxcar` service will use the boxcar notification service to send messages.  It was one of the first IOS notification services..
+
+
+
+```ini
+[config:boxcar]
+targets  = {
+    'source'    : ['recipient key',
+				   'icon url',
+				   'sound']
+          }
+```
+
+'source' is the name of where the message should come from, ie OpenHAB as a source, GPSGate as a source.
+'recipient key' is a users key for receiving a mesage.  See http://help.boxcar.io/support/solutions/articles/6000015725-how-to-get-my-boxcar-access-token-
+'icon url' is an image url, must be publically available.
+'sound' is the name of a sound file.  
+
+Here is the list of sound you can use in the notifications you send to your account:
+
+beep-crisp
+beep-soft
+bell-modern
+bell-one-tone
+bell-simple
+bell-triple
+bird-1
+bird-2
+boing
+cash
+clanging
+detonator-charge
+digital-alarm
+done
+echo
+flourish
+harp
+light
+magic-chime
+magic-coin
+notifier-1
+notifier-2
+notifier-3
+orchestral-long
+orchestral-short
+score
+success
+up
+The special sound "no-sound" forces the notification to be silent, no matter what are defined in the general settings.
+
+
+Requires
+
+* urllib
+* ssl 
+* httplib
+
 ### `gss`
 
 The `gss` service interacts directly with a Google Docs Spreadsheet. Each message can be written to a row in a selected worksheet.

--- a/README.md
+++ b/README.md
@@ -742,6 +742,14 @@ Requires
 
 The `boxcar` service will use the boxcar notification service to send messages.  It was one of the first IOS notification services..
 
+The paylod (message) of the mqtt topic, can use the "|" seperator to contain a notification title, a long message and a url.  
+Urls can go in the long message with an <a href> tag.  Most other html tags will work also.
+To get the message to open a url, use the 3rd section for a url.
+
+Eg:
+ 'testing a message|this one contains a title and long message <a href="http://www.google.co.nz">Link</a>|http://www.google.co.nz'
+
+ Will have a title of "testing a message", and a long text of "this one contains a title and long message Link" (which link being a hyper link.  It will also have a redirection button to the google home page.
 
 
 ```ini
@@ -753,7 +761,7 @@ targets  = {
           }
 ```
 
-* 'source' is the name of where the message should come from, ie OpenHAB as a source, GPSGate as a source.
+* 'source' is the name of where the message should come from, ie OpenHAB as a source, GPSGate as a source.  These can be filtered in boxcar
 * 'recipient key' is a users key for receiving a mesage.  See http://help.boxcar.io/support/solutions/articles/6000015725-how-to-get-my-boxcar-access-token-
 * 'icon url' is an image url, must be publically available.
 * 'sound' is the name of a sound file.  

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ _mqttwarn_ supports a number of services (listed alphabetically below):
 * [amqp](#amqp)
 * [apns](#apns)
 * [asterisk](#asterisk)
+* [boxcar] (#boxcar)
 * [carbon](#carbon)
 * [celery](#celery)
 * [dbus](#dbus)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ _mqttwarn_ supports a number of services (listed alphabetically below):
 * [amqp](#amqp)
 * [apns](#apns)
 * [asterisk](#asterisk)
-* [boxcar] (#boxcar)
+* [boxcar](#boxcar)
 * [carbon](#carbon)
 * [celery](#celery)
 * [dbus](#dbus)
@@ -753,43 +753,43 @@ targets  = {
           }
 ```
 
-'source' is the name of where the message should come from, ie OpenHAB as a source, GPSGate as a source.
-'recipient key' is a users key for receiving a mesage.  See http://help.boxcar.io/support/solutions/articles/6000015725-how-to-get-my-boxcar-access-token-
-'icon url' is an image url, must be publically available.
-'sound' is the name of a sound file.  
+* 'source' is the name of where the message should come from, ie OpenHAB as a source, GPSGate as a source.
+* 'recipient key' is a users key for receiving a mesage.  See http://help.boxcar.io/support/solutions/articles/6000015725-how-to-get-my-boxcar-access-token-
+* 'icon url' is an image url, must be publically available.
+* 'sound' is the name of a sound file.  
 
 Here is the list of sound you can use in the notifications you send to your account:
 
-beep-crisp
-beep-soft
-bell-modern
-bell-one-tone
-bell-simple
-bell-triple
-bird-1
-bird-2
-boing
-cash
-clanging
-detonator-charge
-digital-alarm
-done
-echo
-flourish
-harp
-light
-magic-chime
-magic-coin
-notifier-1
-notifier-2
-notifier-3
-orchestral-long
-orchestral-short
-score
-success
-up
-The special sound "no-sound" forces the notification to be silent, no matter what are defined in the general settings.
+* beep-crisp
+* beep-soft
+* bell-modern
+* bell-one-tone
+* bell-simple
+* bell-triple
+* bird-1
+* bird-2
+* boing
+* cash
+* clanging
+* detonator-charge
+* digital-alarm
+* done
+* echo
+* flourish
+* harp
+* light
+* magic-chime
+* magic-coin
+* notifier-1
+* notifier-2
+* notifier-3
+* orchestral-long
+* orchestral-short
+* score
+* success
+* up
 
+The special sound "no-sound" forces the notification to be silent, no matter what are defined in the general settings.
 
 Requires
 

--- a/services/boxcar.py
+++ b/services/boxcar.py
@@ -6,31 +6,23 @@ __copyright__ = 'Copyright 2017 David Cole'
 __license__   = """Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)"""
 
 import boxcar       # pip install python-boxcar
+from httplib import HTTPSConnection, HTTPException
+import ssl
+import urllib
+from urllib import urlencode
 #from boxcar import Provider # pip install python-boxcar
 
 def plugin(srv, item):
 
     srv.logging.debug("*** MODULE=%s: service=%s, target=%s", __file__, item.service, item.target)
 
-    
-    #p.subscribe(email='test@example.com')
-    #p.notify(emails=['test@example.com'],
-    #     from_screen_name='test',
-    #     message='This is a test message.',
-    #     source_url='https://github.com/markcaudill/boxcar',
-    #     icon_url='http://i.imgur.com/RC220wK.png')
+    # Prepare the notification parameters
     
     boxcar_keys = item.addrs
     srv.logging.debug("*** MODULE=%s: service=%s, target=%s loading api", __file__, item.service, item.target)
-    boxcar_api = boxcar.Provider(
-        key                 = boxcar_keys[0]
-    )
-    #boxcar_api = boxcar.Provider(
-    #    #key='vKLoSqB4vhQ4BPZ2TQ4z',
-    #    key                 = boxcar_keys[0],
-    #    #secret='hPiCqQMuRCDXbkVXYsq4zOu5AGZEZ0bGye7dfl5b'
-    #    secret              = boxcar_keys[1]
-    #)
+    
+    srv.logging.debug('starting')
+    srv.logging.debug(boxcar_keys)
     srv.logging.debug("*** MODULE=%s: service=%s, target=%s loaded api: %s", __file__, item.service, item.target,boxcar_keys[0])
     
     text = item.message[0:138]
@@ -40,12 +32,38 @@ def plugin(srv, item):
         #    message=text,
         #    source_url='https://github.com/markcaudill/boxcar',
         #    icon_url='http://i.imgur.com/RC220wK.png')
-        boxcar_api.notify(emails=['test@example.com'],
-         from_screen_name=item.target,
-         message=text,
-         source_url='www.google.com',
-         icon_url='http://i.imgur.com/RC220wK.png')
+        #boxcar_api.notify(emails=['test@example.com'],
+        # from_screen_name=item.target,
+        # message=text,
+        # source_url='www.google.com',
+        # icon_url='http://i.imgur.com/RC220wK.png')
         
+        params = urlencode(
+            {
+  	        'user_credentials': boxcar_keys[0],
+            'notification[title]': item.target,
+            'notification[source_name]': item.target,
+            'notification[icon_url]' : boxcar_keys[1],
+
+            'notification[long_message]': text,
+            'notification[sound]': boxcar_keys[2]
+            }
+        )
+  
+        # Create a secure connection to Boxcar and POST the message
+        context = ssl.create_default_context()
+        conn = HTTPSConnection('new.boxcar.io', context=context)
+        conn.request('POST', '/api/notifications', params)
+  
+        # Check the response
+        response = conn.getresponse()
+        srv.logging.debug("Boxcar result: %s: %s" % (response.status, response.reason))
+        data = response.read()
+        srv.logging.debug(data)
+  
+        # Clean up the connection
+        conn.close()
+
         srv.logging.debug("Successfully sent tweet")
     except Exception, e:
         srv.logging.error("BoxcarError: %s" % (str(e)))

--- a/services/boxcar.py
+++ b/services/boxcar.py
@@ -25,9 +25,24 @@ def plugin(srv, item):
     srv.logging.debug(boxcar_keys)
     srv.logging.debug("*** MODULE=%s: service=%s, target=%s loaded api: %s", __file__, item.service, item.target,boxcar_keys[0])
     
-    text = item.message[0:138]
+    message = item.message.split("|")
+    title = message[0]
+    longmessage = ""
+
+    if len(message) > 1:
+        longmessage = message[1]
+    else:
+         srv.logging.debug("No long message")
+
+    openurl = ""
+    if len(message) > 2:
+        openurl = message[2]
+    else:
+        srv.logging.debug("No url")
+    
+
     try:
-        srv.logging.debug("Sending notification to %s..." % (item.target))
+        srv.logging.debug("Sending notification to %s... with title:%s and long message: %s " % (item.target, title,longmessage))
         #boxcar_api.broadcast(from_screen_name=item.target,
         #    message=text,
         #    source_url='https://github.com/markcaudill/boxcar',
@@ -41,12 +56,13 @@ def plugin(srv, item):
         params = urlencode(
             {
   	        'user_credentials': boxcar_keys[0],
-            'notification[title]': item.target,
+            'notification[title]': title,
             'notification[source_name]': item.target,
             'notification[icon_url]' : boxcar_keys[1],
 
-            'notification[long_message]': text,
-            'notification[sound]': boxcar_keys[2]
+            'notification[long_message]': longmessage,
+            'notification[sound]': boxcar_keys[2],
+            'notification[open_url]' : openurl
             }
         )
   

--- a/services/boxcar.py
+++ b/services/boxcar.py
@@ -5,7 +5,6 @@ __author__    = 'David Cole <psyciknz()andc.nz>'
 __copyright__ = 'Copyright 2017 David Cole'
 __license__   = """Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)"""
 
-import boxcar       # pip install python-boxcar
 from httplib import HTTPSConnection, HTTPException
 import ssl
 import urllib

--- a/services/boxcar.py
+++ b/services/boxcar.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+__author__    = 'David Cole <psyciknz()andc.nz>'
+__copyright__ = 'Copyright 2017 David Cole'
+__license__   = """Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)"""
+
+import boxcar       # pip install python-boxcar
+#from boxcar import Provider # pip install python-boxcar
+
+def plugin(srv, item):
+
+    srv.logging.debug("*** MODULE=%s: service=%s, target=%s", __file__, item.service, item.target)
+
+    
+    #p.subscribe(email='test@example.com')
+    #p.notify(emails=['test@example.com'],
+    #     from_screen_name='test',
+    #     message='This is a test message.',
+    #     source_url='https://github.com/markcaudill/boxcar',
+    #     icon_url='http://i.imgur.com/RC220wK.png')
+    
+    boxcar_keys = item.addrs
+    srv.logging.debug("*** MODULE=%s: service=%s, target=%s loading api", __file__, item.service, item.target)
+    boxcar_api = boxcar.Provider(
+        key                 = boxcar_keys[0]
+    )
+    #boxcar_api = boxcar.Provider(
+    #    #key='vKLoSqB4vhQ4BPZ2TQ4z',
+    #    key                 = boxcar_keys[0],
+    #    #secret='hPiCqQMuRCDXbkVXYsq4zOu5AGZEZ0bGye7dfl5b'
+    #    secret              = boxcar_keys[1]
+    #)
+    srv.logging.debug("*** MODULE=%s: service=%s, target=%s loaded api: %s", __file__, item.service, item.target,boxcar_keys[0])
+    
+    text = item.message[0:138]
+    try:
+        srv.logging.debug("Sending notification to %s..." % (item.target))
+        #boxcar_api.broadcast(from_screen_name=item.target,
+        #    message=text,
+        #    source_url='https://github.com/markcaudill/boxcar',
+        #    icon_url='http://i.imgur.com/RC220wK.png')
+        boxcar_api.notify(emails=['test@example.com'],
+         from_screen_name=item.target,
+         message=text,
+         source_url='www.google.com',
+         icon_url='http://i.imgur.com/RC220wK.png')
+        
+        srv.logging.debug("Successfully sent tweet")
+    except Exception, e:
+        srv.logging.error("BoxcarError: %s" % (str(e)))
+        return False
+    except Exception, e:
+        srv.logging.error("Error sending tweet to %s: %s" % (item.target, str(e)))
+        return False
+
+    return True


### PR DESCRIPTION
Hi

I've been speaking to @sumnerboy12 regarding mqttwarn.  I was a big proponent of boxcar to ios notifications, and use them a bit on my OpenHAB solutions.  So I've added boxcar support.  But It may have gone from the app store so it may negate it use.  Is there something similar you already run?  Pushover?  

Boxcar does ios (and android I think) notifications, where you can set the warning sound on the message, and the text can contain links etc.  http://blog.boxcar.io/post/93211745502/boxcar-api-update-boxcar-api-update-icon-and

Thoughts?