### PR TITLE
new service `mqtt_filter` and add mqttwarn.openrc script

### DIFF
--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -321,6 +321,7 @@ _mqttwarn_ supports a number of services (listed alphabetically below):
 * [ionic](#ionic)
 * [azure_iot](#azure_iot)
 * [irccat](#irccat)
+* [launch](#launch)
 * [linuxnotify](#linuxnotify)
 * [log](#log)
 * mastodon (see [tootpaste](#tootpaste))
@@ -1284,6 +1285,30 @@ targets = {
 
 Requires:
 * gobject-introspection Python bindings
+
+### `launch`
+
+The `launch` target excutes the specified program and its arguments. It is similar
+to `pipe` but it doesn't open a pipe to the program. It provides stdout as response
+to configured queue.
+Example use cases are f.e. IoT buttons which publish a message when they are pushed
+and the excute an external program. It is also a clone of [mqtt-launcher](https://github.com/jpmens/mqtt-launcher).
+
+```ini
+[config:launch]
+targets = {
+              # full_topic, topic[0], topic[1], args[0], .....
+   'touch'    : [ None,0,0,'touch', '/tmp/executed' ],
+   'fritzctl' : [ None,0,0,'/usr/bin/fritzctl', 'temperature', "{args[0]}", "{args[1]}" ]
+   'backup'   : ["response/{topic[1]}/{topic[2]}",0,0,'/usr/bin/sudo','/usr/sbin/dirvish','--vault', "{args[0]}" ],
+   }
+```
+
+To pass the published data (json args array) to the command, use `{args[0]}` and `{args[1]}` which then gets replaced. Message looks like `'{ "args" : ["' + temp + '","' + room + '"] }'` for `fritzctl`.
+outgoing_topic is constructed by parts of incoming topic or as full_incoming topic.
+
+Note, that for each message targeted to the `launch` service, a new process is
+spawned (fork/exec), so it is quite "expensive".
 
 ### `log`
 

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -1429,8 +1429,8 @@ section must exist.)
 The `mqtt_filter` target executes the specified program and its arguments. It is similar
 to `pipe` but it doesn't open a pipe to the program. It provides stdout as response
 to a configured queue.
-Example use cases are f.e. IoT buttons which publish a message when they are pushed
-and the execute an external program. It is also a clone of [mqtt-launcher](https://github.com/jpmens/mqtt-launcher).
+Example use cases are e.g. IoT buttons which publish a message when they are pushed
+and they execute an external program. It is also a clone of [mqtt-launcher](https://github.com/jpmens/mqtt-launcher).
 With no response configured it acts like `execute` with multiple arguments.
 
 To pass the published data (json args array) to the command, use `{args[0]}` and `{args[1]}` which then gets replaced. Message looks like `'{ "args" : ["' + temp + '","' + room + '"] }'` for `fr
@@ -1442,8 +1442,11 @@ outgoing_topic is constructed by parts of incoming topic or as full_incoming top
 [config:mqtt_filter]
 targets = {
    # full_topic, topic[0], topic[1], args[0], .....
+   # touch file /tmp/executed
    'touch'    : [ None,0,0,'touch', '/tmp/executed' ],
+   # uses firtzctl to set temperature of a room
    'fritzctl' : [ None,0,0,'/usr/bin/fritzctl','--loglevel=ERROR','temperature', "{args[0]}", "{args[1]}" ]
+   # performs a dirvish backup and writes stdout as a new messages to response topic
    'backup'   : ["response/{topic[1]}/{topic[2]}",0,0,'/usr/bin/sudo','/usr/sbin/dirvish','--vault', "{args[0]}" ],
    }
 ```

--- a/etc/mqttwarn.openrc
+++ b/etc/mqttwarn.openrc
@@ -1,0 +1,14 @@
+#!/sbin/openrc-run
+
+command="/usr/bin/python /opt/mqttwarn/mqttwarn.py"
+command_args="${MQTTWARN_OPTIONS}"
+command_background=yes
+pidfile=/run/mqttwarn.pid
+directory=/opt/mqttwarn
+
+name="mqttwarn"
+description="mqttwarn pluggable mqtt notification service"
+
+depend() {
+  need net
+}

--- a/mqttwarn/services/launch.py
+++ b/mqttwarn/services/launch.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+__author__    = 'Tobias Brunner <tobias()tobru.ch>'
+__copyright__ = 'Copyright 2016 Tobias Brunner / 2021 Joerg Gollnick'
+__license__   = """Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)"""
+
+import subprocess
+import json
+from pipes import quote
+from six import string_types
+
+def plugin(srv, item):
+
+    srv.logging.debug("*** MODULE=%s: service=%s, target=%s", __file__, item.service, item.target)
+
+    # same as for ssh - extract args from json item.message
+    args=json.loads(item.message)["args"]
+
+    if type(args) is list and len(args) == 1:
+        args=args[0]
+
+    if type(args) is list:
+        args=tuple([ quote(v) for v  in args ]) #escape the shell args
+    elif type(args) is str or type(args) is unicode:
+        args=(quote(args),)
+
+    topic=list(map( lambda x: quote(x), item.topic.split('/') ))
+    outgoing_topic = item.addrs[0].format(full_topic=quote(item.topic),topic=topic)
+    qos            = item.addrs[1]
+    retain         = item.addrs[2]
+    addrs          = item.addrs[3:]
+    # replace args[0], args[1] ...
+    cmd = [i.format(args=args) for i in addrs]
+    srv.logging.debug("*** MODULE=%s: service=%s, command=%s outgoing_topic=%s", __file__, item.service, str( cmd ),outgoing_topic)
+
+    try:
+        res = subprocess.check_output(cmd, stdin=None, stderr=subprocess.STDOUT, shell=False, universal_newlines=True, cwd='/tmp')
+    except Exception as e:
+        srv.logging.warning("Cannot execute %s because %s" % (cmd, e))
+        return False
+
+    if outgoing_topic is not None:
+        outgoing_payload = res.rstrip('\n')
+        if isinstance(outgoing_payload, string_types):
+            outgoing_payload = bytearray(outgoing_payload, encoding='utf-8')
+        try:
+            srv.mqttc.publish(outgoing_topic, outgoing_payload, qos=qos, retain=retain)
+        except Exception as e:
+            srv.logging.warning("Cannot PUBlish response %s: %s" % (outgoing_topic, e))
+            return False
+
+    return True

--- a/mqttwarn/services/mqtt_filter.py
+++ b/mqttwarn/services/mqtt_filter.py
@@ -28,13 +28,17 @@ def plugin(srv, item):
     # parse topic
     topic=list(map( lambda x: quote(x), item.topic.split('/') ))
 
+    outgoing_topic = None
     # replace palceholders args[0], args[1] ..., full_topic, topic[0],
-    outgoing_topic = item.addrs[0].format(args=args,full_topic=quote(item.topic),topic=topic)
+    if item.addrs[0] is not None:
+        outgoing_topic = item.addrs[0].format(args=args,full_topic=quote(item.topic),topic=topic)
     qos            = item.addrs[1]
     retain         = item.addrs[2]
     addrs          = item.addrs[3:]
 
-    cmd = [i.format(args=args, full_topic=quote(item.topic),topic=topic) for i in addrs]
+    cmd = None
+    if addrs is not None:
+        cmd = [i.format(args=args, full_topic=quote(item.topic),topic=topic) for i in addrs]
 
     srv.logging.debug("*** MODULE=%s: service=%s, command=%s outgoing_topic=%s", __file__, item.service, str( cmd ),outgoing_topic)
 

--- a/mqttwarn/services/mqtt_filter.py
+++ b/mqttwarn/services/mqtt_filter.py
@@ -15,15 +15,19 @@ def plugin(srv, item):
     srv.logging.debug("*** MODULE=%s: service=%s, target=%s", __file__, item.service, item.target)
 
     # same as for ssh
-    args=json.loads(item.message)["args"]
+    json_message=json.loads(item.message)
 
-    if type(args) is list and len(args) == 1:
-        args=args[0]
+    args = None
+    if json_message is not None:
+        args = json_message["args"]
 
-    if type(args) is list:
-        args=tuple([ quote(v) for v  in args ]) #escape the shell args
-    elif type(args) is str or type(args) is unicode:
-        args=(quote(args),)
+        if type(args) is list and len(args) == 1:
+            args=args[0]
+
+        if type(args) is list:
+            args=tuple([ quote(v) for v  in args ]) #escape the shell args
+        elif type(args) is str or type(args) is unicode:
+            args=(quote(args),)
 
     # parse topic
     topic=list(map( lambda x: quote(x), item.topic.split('/') ))

--- a/mqttwarn/services/mqtt_filter.py
+++ b/mqttwarn/services/mqtt_filter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__author__    = 'Tobias Brunner <tobias()tobru.ch>'
+__author__    = 'Joerg Gollnick <github+mqttwarn()wurzelbenutzer.de>'
 __copyright__ = 'Copyright 2016 Tobias Brunner / 2021 Joerg Gollnick'
 __license__   = """Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)"""
 
@@ -14,7 +14,7 @@ def plugin(srv, item):
 
     srv.logging.debug("*** MODULE=%s: service=%s, target=%s", __file__, item.service, item.target)
 
-    # same as for ssh - extract args from json item.message
+    # same as for ssh
     args=json.loads(item.message)["args"]
 
     if type(args) is list and len(args) == 1:
@@ -25,13 +25,17 @@ def plugin(srv, item):
     elif type(args) is str or type(args) is unicode:
         args=(quote(args),)
 
+    # parse topic
     topic=list(map( lambda x: quote(x), item.topic.split('/') ))
-    outgoing_topic = item.addrs[0].format(full_topic=quote(item.topic),topic=topic)
+
+    # replace palceholders args[0], args[1] ..., full_topic, topic[0],
+    outgoing_topic = item.addrs[0].format(args=args,full_topic=quote(item.topic),topic=topic)
     qos            = item.addrs[1]
     retain         = item.addrs[2]
     addrs          = item.addrs[3:]
-    # replace args[0], args[1] ...
-    cmd = [i.format(args=args) for i in addrs]
+
+    cmd = [i.format(args=args, full_topic=quote(item.topic),topic=topic) for i in addrs]
+
     srv.logging.debug("*** MODULE=%s: service=%s, command=%s outgoing_topic=%s", __file__, item.service, str( cmd ),outgoing_topic)
 
     try:


### PR DESCRIPTION
This new service emulates mqtt-launcher:
- Run a command with several arguments provides as json string
- Sends back stdout, if configured
-  command arguments are read from json list and put into args[0]
- outgoing topic can be use all parts of topic topic[0]/topic[1]/topic[2] or full_topic 