### PR TITLE
Replace slacker with slack-sdk

### DIFF
--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -2291,8 +2291,7 @@ joined the channel.
 
 ![Slack](assets/slack.png)
 
-This plugin requires [Python slacker](https://github.com/os/slacker).
-For image support (added November 2018), slacker 0.10.0 is required.
+This plugin requires [Python slack-sdk](https://github.com/slackapi/python-slack-sdk).
 
 The slack service will accept a payload with either a simple text message, or a json payload which contains
 a `message` and either an `imageurl` or `imagebase64` encoded image.

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ extras = {
         'pyserial>=3.4',
     ],
     'slack': [
-        'slacker>=0.9.65',
+        'slack-sdk>=3.1.0',
     ],
     'ssh': [
         'paramiko>=2.4.1',


### PR DESCRIPTION
[slacker](https://github.com/os/slacker) project is archived, replace with official [slack-sdk](https://github.com/slackapi/python-slack-sdk)

- Remove write to disk hack for uploading images
- Remove deprecated `as_user` method

Resolves #476 