### PR TITLE
Websocket service

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ _mqttwarn_ supports a number of services (listed alphabetically below):
 * [xbmc](#xbmc)
 * [xmpp](#xmpp)
 * [xively](#xively)
+* [websocket](#websocket)
 * [zabbix](#zabbix)
 
 ![definition by Google](assets/mqttwarn.png)
@@ -2409,6 +2410,22 @@ mosquitto_pub -t "osx/json" -m '{"temperature":15,"waterlevel":100,"humidity":35
 Requires:
 * [Xively](http://xively.com) account with an already existing Feed
 * [xively-python](https://github.com/xively/xively-python) - pip install xively-python
+
+### `websocket`
+
+The websocket service can be used to send data to a websocket server defined by its uri. `ws://` or `wss://` schemas
+are supported.
+
+```ini
+[config:websocket]
+targets = {
+        # targetid        : [ 'wsuri']
+        'wssserver' : [ 'ws://localhost/ws' ],
+ 
+```
+
+Requires:
+* [websocket-client](https://pypi.python.org/pypi/websocket-client/) - pip install websocket-client
 
 ### `zabbix`
 

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ _mqttwarn_ supports a number of services (listed alphabetically below):
 * [tootpaste](#tootpaste)
 * [twilio](#twilio)
 * [twitter](#twitter)
+* [websocket](#websocket)
 * [xbmc](#xbmc)
 * [xmpp](#xmpp)
 * [xively](#xively)
-* [websocket](#websocket)
 * [zabbix](#zabbix)
 
 ![definition by Google](assets/mqttwarn.png)
@@ -2343,6 +2343,22 @@ Requires:
 * app keys for Twitter, from [apps.twitter.com](https://apps.twitter.com)
 * [python-twitter](https://github.com/bear/python-twitter)
 
+### `websocket`
+
+The websocket service can be used to send data to a websocket server defined by its uri. `ws://` or `wss://` schemas
+are supported.
+
+```ini
+[config:websocket]
+targets = {
+        # targetid        : [ 'wsuri']
+        'wssserver' : [ 'ws://localhost/ws' ],
+} 
+```
+
+Requires:
+* [websocket-client](https://pypi.python.org/pypi/websocket-client/) - pip install websocket-client
+
 ### `xbmc`
 
 This service allows for on-screen notification pop-ups on [XBMC](http://xbmc.org/) instances. Each target requires
@@ -2410,22 +2426,6 @@ mosquitto_pub -t "osx/json" -m '{"temperature":15,"waterlevel":100,"humidity":35
 Requires:
 * [Xively](http://xively.com) account with an already existing Feed
 * [xively-python](https://github.com/xively/xively-python) - pip install xively-python
-
-### `websocket`
-
-The websocket service can be used to send data to a websocket server defined by its uri. `ws://` or `wss://` schemas
-are supported.
-
-```ini
-[config:websocket]
-targets = {
-        # targetid        : [ 'wsuri']
-        'wssserver' : [ 'ws://localhost/ws' ],
- 
-```
-
-Requires:
-* [websocket-client](https://pypi.python.org/pypi/websocket-client/) - pip install websocket-client
 
 ### `zabbix`
 

--- a/services/websocket.py
+++ b/services/websocket.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+__author__    = 'Giovanni Angoli <juzam76()gmail.com>'
+__copyright__ = 'Copyright 2018 Giovanni Angoli'
+__license__   = """Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)"""
+
+# this is basically the file.py service but declined for websockets, not more than s/file/websocket/g
+
+import websocket # pip install websocket-client
+
+def plugin(srv, item):
+
+    srv.logging.debug("*** MODULE=%s: service=%s, target=%s", __file__, item.service, item.target)
+
+
+    # item.config is brought in from the configuration file
+    config   = item.config
+
+    # addrs is a list[] associated with a particular target.
+    # While it may contain more than one item (e.g. pushover)
+    # the `websocket' service carries one only, i.e. a ws:// or wss:// uri
+    uri = item.addrs[0].format(**item.data).encode('utf-8')
+
+    # If the incoming payload has been transformed, use that,
+    # else the original payload
+    text = item.message
+
+    try:
+        ws = websocket.WebSocket()
+        ws.connect(uri)
+        ws.send(text)
+        ws.close()
+    except Exception, e:
+        srv.logging.warning("Cannot write to websocket `%s': %s" % (uri, str(e)))
+        return False
+
+    return True


### PR DESCRIPTION
This is heavily based on `file` plugin.  It can be used to send data to Websockets servers (be it `ws://` or `wss://`).

disabling certificate/hostname check for secure websockets is not currently supported.