### PR TITLE
Fix #410: Load functions file at configuration load

### DIFF
--- a/mqttwarn/configuration.py
+++ b/mqttwarn/configuration.py
@@ -13,6 +13,8 @@ try:
 except ImportError:
     HAVE_TLS = False
 
+from mqttwarn.util import load_functions
+
 logger = logging.getLogger(__name__)
 
 
@@ -80,6 +82,8 @@ class Config(RawConfigParser):
                 self.tls_version = ssl.PROTOCOL_SSLv3
 
         self.loglevelnumber = self.level2number(self.loglevel)
+        self.functions = load_functions(self.functions)
+
 
     def level2number(self, level):
 

--- a/mqttwarn/context.py
+++ b/mqttwarn/context.py
@@ -136,7 +136,7 @@ class FunctionInvoker(object):
 
         val = None
         try:
-            func = load_function(name=name, filepath=self.config.functions)
+            func = load_function(name=name, py_mod=self.config.functions)
             try:
                 val = func(topic, self.srv)  # new version
             except TypeError:
@@ -158,7 +158,7 @@ class FunctionInvoker(object):
 
         val = None
         try:
-            func = load_function(name=name, filepath=self.config.functions)
+            func = load_function(name=name, py_mod=self.config.functions)
             val = func(topic, data, self.srv)
         except:
             raise
@@ -179,7 +179,7 @@ class FunctionInvoker(object):
 
         val = None
         try:
-            func = load_function(name=name, filepath=self.config.functions)
+            func = load_function(name=name, py_mod=self.config.functions)
             val = func(topic=topic, data=data, srv=self.srv)
         except:
             raise
@@ -199,7 +199,7 @@ class FunctionInvoker(object):
 
         rc = False
         try:
-            func = load_function(name=name, filepath=self.config.functions)
+            func = load_function(name=name, py_mod=self.config.functions)
             try:
                 rc = func(topic, payload, section, self.srv)  # new version
             except TypeError:

--- a/mqttwarn/core.py
+++ b/mqttwarn/core.py
@@ -627,7 +627,7 @@ def start_workers():
     if cf.has_section('cron'):
         for name, val in cf.items('cron'):
             try:
-                func = load_function(name=name, filepath=cf.functions)
+                func = load_function(name=name, py_mod=cf.functions)
                 cron_options = parse_cron_options(val)
                 interval = cron_options['interval']
                 logger.debug('Scheduling function "{name}" as periodic task ' \

--- a/mqttwarn/util.py
+++ b/mqttwarn/util.py
@@ -143,7 +143,7 @@ def sanitize_function_name(s):
 
     if s is not None:
         try:
-            valid = re.match('^[\w]+\(\)', s)
+            valid = re.match(r'^[\w]+\(\)', s)
             if valid is not None:
                 func = re.sub('[()]', '', s)
         except:
@@ -164,11 +164,12 @@ def load_module(path):
             pass
 
 
-def load_function(name=None, filepath=None):
-    mod_inst = None
+def load_functions(filepath=None):
+    if not filepath:
+        return None
 
-    assert name, 'Function name must be given'
-    assert filepath, 'Path to file must be given'
+    if not os.path.isfile(filepath):
+        raise IOError("'{}' not found".format(filepath))
 
     mod_name, file_ext = os.path.splitext(os.path.split(filepath)[-1])
 
@@ -179,14 +180,21 @@ def load_function(name=None, filepath=None):
         py_mod = imp.load_compiled(mod_name, filepath)
 
     else:
-        raise RuntimeError("Loading Python code from '{}' failed".format(filepath))
+        raise ValueError("'{}' does not have the .py or .pyc extension".format(filepath))
 
-    if hasattr(py_mod, name):
-        mod_inst = getattr(py_mod, name)
-    else:
-        raise RuntimeError("Loading function '{}' from '{}' failed".format(name, filepath))
+    return py_mod
 
-    return mod_inst
+
+def load_function(name=None, py_mod=None):
+    assert name, 'Function name must be given'
+    assert py_mod, 'Python module must be given'
+
+    func = getattr(py_mod, name, None)
+
+    if func is None:
+        raise AttributeError("Function '{}' does not exist in '{}'".format(name, py_mod.__file__))
+
+    return func
 
 
 def get_resource_content(package, filename):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,3 +4,4 @@
 # Configuration- and function files used by the test harness
 configfile = 'tests/selftest.ini'
 funcfile = 'tests/selftest.py'
+bad_funcfile = 'tests/bad_funcs.py'

--- a/tests/bad_funcs.py
+++ b/tests/bad_funcs.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# (c) 2020 The mqttwarn developers
+
+def foobar():
+   foo # intentional indentation error
+    return True

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -6,8 +6,8 @@ from past.utils import old_div
 import time
 import pytest
 from mqttwarn.util import Struct, Formatter, asbool, parse_cron_options, timeout, sanitize_function_name, load_module, \
-    load_function, get_resource_content, exception_traceback
-from tests import funcfile
+    load_functions, load_function, get_resource_content, exception_traceback
+from tests import funcfile, configfile, bad_funcfile
 
 
 def test_struct():
@@ -89,21 +89,45 @@ def test_load_module():
     assert 'item' in module.plugin.__code__.co_varnames
 
 
+def test_load_functions():
+
+    # Load valid functions file
+    py_mod = load_functions(filepath=funcfile)
+    assert py_mod is not None
+
+    # No-op
+    py_mod = load_functions(filepath=None)
+    assert py_mod is None
+
+    # Load missing functions file
+    with pytest.raises(IOError) as excinfo:
+        load_functions(filepath='unknown.txt')
+    assert str(excinfo.value) == "'{}' not found".format('unknown.txt')
+
+    # Load functions file that is not a python file
+    with pytest.raises(ValueError) as excinfo:
+        load_functions(filepath=configfile)
+    assert str(excinfo.value) == "'{}' does not have the .py or .pyc extension".format(configfile)
+
+    # Load bad functions file
+    with pytest.raises(Exception):
+        load_functions(filepath=bad_funcfile)
+
+
 def test_load_function():
 
+    # Load valid functions file
+    py_mod = load_functions(filepath=funcfile)
+    assert py_mod is not None
+
     # Load valid function
-    func = load_function(name='foobar', filepath=funcfile)
+    func = load_function(name='foobar', py_mod=py_mod)
     assert func is not None
 
     # Load invalid function, function name does not exist in "funcfile"
-    with pytest.raises(RuntimeError) as excinfo:
-        load_function(name='unknown', filepath=funcfile)
-    assert str(excinfo.value) == "Loading function 'unknown' from '{}' failed".format(funcfile)
-
-    # Load invalid function, "funcfile" does not exist at all
-    with pytest.raises(RuntimeError) as excinfo:
-        load_function(name='unknown', filepath='unknown.txt')
-    assert str(excinfo.value) == "Loading Python code from 'unknown.txt' failed"
+    with pytest.raises(AttributeError) as excinfo:
+        load_function(name='unknown', py_mod=py_mod)
+    assert str(excinfo.value) == "Function 'unknown' does not exist in '{}'".format(funcfile)
 
 
 def test_get_resource_content():


### PR DESCRIPTION
This has several advantages over loading the file at every message:

1) More efficient.
2) A bad functions file fails fast, i.e. mqttwarn will fail to start rather than waiting until a message arrives to show the failure.
3) When an error in the functions file exists, mqttwarn will fail with the actual exception string causing the failure, which makes it considerably easier to find and fix the problem.
4) State: since the functions module is only loaded once, the user can now keep state between function calls by using module level variables.