### PR TITLE
Add Docker Compose file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:3.8.2-slim-buster
 
 # based on https://github.com/pfichtner/docker-mqttwarn
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,22 +5,22 @@ FROM python:2.7
 # install mqttwarn
 RUN pip install mqttwarn
 
-# build /opt/mqttwarn
-RUN mkdir -p /opt/mqttwarn
-WORKDIR /opt/mqttwarn
+# create /etc/mqttwarn
+RUN mkdir -p /etc/mqttwarn
+WORKDIR /etc/mqttwarn
 
 # add user mqttwarn to image
 RUN groupadd -r mqttwarn && useradd -r -g mqttwarn mqttwarn
-RUN chown -R mqttwarn /opt/mqttwarn
+RUN chown -R mqttwarn:mqttwarn /etc/mqttwarn
 
 # process run as mqttwarn user
 USER mqttwarn
 
 # conf file from host
-VOLUME ["/opt/mqttwarn/conf"]
+VOLUME ["/etc/mqttwarn"]
 
 # set conf path
-ENV MQTTWARNINI="/opt/mqttwarn/conf/mqttwarn.ini"
+ENV MQTTWARNINI="/etc/mqttwarn/mqttwarn.ini"
 
 # run process
 CMD mqttwarn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.7'
+
+services:
+  mqttwarn:
+    image: jpmens/mqttwarn 
+    container_name: mqttwarn
+    restart: always
+    volumes:
+      - /path/to/mqttwarn:/etc/mqttwarn # Location for mqttwarn.ini and funcs.py
+      - /etc/localtime:/etc/localtime:ro
+    # If you want to change the default location of mqttwarn.ini, uncomment the following lines:
+    #environment:
+    #  - MQTTWARNINI=/etc/mqttwarn/mqttwarn.ini

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,26 @@
 version: '3.7'
 
 services:
+# To use this Docker Compose file for mqttwarn:
+#
+# 1. Acquire "docker-compose.yml":
+# wget https://raw.githubusercontent.com/jpmens/mqttwarn/master/docker-compose.yml
+#
+# 2. Create a directory for mqttwarn to store "mqttwarn.ini" and "funcs.py" in:
+# mkdir /path/to/mqttwarn
+#
+# 3. Acquire "mqttwarn.ini":
+# wget https://raw.githubusercontent.com/jpmens/mqttwarn/master/mqttwarn/examples/basic/mqttwarn.ini -O /path/to/mqtwarn/mqttwarn.ini
+#
+# 4. Define the location to the custom functions file within "mqttwarn.ini":
+#
+# functions = 'funcs.py'
   mqttwarn:
     image: jpmens/mqttwarn 
     container_name: mqttwarn
     restart: always
     volumes:
-      - /path/to/mqttwarn:/etc/mqttwarn # Location for mqttwarn.ini and funcs.py
+      - /path/to/mqttwarn:/etc/mqttwarn
       - /etc/localtime:/etc/localtime:ro
     # If you want to change the default location of mqttwarn.ini, uncomment the following lines:
     #environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,3 @@
-version: '3.7'
-
-services:
 # To use this Docker Compose file for mqttwarn:
 #
 # 1. Acquire "docker-compose.yml":
@@ -15,8 +12,11 @@ services:
 # 4. Define the location to the custom functions file within "mqttwarn.ini":
 #
 # functions = 'funcs.py'
+version: '3.7'
+
+services:
   mqttwarn:
-    image: jpmens/mqttwarn 
+    image: jpmens/mqttwarn
     container_name: mqttwarn
     restart: always
     volumes:


### PR DESCRIPTION
This PR:
- adds a Docker Compose file that (together with the updated Dockerfile) uses `/etc/mqttwarn` instead of `/opt/mqttwarn`.
- adds comments to the Docker Compose file to document how to use it.
- updates the Dockerfile base image to `python:3.8.2-slim-buster`.

Tested on a Raspberry Pi 4 with smtp and log services and custom functions.

See https://github.com/jpmens/mqttwarn/issues/341#issuecomment-623661119