### PR TITLE
Adding warntoggle to the examples folder

### DIFF
--- a/examples/warntoggle/README.rst
+++ b/examples/warntoggle/README.rst
@@ -7,7 +7,7 @@ A custom function to be used when configuring streams in ``mqttwarn``, ``warntog
 Example workflow
 ================
 
-- ``mqttwarn.ini`` has a section ``[+/temperature]```, which applies to all MQTT messages received on matching topics. This section includes a filter, referring to our custom function.
+- ``mqttwarn.ini`` has a section ``[+/temperature]``, which applies to all MQTT messages received on matching topics. This section includes a filter, referring to our custom function.
 - When an MQTT message is received, the custom function is triggered.
 - This custom function checks a JSON file for the topic, and based on ``TRUE`` or ``FALSE`` setting will return a message back to `mqttwarn` to either allow the notification to happen or not.
 - If an MQTT topic was not found in aforementioned JSON file, it will be added and set with a configurable default value.
@@ -17,6 +17,6 @@ Installation
 ============
 
 - Copy the ``togglestate()`` function from ``mqttwarn/customfunctions.py`` to your own custom functions file, or copy the entire file and refer to it in `mqttwarn.ini` with a  ``functions = 'customfunctions.py'`` directive.
-- Copy the content of the `www` folder to a web server on the same host as `mqttwarn`, ensure Python is enabled for the server.
+- Copy the content of the `www` folder to a web server on the same host as `mqttwarn`, ensure Python is enabled for the server and ``warntoggle.json`` is writeable by the web server.
 - Create a symbolic link from ``/opt/mqttwarn/warntoggle.json`` -> ``/var/www/html/warntoggle.json`, obviously adjusted for your local situation. Alternatively, configure the filename inside the custom function where it now says ``filename = "warntoggle.js"`` to contain an absolute path.
 - For each stream you wish to be considered by ``warntoggle``, add a line ``filter = togglestate()`` to ``mqttwarn.ini``. This must be done inside each stream section.

--- a/examples/warntoggle/README.rst
+++ b/examples/warntoggle/README.rst
@@ -1,0 +1,22 @@
+**********
+warntoggle
+**********
+
+A custom function to be used when configuring streams in `mqttwarn`, `warntoggle` makes it easy to toggle notifications on or off through a simple web interface.
+
+Example workflow
+================
+
+- `mqttwarn.ini` has a section `[+/temperature]`, which applies to all MQTT messages received on matching topics. This section includes a filter, referring to our custom function.
+- When an MQTT message is received, the custom function is triggered.
+- This custom function checks a JSON file for the topic, and based on `TRUE` or `FALSE` setting will return a message back to `mqttwarn` to either allow the notification to happen or not.
+- If an MQTT topic was not found in aforementioned JSON file, it will be added and set with a configurable default value.
+- For the user, an accompanying web script allows the toggle to be changed.
+
+Installation
+============
+
+- Copy the `togglestate()` function from `mqttwarn/customfunctions.py` to your own custom functions file, or copy the entire file and refer to it in `mqttwarn.ini` with a  `functions = 'customfunctions.py'` directive.
+- Copy the content of the `www` folder to a web server on the same host as `mqttwarn`, ensure Python is enabled for the server.
+- Create a symbolic link from `/opt/mqttwarn/warntoggle.json` -> `/var/www/html/warntoggle.json`, obviously adjusted for your local situation. Alternatively, configure the filename inside the custom function where it now says `filename = "warntoggle.js"` to contain an absolute path.
+- For each stream you wish to be considered by `warntoggle`, add a line `filter = togglestate()` to `mqttwarn.ini`. This must be done inside each stream section. 

--- a/examples/warntoggle/README.rst
+++ b/examples/warntoggle/README.rst
@@ -2,21 +2,21 @@
 warntoggle
 **********
 
