### PR TITLE
Add missing text encode in pipe module

### DIFF
--- a/mqttwarn/services/pipe.py
+++ b/mqttwarn/services/pipe.py
@@ -29,7 +29,7 @@ def plugin(srv, item):
         return False
 
     try:
-        proc.stdin.write(text)
+        proc.stdin.write(text.encode('utf-8'))
     except IOError as e:
         srv.logging.warn("Cannot write to pipe: errno %d" % (e.errno))
         return False


### PR DESCRIPTION
Another case of a missing text encode, that otherwise triggers an error:
`Cannot write to pipe: a bytes-like object is required, not 'str'`