### PR TITLE
use MQTTWARNLOG, if set

### DIFF
--- a/mqttwarn.py
+++ b/mqttwarn.py
@@ -340,7 +340,10 @@ except Exception, e:
     sys.exit(2)
 
 LOGLEVEL  = cf.loglevelnumber
-LOGFILE   = cf.logfile
+
+# if MQTTWARNLOG env variable exists, use it; otherwise, use config file
+LOGFILE    = os.getenv(SCRIPTNAME.upper() + 'LOG', cf.logfile)
+
 LOGFORMAT = cf.logformat
 
 # initialise logging

--- a/mqttwarn.py
+++ b/mqttwarn.py
@@ -341,7 +341,7 @@ except Exception, e:
 
 LOGLEVEL  = cf.loglevelnumber
 
-# if MQTTWARNLOG env variable exists, use it; otherwise, use config file
+# if MQTTWARNLOG env variable exists, use it; otherwise, use 'logfile' option from mqttwarn.ini
 LOGFILE    = os.getenv(SCRIPTNAME.upper() + 'LOG', cf.logfile)
 
 LOGFORMAT = cf.logformat


### PR DESCRIPTION
mqttwarn ignores the `MQTTWARNLOG` environment variable, if set, and instead uses the logfile location set within the configuration file.

This PR determines the location of the logfile by using the following order of precedence:

1. `MQTTWARNLOG` environment variable
2. logfile as defined in the configuration file
