### PR TITLE
Update changelog and prepare next release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,9 +6,24 @@ mqttwarn changelog
 in progress
 ===========
 
+
+2021-06-02 0.21.0
+=================
+- [xmpp] Add slixmpp plugin and documentation. Thanks, Remi!
+- [mysql] Fix unicode vs byte issue for Python 3. Thanks, Filip!
+- [http] Fix to send whole message. Thanks, Gergo!
+- [slack] Replace ``slacker`` with ``slack-sdk``. Thanks, mcdamo!
+- [mysql] Fix specified port bug. Thanks, Hyman!
+- [launch] Add new service ``launch``. Flexible arguments for command,
+  responds with MQTT publish. Thanks, Jörg!
+- [core] Remove "os.chdir" as it is apparently not needed anymore. Thanks, Dan!
+- [ci] Run tests on Python 3.9, remove testing on Python 3.5
+
+
 2020-10-20 0.20.0
 =================
 - [telegram] Fix encoding of data for python3. Thanks, Ben!
+
 
 2020-10-11 0.19.0
 =================


### PR DESCRIPTION
This patch retroactively updates the changelog and is meant to prepare the next release of `mqttwarn`. Thank you everyone who has contributed to this release!