### PR TITLE
Replace slacker with slack-sdk

### DIFF
--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -2291,8 +2291,7 @@ joined the channel.
 
 ![Slack](assets/slack.png)
 
-This plugin requires [Python slacker](https://github.com/os/slacker).
-For image support (added November 2018), slacker 0.10.0 is required.
+This plugin requires [Python slack-sdk](https://github.com/slackapi/python-slack-sdk).
 
 The slack service will accept a payload with either a simple text message, or a json payload which contains
 a `message` and either an `imageurl` or `imagebase64` encoded image.

--- a/mqttwarn.py
+++ b/mqttwarn.py
@@ -1,0 +1,8 @@
+#!/opt/mqttwarn/bin/python
+# -*- coding: utf-8 -*-
+import re
+import sys
+from mqttwarn.commands import run
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
+    sys.exit(run())

--- a/mqttwarn/core.py
+++ b/mqttwarn/core.py
@@ -204,7 +204,7 @@ def on_message(mosq, userdata, msg):
 
     topic = msg.topic
     payload = msg.payload.decode('utf-8')
-    logger.debug("Message received on %s: %s" % (topic, payload))
+    logger.debug("Message received on %s: %s" % (topic, payload[0:250])) # truncate long payloads
 
     if msg.retain == 1:
         if cf.skipretained:

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ extras = {
         'pyserial>=3.4',
     ],
     'slack': [
-        'slacker>=0.9.65',
+        'slack-sdk>=3.1.0',
     ],
     'ssh': [
         'paramiko>=2.4.1',


### PR DESCRIPTION
[slacker](https://github.com/os/slacker) project is archived, replace with official [slack-sdk](https://github.com/slackapi/python-slack-sdk)

- Remove write to disk hack for uploading images
- Remove deprecated `as_user` method