### PR TITLE
Fix inconsistent use of tabs and spaces

### DIFF
--- a/examples/warntoggle/mqttwarn/customfunctions.py
+++ b/examples/warntoggle/mqttwarn/customfunctions.py
@@ -14,7 +14,7 @@ def togglestate(topic, payload, section, srv):
         if topic in toggles:
             # file found, topic found
             topicblock = toggles[topic]
-	        srv.logging.debug('togglestate() was called from the ' + section + ' section and found ' + topic + ' in ' + filename)
+	    srv.logging.debug('togglestate() was called from the ' + section + ' section and found ' + topic + ' in ' + filename)
         else:
             # file found, adding new topic
             toggles[topic] = default_topicblock


### PR DESCRIPTION
I saw this while building:

*** Sorry: TabError: inconsistent use of tabs and spaces in indentation (customfunctions.py, line 17)