### PR TITLE
InfluxDB plugin enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1116,7 +1116,7 @@ database  = 'mqttwarn'
 rp        = 'retentionpolicy'
 precision = 'ns'    # { ns, u, ms, s, m, h }
 targets = {
-                       # measurement (use database, rp, aprecision specified above)
+                       # measurement (use database, rp, and precision specified above)
     'temperature'   : [ 'temperature' ],
                        # measurement,    database,   rp,     precision
     'disk'          : [ 'disk',          'servers',  'rp',   'h' ]

--- a/README.md
+++ b/README.md
@@ -1149,6 +1149,7 @@ format = room=basement,entity=sensor2 temperature={payload}
 ... will be stored as:
 
 ```
+             (tag)    (tag)     (field)      (tag)
 time         entity   room      temperature  topic
 ----         ------   ----      -----------  -----
 {timestamp}  sensor2  basement  47.5         environment_temperature_basement

--- a/README.md
+++ b/README.md
@@ -1107,6 +1107,7 @@ targets = {
 Individual targets can override the default measurement, retention policy, and/or precision:
 
 ```ini
+[config:influxdb]
 host      = 'influxdbhost'
 port      = 8086
 username  = 'username'


### PR DESCRIPTION
Enhanced the InfluxDB plugin:

- Support InfluxDB retention policies (optional, global, and can override per target)
- Support InfluxDB precision (optional, global, and can override per target)
- Support writing to multiple InfluxDB databases (optional, can override the default database per target)
- Support InfluxDB tags and fields using transformation format string (optional, can specify per topic)

Sample ini snippet illustrating the new features:

```ini
[config:influxdb]
host      = 'influxdbhost'
port      = 8086
username  = 'username'
password  = 'password'
database  = 'mqttwarn'

# Retention Policy: optional (default: autogen)
rp        = 'retentionpolicy'
# Precision: optional (default: ns)
precision = 's'    # { ns, u, ms, s, m, h }

targets = {
                       # measurement (use database, rp, and precision specified above)
    'temperature'   : [ 'temperature' ],
                       # measurement,    database,   rp,     precision
    'disk'          : [ 'disk',          'servers',  'rp',   'h' ]
                       # measurement,    database   (default rp & precision)
    'cpu'           : [ 'cpu',           'servers' ],
                       # use default rp, but override database & precision:
    'alpha'         : [ 'alpha',         'metrics',  '',    's' ]
    }
```
```ini
[environment/temperature/basement]
targets = influxdb:temperature
format = room=basement,entity=sensor2 temperature={payload}
```

This should be backward-compatible with existing configurations using the InfluxDB plugin: it should work if `rp` and/or `precision` are not specified, and if targets only contain the minimum required value (measurement name).