### PR TITLE
copy sample ini file to conf directory

### DIFF
--- a/mqttwarn.py
+++ b/mqttwarn.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import shutil
 import paho.mqtt.client as paho   # pip install paho-mqtt
 import imp
 import logging
@@ -337,6 +338,8 @@ try:
     cf = Config(CONFIGFILE)
 except Exception, e:
     print "Cannot open configuration at %s: %s" % (CONFIGFILE, str(e))
+    shutil.copyfile('mqttwarn.ini.sample', CONFIGFILE + '.sample')
+    print "\nA sample configuration file has been created at %s. Please rename to mqttwarn.ini and edit as appropriate." % (CONFIGFILE + '.sample')
     sys.exit(2)
 
 LOGLEVEL  = cf.loglevelnumber


### PR DESCRIPTION
I am running mqttwarn in a Docker on [unRAID](https://unraid.net/), and using the `MQTTWARNINI` environment variable to change my configuration directory to a directory on the local host. This PR causes the `mqttwarn.ini.sample` file to be copied to the configuration directory on startup, if `mqttwarn.ini` doesn't exist.