-A custom function to be used when configuring streams in `mqttwarn`, `warntoggle` makes it easy to toggle notifications on or off through a simple web interface.
+A custom function to be used when configuring streams in ``mqttwarn``, ``warntoggle`` makes it easy to toggle notifications on or off through a simple web interface.
 
 Example workflow
 ================
 
-- `mqttwarn.ini` has a section `[+/temperature]`, which applies to all MQTT messages received on matching topics. This section includes a filter, referring to our custom function.
+- ``mqttwarn.ini`` has a section ``[+/temperature]```, which applies to all MQTT messages received on matching topics. This section includes a filter, referring to our custom function.
 - When an MQTT message is received, the custom function is triggered.
-- This custom function checks a JSON file for the topic, and based on `TRUE` or `FALSE` setting will return a message back to `mqttwarn` to either allow the notification to happen or not.
+- This custom function checks a JSON file for the topic, and based on ``TRUE`` or ``FALSE`` setting will return a message back to `mqttwarn` to either allow the notification to happen or not.
 - If an MQTT topic was not found in aforementioned JSON file, it will be added and set with a configurable default value.
 - For the user, an accompanying web script allows the toggle to be changed.
 
 Installation
 ============
 
-- Copy the `togglestate()` function from `mqttwarn/customfunctions.py` to your own custom functions file, or copy the entire file and refer to it in `mqttwarn.ini` with a  `functions = 'customfunctions.py'` directive.
+- Copy the ``togglestate()`` function from ``mqttwarn/customfunctions.py`` to your own custom functions file, or copy the entire file and refer to it in `mqttwarn.ini` with a  ``functions = 'customfunctions.py'`` directive.
 - Copy the content of the `www` folder to a web server on the same host as `mqttwarn`, ensure Python is enabled for the server.
-- Create a symbolic link from `/opt/mqttwarn/warntoggle.json` -> `/var/www/html/warntoggle.json`, obviously adjusted for your local situation. Alternatively, configure the filename inside the custom function where it now says `filename = "warntoggle.js"` to contain an absolute path.
-- For each stream you wish to be considered by `warntoggle`, add a line `filter = togglestate()` to `mqttwarn.ini`. This must be done inside each stream section. 
+- Create a symbolic link from ``/opt/mqttwarn/warntoggle.json`` -> ``/var/www/html/warntoggle.json`, obviously adjusted for your local situation. Alternatively, configure the filename inside the custom function where it now says ``filename = "warntoggle.js"`` to contain an absolute path.
+- For each stream you wish to be considered by ``warntoggle``, add a line ``filter = togglestate()`` to ``mqttwarn.ini``. This must be done inside each stream section.

--- a/examples/warntoggle/mqttwarn/customfunctions.py
+++ b/examples/warntoggle/mqttwarn/customfunctions.py
@@ -2,23 +2,23 @@ import time
 import copy
 import json
 
-def togglestate(topic, payload, section, srv): 
+def togglestate(topic, payload, section, srv):
     filename = "warntoggle.json"
     default_topicblock = False
 
     try:
-        with open(filename) as infile:    
+        with open(filename) as infile:
             toggles = json.load(infile)
             infile.close()
 
-        if topic in toggles: 
+        if topic in toggles:
             # file found, topic found
             topicblock = toggles[topic]
-	    srv.logging.debug('togglestate() was called from the ' + section + ' section and found ' + topic + ' in ' + filename)
+	        srv.logging.debug('togglestate() was called from the ' + section + ' section and found ' + topic + ' in ' + filename)
         else:
             # file found, adding new topic
             toggles[topic] = default_topicblock
-            with open(filename, 'w') as outfile: 
+            with open(filename, 'w') as outfile:
                 json.dump(toggles, outfile)
                 outfile.close()
 
@@ -27,9 +27,9 @@ def togglestate(topic, payload, section, srv):
 )
             srv.logging.debug('togglestate() added ' + topic + ' to ' + filename + ' with blocking set to ' + str(topicblock))
 
