### PR TITLE
Load plugin service from any Python package

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ mqttwarn changelog
 
 in progress
 ===========
+- Use ``allow_dirty = False`` within ``.bumpversion.cfg``
 - Use Python3 to create virtualenv
+- Bump version numbers for release tools packages
 
 
 2020-08-31 0.17.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,9 +5,10 @@ mqttwarn changelog
 
 in progress
 ===========
+- Use Python3 to create virtualenv
 
 
-2020-08-31 0.16.3
+2020-08-31 0.17.0
 =================
 - srv.mqttc is None when calling into a custom function. Thanks, Ben.
 - sundry changes for FreeBSD package. Thanks, Dan.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,12 +8,14 @@ in progress
 - Use ``allow_dirty = False`` within ``.bumpversion.cfg``
 - Use Python3 to create virtualenv
 - Bump version numbers for release tools packages
+- Add external plugin module loading. Thanks, @psyciknz!
 
 
 2020-08-31 0.17.0
 =================
 - srv.mqttc is None when calling into a custom function. Thanks, Ben.
 - sundry changes for FreeBSD package. Thanks, Dan.
+- Fix ``ZabbixSender.py``. Thanks, Ben!
 - service tweaks: nsca, zabbix
 
 2020-06-06 0.16.2

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -154,7 +154,10 @@ I've written an introductory post, explaining [what mqttwarn can be used for](ht
   
   ###### `launch`
   
-  In the `launch` option you specify which _services_ (of those available in the `services/` directory of _mqttwarn_ or using the `module` option, see the following paragraphs) you want to be able to use in target definitions.
+  In the `launch` option you specify a list of comma-separated _service_ names  
+  defined within the `[config:xxx]` sections which should be launched.
+  
+  You should launch every service you want to use from your topic/target definitions here.
   
   #### The `[config:xxx]` sections
   
@@ -162,9 +165,16 @@ I've written an introductory post, explaining [what mqttwarn can be used for](ht
   has a mandatory option called `targets`, which is a dictionary of target names, each
   pointing to an array of "addresses". Address formats depend on the particular service.
   
-  A service section may have an option called `module`, which refers to the name
-  of the actual service module to use. A service called `filetruncate` - and
-  referenced as such in the `launch` option -
+  The Python module name for this service will be derived
+  a) from the name of the definition itself, i.e. the `xxx` part, or
+  b) from the value of the `module` option within that configuration section.
+  
+  - When the module name is a plain string, it will be resolved as a filename inside the  
+    built-in `mqttwarn/services` directory.
+  - When the module name contains a dot, it will be resolved as an absolute dotted reference.
+  
+  Example:
+  A service called `filetruncate` - and referenced as such in the `launch` option -
   may have `module = file`, in which case the service works like a regular `file`
   service, with its own distinct set of service options. It is thus possible to
   have several different service configurations for the same underlying service,

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ $(eval sphinx       := $(venvpath)/bin/sphinx-build)
 
 # Setup Python virtualenv
 setup-virtualenv:
-	@test -e $(python) || `command -v virtualenv` --python=`command -v python` --no-site-packages $(venvpath)
+	@test -e $(python) || `command -v virtualenv` --python=`command -v python3` --no-site-packages $(venvpath)
 
 
 # -------

--- a/mqttwarn/core.py
+++ b/mqttwarn/core.py
@@ -23,7 +23,7 @@ import paho.mqtt.client as paho
 from mqttwarn.context import RuntimeContext, FunctionInvoker
 from mqttwarn.cron import PeriodicThread
 from mqttwarn.util import \
-    load_function, load_module, timeout, \
+    load_function, load_module_from_file, load_module_by_name, timeout, \
     parse_cron_options, sanitize_function_name, Struct, Formatter, asbool, exception_traceback
 
 try:
@@ -500,7 +500,10 @@ def processor(worker_id=None):
             try:
                 # Fire the plugin in a separate thread and kill it if it doesn't return in 10s
                 module = service_plugins[service]['module']
-                service_logger_name = 'mqttwarn.services.{}'.format(service)
+                if '.' in service:
+                    service_logger_name = service
+                else:
+                    service_logger_name = 'mqttwarn.services.{}'.format(service)
                 srv = make_service(mqttc=mqttc, name=service_logger_name)
                 notified = timeout(module.plugin, (srv, st))
             except Exception as e:
@@ -528,13 +531,21 @@ def load_services(services):
         service_plugins[service]['config'] = service_config
 
         module = cf.g('config:' + service, 'module', service)
