### PR TITLE
Add b prefix for compatibility with Python3. Backwards compatible to …

### DIFF
--- a/mqttwarn/vendor/ZabbixSender.py
+++ b/mqttwarn/vendor/ZabbixSender.py
@@ -20,7 +20,7 @@ except ImportError:
 
 class ZabbixSender:
     
-    zbx_header = 'ZBXD'
+    zbx_header = b'ZBXD'
     zbx_version = 1
     zbx_sender_data = {u'request': u'sender data', u'data': []}
     send_data = ''


### PR DESCRIPTION
…2.6+