### PR TITLE
Replace xmpppy by slixmpp

### DIFF
--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -2689,7 +2689,7 @@ recipients get the message.
 
 Requires:
 * XMPP (Jabber) accounts (at least one for the sender and one for the recipient)
-* [xmpppy](http://xmpppy.sourceforge.net)
+* [slixmpp](https://lab.louiz.org/poezio/slixmpp)
 
 ### `xively`
 

--- a/setup.py
+++ b/setup.py
@@ -102,8 +102,7 @@ extras = {
         'xively-python',
     ],
     'xmpp': [
-        'xmpppy>=0.6.1',
-        'dnspython>=1.16.0',
+        'slixmpp>=1.5.2',
     ],
     'test': [
         'pytest>=4.6.7',


### PR DESCRIPTION
Updated the xmpp plugin to use the slixmpp library instead of xmpppy.
xmpppy is not compatible with recent Python version and was preventing the plugin from working on my computer.

This will work as a drop-in replacement and will reuse the same configuration keys.

**Added dependency:** slixmpp https://lab.louiz.org/poezio/slixmpp
**Removed dependency:** xmpppy