-        modulefile = resource_filename('mqttwarn.services', module + '.py')
 
-        try:
-            service_plugins[service]['module'] = load_module(modulefile)
-            logger.info('Successfully loaded service "{}"'.format(service))
-        except Exception as ex:
-            logger.exception('Unable to load service "{}" from file "{}": {}'.format(service, modulefile, ex))
+        if '.' in module:
+            try:
+                service_plugins[service]['module'] = load_module_by_name(module)
+                logger.info('Successfully loaded service "{}" from module "{}"'.format(service, module))
+            except Exception as ex:
+                logger.exception('Unable to load service "{}" from module "{}": {}'.format(service, module, ex))
+
+        else:
+            modulefile = resource_filename('mqttwarn.services', module + '.py')
+            try:
+                service_plugins[service]['module'] = load_module_from_file(modulefile)
+                logger.info('Successfully loaded service "{}"'.format(service))
+            except Exception as ex:
+                logger.exception('Unable to load service "{}" from file "{}": {}'.format(service, modulefile, ex))
 
 
 def connect():
@@ -700,7 +711,10 @@ def run_plugin(config=None, name=None, data=None):
 
     # Load designated service plugins
     load_services([name])
-    service_logger_name = 'mqttwarn.services.{}'.format(name)
+    if '.' in name:
+        service_logger_name = name
+    else:
+        service_logger_name = 'mqttwarn.services.{}'.format(name)
     srv = make_service(mqttc=None, name=service_logger_name)
 
     # Build a mimikry item instance for feeding to the service plugin

--- a/mqttwarn/util.py
+++ b/mqttwarn/util.py
@@ -151,8 +151,13 @@ def sanitize_function_name(s):
     return func
 
 
-# http://code.davidjanes.com/blog/2008/11/27/how-to-dynamically-load-python-code/
-def load_module(path):
+def load_module_from_file(path):
+    """
+    http://code.davidjanes.com/blog/2008/11/27/how-to-dynamically-load-python-code/
+
+    :param path:
+    :return:
+    """
     try:
         fp = open(path, 'rb')
         digest = md(path.encode('utf-8')).hexdigest()
@@ -162,6 +167,42 @@ def load_module(path):
             fp.close()
         except:
             pass
+
+
+def load_module_by_name(name):
+    """
+    https://pymotw.com/2/imp/#loading-modules
+
+    :param name:
+    :return:
+    """
+    module = import_module(name)
+    return module
+
+
+def import_module(name, path=None):
+    """
+    Derived from `import_from_dotted_path`:
+    https://chase-seibert.github.io/blog/2014/04/23/python-imp-examples.html
+
+    import_from_dotted_path('foo.bar') -> from foo import bar; return bar
+    """
+
+    try:
+        next_module, remaining_names = name.split('.', 1)
+    except ValueError:
+        next_module = name
+        remaining_names = None
+
+    fp, pathname, description = imp.find_module(next_module, path)
+    module = imp.load_module(next_module, fp, pathname, description)
+
+    if remaining_names is None:
+        return module
+    if hasattr(module, remaining_names):
+        return getattr(module, remaining_names)
+
+    return import_module(remaining_names, path=module.__path__)
 
 
 def load_functions(filepath=None):

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,3 +1,3 @@
-bumpversion==0.5.3
-twine==1.11.0
-keyring==12.0.1
+bump2version==1.0.0
+twine==3.2.0
+keyring==21.4.0

--- a/tests/acme/foobar.py
+++ b/tests/acme/foobar.py
@@ -1,0 +1,3 @@
+def plugin(srv, item):
+    srv.logging.debug("*** MODULE=%s: service=%s, target=%s", __file__, item.service, item.target)
+    srv.logging.info('Plugin invoked.')

--- a/tests/selftest.ini
+++ b/tests/selftest.ini
@@ -55,7 +55,7 @@ loglevel  = DEBUG
 functions = 'tests/selftest.py'
 
 ; name the service providers you will be using.
