### PR TITLE
Fix Dockerfile to use mqttwarn pip module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM python:2.7
 
 # based on https://github.com/pfichtner/docker-mqttwarn
 
-# install python libraries (TODO: any others?)
-RUN pip install paho-mqtt requests jinja2
+# install mqttwarn
+RUN pip install mqttwarn
 
 # build /opt/mqttwarn
 RUN mkdir -p /opt/mqttwarn
@@ -22,10 +22,6 @@ VOLUME ["/opt/mqttwarn/conf"]
 # set conf path
 ENV MQTTWARNINI="/opt/mqttwarn/conf/mqttwarn.ini"
 
-# finally, copy the current code (ideally we'd copy only what we need, but it
-#  is not clear what that is, yet)
-COPY . /opt/mqttwarn
-
 # run process
-CMD python mqttwarn.py
+CMD mqttwarn
 


### PR DESCRIPTION
The current Dockerfile doesn't work anymore.

This PR fixes the Dockerfile so it:

- installs the mqttwarn pip module (which pulls in the dependencies)
- runs the installed module instead of mqttwarn.py
- doesn't copy the whole repo directory into /opt/mqttwarn

I must admit that I'm not a poweruser of mqttwarn, so I haven't tested all functionality, but my tests of this Docker image with the smtp and log services on a Raspberry Pi 4 worked.