### PR TITLE
Fix for mqttwarn.service

### DIFF
--- a/etc/mqttwarn.service
+++ b/etc/mqttwarn.service
@@ -63,8 +63,9 @@ LimitNOFILE=65536
 Environment='STDOUT=/var/log/mqttwarn/mqttwarn.log'
 Environment='STDERR=/var/log/mqttwarn/mqttwarn.log'
 EnvironmentFile=/etc/default/mqttwarn
+PassEnvironment=MQTTWARNINI
 WorkingDirectory=/opt/mqttwarn
-ExecStart=/opt/mqttwarn/bin/mqttwarn ${MQTTWARN_OPTIONS} >>${STDOUT} 2>>${STDERR}
+ExecStart=/bin/sh -c 'exec /opt/mqttwarn/bin/mqttwarn ${MQTTWARN_OPTIONS} >>${STDOUT} 2>>${STDERR}'
 KillMode=control-group
 Restart=on-failure
 


### PR DESCRIPTION
MQTTWARNINI is not present in the environment of the python process therefore mqttwarn doesn't find the configuration file.
`PassEnvironment` remedies that.
Also the variables are not expanded properly in the ExecStart.
If MQTTWARN_OPTIONS is an empty string it's passed as first argument to mqttwarn, resulting in the usage info being printed out.
I haven't checked but redirections shouldn't work in the ExecStart string.
Calling with an exec from sh -c remedies all that.
Tested on systemd 229 on Ubuntu 16.04.

PS I am not sure that the `--create-home` switch is needed in the `useradd` invocation of the commented guide.
