### PR TITLE
Add XMPP service using slixmpp

### DIFF
--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -361,6 +361,7 @@ _mqttwarn_ supports a number of services (listed alphabetically below):
 * [websocket](#websocket)
 * [xbmc](#xbmc)
 * [xmpp](#xmpp)
+* [slixmpp](#slixmpp)
 * [xively](#xively)
 * [zabbix](#zabbix)
 
@@ -2690,6 +2691,27 @@ recipients get the message.
 Requires:
 * XMPP (Jabber) accounts (at least one for the sender and one for the recipient)
 * [xmpppy](http://xmpppy.sourceforge.net)
+
+### `slixmpp`
+
+The `slixmpp` service sends notification to one or more [XMPP](http://en.wikipedia.org/wiki/XMPP)
+(Jabber) recipients.
+
+```ini
+[config:slixmpp]
+sender = 'mqttwarn@jabber.server'
+password = 'Password for sender'
+targets = {
+    'admin' : [ 'admin1@jabber.server', 'admin2@jabber.server' ]
+    }
+```
+
+Targets may contain more than one recipient, in which case all specified
+recipients get the message.
+
+Requires:
+* XMPP (Jabber) accounts (at least one for the sender and one for the recipient)
+* [slixmpp](https://lab.louiz.org/poezio/slixmpp)
 
 ### `xively`
 

--- a/mqttwarn/services/slixmpp.py
+++ b/mqttwarn/services/slixmpp.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Based on xmpp plugin
+__originalauthor__ = 'Fabian Affolter <fabian()affolter-engineering.ch>'
+__author__         = 'Remi Vincent <remi.vincent()gmail.com>'
+__copyright__      = 'Copyright 2020 Remi Vincent'
+__license__        = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
+
+import slixmpp
+import asyncio
+
+class send_msg_bot(slixmpp.ClientXMPP):
+    def __init__(self, sender, password, recipient, message, loop):
+        self.loop = loop
+        asyncio.set_event_loop(loop)
+        slixmpp.ClientXMPP.__init__(self, sender, password)
+        self.recipient = recipient
+        self.message = message
+        self.add_event_handler("session_start", self.start)
+
+    async def start(self, event):
+        self.send_message(mto = self.recipient, mbody = self.message, mtype = 'chat')
+        self.disconnect()
+
+def plugin(srv, item):
+    """Send a message to XMPP recipient(s)."""
+
+    srv.logging.debug("*** MODULE=%s: service=%s, target=%s", __file__, item.service, item.target)
+
+    xmpp_addresses = item.addrs
+    sender = item.config['sender']
+    password = item.config['password']
+    text = item.message
+
+    if not xmpp_addresses:
+        srv.logging.warn("Skipped sending XMPP notification to %s, "
+                         "no addresses configured" % (item.target))
+        return False
+
+    try:
+        srv.logging.debug("Sending XMPP notification to %s, addresses: %s" % (item.target, xmpp_addresses))
+        loop = asyncio.new_event_loop()
+        for target in xmpp_addresses:
+            xmpp = send_msg_bot(sender, password, target, text, loop)
+            xmpp.connect()
+            xmpp.process(forever=False)
+        srv.logging.debug("Successfully sent message")
+    except Exception as e:
+        srv.logging.error("Error sending message to %s: %s" % (item.target, e))
+        return False
+
+    return True

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,9 @@ extras = {
         'xmpppy>=0.6.1',
         'dnspython>=1.16.0',
     ],
+    'slixmpp': [
+        'slixmpp>=1.5.2',
+    ],
     'test': [
         'pytest>=4.6.7',
         'pytest-cov>=2.8.1',


### PR DESCRIPTION
Dear team,

As seen in PR #467 this is a separate service using the slixmpp library to push XMPP notifications.

This is a separate plugin so mqttwarn doesn't depend on python 3.5 or higher.

Thanks,
Rémi