### PR TITLE
Fix Apprise service for Python 3.5

### DIFF
--- a/mqttwarn/services/apprise.py
+++ b/mqttwarn/services/apprise.py
@@ -31,7 +31,7 @@ def plugin(srv, item):
         to = ','.join(addresses)
 
         # Create an Apprise instance.
-        apobj = apprise.Apprise()
+        apobj = apprise.Apprise(asset=apprise.AppriseAsset(async_mode=False))
 
         # Add notification services by server url.
         uri = '{baseuri}?from={sender}&to={to}'.format(baseuri=baseuri, sender=sender, to=to)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ extras = {
         'apns>=2.0.1',
     ],
     'apprise': [
-        'apprise>=0.8.5',
+        'apprise>=0.8.9',
     ],
     'asterisk': [
         'pyst2>=0.5.0',


### PR DESCRIPTION
## Problem
@clach04 reported problems when using the Apprise service with Python 3.5.3 within #456. The error is
```
ERROR    [mqttwarn.services.apprise-telegram] Error sending message to n/a: There is no current event loop in thread 'Thread-2'.
```

## Solution
Apprise 0.8.8 recently added Python asyncio integration in order to send notifications asynchronously, see https://github.com/caronc/apprise/pull/273.

By explicitly turning to legacy/synchronous mode using `AppriseAsset(async_mode=False)`, the error goes away.
