### PR TITLE
Fix removal of as_user option within Slack plugin

### DIFF
--- a/mqttwarn/services/slack.py
+++ b/mqttwarn/services/slack.py
@@ -33,7 +33,7 @@ def plugin(srv, item):
     # check if we have the optional as_user token (extract and remove if so)
     if isinstance(addrs[-1], (bool)):
         as_user = addrs[-1]
-        local_addrs = addrs[:len(addrs) - 1]
+        addrs = addrs[:len(addrs) - 1]
 
     # check for target level tokens (which have preference)
     try:


### PR DESCRIPTION
When the optional parameter "as_user" is present, the Slack module attempts to remove it, in accordance with comments. It however fails to do so, as the shortened parameter list is assigned to a new/local variable, which is never used, instead of overwriting the original, as presumably intended.

This leads to failed logic later, when the number of parameters do not match expectations, which in turn leads to failed auth with Slack.