-launch    = log, file
+launch    = log, file, tests.acme.foobar
 
 [config:log]
 targets = {
@@ -71,6 +71,11 @@ append_newline = True
 targets = {
     'test-1'   : ['/tmp/mqttwarn-test.01'],
     'test-2'   : ['/tmp/mqttwarn-test.02'],
+  }
+
+[config:tests.acme.foobar]
+targets = {
+    'default'  : [ 'default' ],
   }
 
 
@@ -97,6 +102,11 @@ format = {name}: {value}
 ; echo '{"item": "Räuber Hotzenplotz", "value": 42.42}' | mosquitto_pub -h localhost -t test/file-2 -l
 targets = file:test-2
 format = {item}
+
+[test/plugin-1]
+; echo '{"name": "temperature", "value": 42.42}' | mosquitto_pub -h localhost -t test/plugin-1 -l
+targets = tests.acme.foobar:default
+format = {name}: {value}
 
 [test/datamap]
 targets = log:info

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -167,6 +167,23 @@ def test_message_file_unicode():
         assert u'Räuber Hotzenplotz' in content, content
 
 
+def test_plugin_module(caplog):
+    """
+    Check if using a module with dotted name also works.
+    """
+
+    with caplog.at_level(logging.DEBUG):
+
+        # Bootstrap the core machinery without MQTT
+        core_bootstrap(configfile=configfile)
+
+        # Signal mocked MQTT message to the core machinery for processing
+        send_message(topic='test/plugin-1', payload='{"name": "temperature", "value": 42.42}')
+
+        # Proof that the message has been routed to the "log" plugin properly
+        assert 'Plugin invoked' in caplog.text, caplog.text
+
+
 def test_xform_func(caplog):
     """
     Submit a message to the "log" plugin and proof

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -6,7 +6,8 @@ from builtins import str
 from past.utils import old_div
 import time
 import pytest
-from mqttwarn.util import Struct, Formatter, asbool, parse_cron_options, timeout, sanitize_function_name, load_module, \
+from mqttwarn.util import Struct, Formatter, asbool, parse_cron_options, timeout, sanitize_function_name, \
+    load_module_from_file, load_module_by_name, \
     load_functions, load_function, get_resource_content, exception_traceback
 from tests import funcfile, configfile, bad_funcfile
 
@@ -82,12 +83,32 @@ def test_sanitize_function_name():
     assert sanitize_function_name(None) is None
 
 
-def test_load_module():
-    module = load_module('mqttwarn/services/file.py')
+def test_load_module_from_file_good():
+    module = load_module_from_file('mqttwarn/services/file.py')
     assert 'plugin' in dir(module)
     assert module.plugin.__code__.co_argcount == 2
     assert 'srv' in module.plugin.__code__.co_varnames
     assert 'item' in module.plugin.__code__.co_varnames
+
+
+def test_load_module_from_file_bad():
+    with pytest.raises(IOError) as excinfo:
+        load_module_from_file('mqttwarn/services/unknown.py')
+        assert str(excinfo.value) == "IOError: [Errno 2] No such file or directory: 'mqttwarn/services/unknown.py'"
+
+
+def test_load_module_by_name_good():
+    module = load_module_by_name('mqttwarn.services.file')
+    assert 'plugin' in dir(module)
+    assert module.plugin.__code__.co_argcount == 2
+    assert 'srv' in module.plugin.__code__.co_varnames
+    assert 'item' in module.plugin.__code__.co_varnames
+
+
+def test_load_module_by_name_bad():
+    with pytest.raises(ImportError) as excinfo:
+        load_module_by_name('mqttwarn.services.unknown')
+        assert str(excinfo.value) == "ImportError: No module named unknown"
 
 
 def test_load_functions():

--- a/tests/util.py
+++ b/tests/util.py
@@ -30,7 +30,8 @@ def send_message(topic=None, payload=None):
 
     # Mock an instance of an Eclipse Paho MQTTMessage
     message = MQTTMessage(mid=42, topic=topic.encode('utf-8'))
-    message.payload = payload.encode('utf-8')
+    if payload is not None:
+        message.payload = payload.encode('utf-8')
 
     # Signal the message to the machinery
     on_message(None, None, message)


### PR DESCRIPTION
Hi there,

service plugins can now be loaded from arbitrary Python packages with dotted string notation like `foo.bar.baz.qux`. This actually might implement the same thing originally intended by @psyciknz through #375.

Contrary to @psyciknz' implementation around the idea regarding
> The user can also specify a local directory and local services to launch.

this implementation doesn't mess with additional/optional directories with the need for specific code at all but instead builds upon native mechanisms from Python itself to let the user load service plugins from arbitrary Python packages. In this way, it is way more convenient for users to bundle their services within different/custom Python packages and deploy them alongside mqttwarn.

While I've retained the current code path for loading modules from within `mqttwarn.services` for now, this code can well be replaced by the new mechanics some time in the future, thus providing both kinds of module loading using the very same routines. The test `test_load_module_by_name_good` loading the built-in module `mqttwarn.services.file` using dotted string notation already reflects that.

With kind regards,
Andreas.

cc @rgitzel 