-    except Exception as e: 
+    except Exception as e:
         # file not found or other error
-        topicblock = default_topicblock 
+        topicblock = default_topicblock
         srv.logging.debug('togglestate() encountered an error: ' + str(e) )
 
     srv.logging.debug('togglestate() will return ' + str(topicblock))

--- a/examples/warntoggle/mqttwarn/customfunctions.py
+++ b/examples/warntoggle/mqttwarn/customfunctions.py
@@ -1,0 +1,36 @@
+import time
+import copy
+import json
+
+def togglestate(topic, payload, section, srv): 
+    filename = "warntoggle.json"
+    default_topicblock = False
+
+    try:
+        with open(filename) as infile:    
+            toggles = json.load(infile)
+            infile.close()
+
+        if topic in toggles: 
+            # file found, topic found
+            topicblock = toggles[topic]
+	    srv.logging.debug('togglestate() was called from the ' + section + ' section and found ' + topic + ' in ' + filename)
+        else:
+            # file found, adding new topic
+            toggles[topic] = default_topicblock
+            with open(filename, 'w') as outfile: 
+                json.dump(toggles, outfile)
+                outfile.close()
+
+            topicblock = default_topicblock
+            srv.logging.debug('togglestate() was called from the ' + section + ' section, did not find ' + topic + ' in ' + filename
+)
+            srv.logging.debug('togglestate() added ' + topic + ' to ' + filename + ' with blocking set to ' + str(topicblock))
+
+    except Exception as e: 
+        # file not found or other error
+        topicblock = default_topicblock 
+        srv.logging.debug('togglestate() encountered an error: ' + str(e) )
+
+    srv.logging.debug('togglestate() will return ' + str(topicblock))
+    return topicblock

--- a/examples/warntoggle/www/warntoggle.json
+++ b/examples/warntoggle/www/warntoggle.json
@@ -1,0 +1,5 @@
+{
+  "livingroom/temperature": true, 
+  "bedroom/temperature": true, 
+  "bedroom/lights": false
+}

--- a/examples/warntoggle/www/warntoggle.py
+++ b/examples/warntoggle/www/warntoggle.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python
+
+import json
+
+def index(req):
+
+    filename = "/var/www/html/warntoggle/warntoggle.json"
+    writetoggles = {}
+    readtoggles = {} 
+    scriptname = __file__.split('/')[-1:][0]
+
+    # write form data to the file if applicable
+
+    if bool(req.form): 
+
+        for k,v in req.form.items():
+            writetoggles[k] = eval(str(v))
+
+        with open(filename, 'w') as outfile: 
+            json.dump(writetoggles, outfile)
+            outfile.close()
+
+    # read data from the file
+
+    with open(filename, 'r') as infile:
+        readtoggles = json.load(infile)
+        infile.close()
+
+    # display the form
+
+    html  = "<html><body><h1>mqttwarn notification toggles</h1>"
+    html += "<table>"
+    html += "<form action=\"" + scriptname + "\" method=\"post\">"
+
+    for key in sorted(readtoggles.keys()):
+        if readtoggles[key] == True:
+            block_checked = " checked"
+            notify_checked = ""
+        else:
+            block_checked = ""
+            notify_checked = " checked"
+
+        html += "<tr><td>" + key + "</td><td><input type='radio' name='" + key + "' value='True'" + block_checked + ">Block <input type='radio' name='" + key + "' value='False'" + notify_checked+ ">Notify</td></tr>"
+
+    html += "</table><br/>"
+    html += "<nobr><input type='submit' value='Submit'> <a href='" + scriptname + "'>reload</a></nobr>"
+    html += "</form>"
+    html += "</body></html>"
+
+    return html 


### PR DESCRIPTION
Following up on https://github.com/jpmens/mqttwarn/issues/404, adding a custom function to be used when configuring streams in `mqttwarn`, `warntoggle` makes it easy to toggle notifications on or off through a simple web interface. 