### PR TITLE
Optional JSON output serialization using type coercion before formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2392,6 +2392,31 @@ item = {
 
 ## Advanced features
 
+### JSON output serialization
+
+When receiving JSON data like `{"data": {"humidity": 62.18}}`, you might
+want to extract values using the `format` mechanism before forwarding
+it to other data sinks, like
+
+```ini
+format = "{data}"
+```
+
+However, the outcome will be the string-serialized form of the Python
+representation: `{u'humidity': 62.18}`, which could not be what you
+want if your data sink is expecting JSON format again.
+
+To achieve this, you should use appropriate type coercion before
+formatting, like
+
+```ini
+format = "{data!j}"
+```
+
+This will serialize the formatted data to JSON format appropriately,
+so the outcome will be `{"humidity": 62.18}`.
+
+
 ### Transformation data
 
 _mqttwarn_ can transform an incoming message before passing it to a plugin service.


### PR DESCRIPTION
Dear Jan-Piet and Gary (@rapport),

we just found #146 and tried to solve it without using a custom function. The problem was that _mqttwarn_ puts things like `{u'humidity': u'62.18'}` on its egress data path, which is the String-serialized **Python representation** of the respective data structure.

Receivers **expecting JSON** will probably croak on that, so @rapport worked around it by implementing a custom function which does the data extraction and JSON serialization manually.

With this PR, it will become possible to achieve the same thing solely by applying type coercion using the custom conversion flag "`!j`" with the regular Python string formatting machinery, like
```ini
format = "{data!j}"
```
... which will serialize the value to JSON before putting it on the egress data path.

The change is not very intrusive, we included appropriate documentation for the README and hope you like this.

With kind regards,
Andreas.
