### PR TITLE
Encoding change needed to allow postgres inserts in python3

### DIFF
--- a/mqttwarn/services/postgres.py
+++ b/mqttwarn/services/postgres.py
@@ -14,7 +14,7 @@ __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/ep
 # user    = 'username'
 # pass    = 'password'
 # dbname  = 'databasename'
-# targets = { 
+# targets = {
 #    'target1': ['table1', 'fallbackcol1', 'schema']
 #  }
 
@@ -68,7 +68,7 @@ def plugin(srv, item):
             schema = item.addrs[2].format(**item.data).encode('utf-8')
         except:
             schema = 'public'
-    except:        
+    except:
         srv.logging.warn("postgres target incorrectly configured")
         return False
 

--- a/mqttwarn/services/postgres.py
+++ b/mqttwarn/services/postgres.py
@@ -62,10 +62,10 @@ def plugin(srv, item):
     dbname  = item.config.get('dbname')
 
     try:
-        table_name = item.addrs[0].format(**item.data).encode('utf-8')
-        fallback_col = item.addrs[1].format(**item.data).encode('utf-8')
+        table_name = item.addrs[0].format(**item.data)
+        fallback_col = item.addrs[1].format(**item.data)
         try:
-            schema = item.addrs[2].format(**item.data).encode('utf-8')
+            schema = item.addrs[2].format(**item.data)
         except:
             schema = 'public'
     except:
@@ -94,7 +94,7 @@ def plugin(srv, item):
     if item.data is not None:
         for key in list(item.data.keys()):
             try:
-                col_data[key] = item.data[key].format(**item.data).encode('utf-8')
+                col_data[key] = item.data[key].format(**item.data)
             except Exception as e:
                 col_data[key] = item.data[key]
 


### PR DESCRIPTION
I'm trying to use the postgres service on a fresh (pypi) install in a python3 virtual environment (after having used it for some time by cloning from github).  I could only get it to work without the forced encoding.  I also checked that the service still works in a python2 virtual environment as well.  I'm not sure what else this change might break.

I can provide more info detailing the specific messages that i was running into if it would help.
