### PR TITLE
fix the docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,21 @@
 FROM python:3.8.2-slim-buster
 
-# based on https://github.com/pfichtner/docker-mqttwarn
+#install dir
+RUN mkdir -p /app
 
-# install mqttwarn
-RUN pip install mqttwarn
-
-# create /etc/mqttwarn
-RUN mkdir -p /etc/mqttwarn
+# run dir
+RUN mkdir -p /etc/mqttwarn/
 WORKDIR /etc/mqttwarn
-
-# add user mqttwarn to image
-RUN groupadd -r mqttwarn && useradd -r -g mqttwarn mqttwarn
-RUN chown -R mqttwarn:mqttwarn /etc/mqttwarn
-
-# process run as mqttwarn user
-USER mqttwarn
 
 # conf file from host
 VOLUME ["/etc/mqttwarn"]
 
 # set conf path
 ENV MQTTWARNINI="/etc/mqttwarn/mqttwarn.ini"
+
+# copy and install requirements
+COPY . /app
+RUN cd /app && python setup.py develop
 
 # run process
 CMD mqttwarn


### PR DESCRIPTION
As I tried to resolve a http plugin issue, I tried to modify/debug my container, and I found out some really strange things.

#### Documentation
The documentation refers the /opt dir while in #423 it modified to /etc (I reverted back to /opt)

#### Dockerhub vs versions
If you check the digests on [dockerhub](https://hub.docker.com/r/jpmens/mqttwarn/tags?page=1&ordering=last_updated) it is the same in the latest, 0.20.0, 0.19.0, ... 0.16.0 versions. Also if you `docker run -it --rm jpmens/mqttwarn:0.20.0 mqttwarn --version` you will get back 0.16.0

#### Dockerfile
In general I think it is a really bad idea to just pip install the tool... This should be something like in this PR.
The contents of the dockerfile should build from the source. Not from a pip install...

I think the 0.16.0 bug comes from the fact that docker caches image layers, so when sb pushed 0.16.0 he/she did run the docker build, got the layers cached, and bcs there was no copy command, next time the docker build found no changes, and happily published 0.20.0 as the same image as the 0.16.0 was.

#### Concerns about this PR
I have close to zero idea about the python world, so this setup.py call could be as bad as the pip install was before (but at least for different reasons). BUT this PR unlocks the option in dockerhub to maintain a develop/master tag with the dockerhub autobuild from master trigger thingy.