### PR TITLE
Respect relative path names within configuration file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,13 @@ mqttwarn changelog
 in progress
 ===========
 
+
+2021-06-03 0.22.0
+=================
+
 - [build] Fix unwanted cache hits when automatically building Docker images. Thanks, Gergő!
+- [core] Respect relative path names within configuration file. This applies
+  to both the function file as well as module files.
 
 
 2021-06-03 0.21.0
@@ -20,7 +26,7 @@ in progress
   responds with MQTT publish. Thanks, Jörg!
 - [core] Remove "os.chdir" as it is apparently not needed anymore. Thanks, Dan!
 - [ci] Run tests on Python 3.9, remove testing on Python 3.5
-- [core] Load service plugins from both modules and files
+- [core] Load service plugins from both modules and files.
 
 
 2020-10-20 0.20.0

--- a/mqttwarn/configuration.py
+++ b/mqttwarn/configuration.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (c) 2014-2019 The mqttwarn developers
+# (c) 2014-2021 The mqttwarn developers
 import os
 import sys
 import ast
@@ -34,6 +34,8 @@ class Config(RawConfigParser):
         f = codecs.open(configuration_file, 'r', encoding='utf-8')
         self.read_file(f)
         f.close()
+
+        self.configuration_path = os.path.dirname(configuration_file)
 
         ''' set defaults '''
         self.hostname     = 'localhost'
@@ -81,7 +83,20 @@ class Config(RawConfigParser):
                 self.tls_version = ssl.PROTOCOL_SSLv3
 
         self.loglevelnumber = self.level2number(self.loglevel)
-        self.functions = load_functions(self.functions)
+
+        # Load function file as given (backward-compatibility).
+        if os.path.isfile(self.functions):
+            functions_file = self.functions
+
+        # Load function file as given if path is absolute.
+        elif os.path.isabs(self.functions):
+            functions_file = self.functions
+
+        # Load function file relative to path of configuration file if path is relative.
+        else:
+            functions_file = os.path.join(self.configuration_path, self.functions)
+
+        self.functions = load_functions(functions_file)
 
 
     def level2number(self, level):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,5 +3,6 @@
 
 # Configuration- and function files used by the test harness
 configfile = 'tests/selftest.ini'
+configfile_v2 = 'tests/selftest_v2.ini'
 funcfile = 'tests/selftest.py'
 bad_funcfile = 'tests/bad_funcs.py'

--- a/tests/selftest_v2.ini
+++ b/tests/selftest_v2.ini
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# (c) 2014-2021 The mqttwarn developers
+#
+# mqttwarn configuration file for testing function and module loading with relative paths.
+#
+
+; ------------------------------------------
+;             Base configuration
+; ------------------------------------------
+
+[defaults]
+
+
+; --------
+; Services
+; --------
+
+; path to file containing self-defined functions for formatmap and datamap
+; generate with "mqttwarn make-samplefuncs"
+functions = 'selftest.py'
+
+; name the service providers you will be using.
+launch    = tests.acme.foobar, acme/foobar.py
+
+
+[config:tests.acme.foobar]
+targets = {
+    'default'  : [ 'default' ],
+  }
+
+[config:acme/foobar.py]
+targets = {
+    'default'  : [ 'default' ],
+  }
+
+
+; -------
+; Targets
+; -------
+
+[test/plugin-module]
+; echo '{"name": "temperature", "value": 42.42}' | mosquitto_pub -h localhost -t test/plugin-module -l
+targets = tests.acme.foobar:default
+format = {name}: {value}
+
+[test/plugin-file]
+; echo '{"name": "temperature", "value": 42.42}' | mosquitto_pub -h localhost -t test/plugin-file -l
+targets = acme/foobar.py:default
+format = {name}: {value}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,8 +7,10 @@ import json
 from builtins import str
 import logging
 
+import pytest
+
 from mqttwarn.core import make_service, decode_payload
-from tests import configfile
+from tests import configfile, configfile_v2
 from tests.util import core_bootstrap, send_message
 
 
@@ -167,9 +169,10 @@ def test_message_file_unicode():
         assert u'Räuber Hotzenplotz' in content, content
 
 
-def test_plugin_module(caplog):
+@pytest.mark.parametrize("configfile", [configfile, configfile_v2])
+def test_plugin_module(caplog, configfile):
     """
-    Check if using a module with dotted name also works.
+    Check if loading a service module with dotted name works.
     """
 
     with caplog.at_level(logging.DEBUG):
@@ -184,9 +187,10 @@ def test_plugin_module(caplog):
         assert 'Plugin invoked' in caplog.text, caplog.text
 
 
-def test_plugin_file(caplog):
+@pytest.mark.parametrize("configfile", [configfile, configfile_v2])
+def test_plugin_file(caplog, configfile):
     """
-    Check if using a module with dotted name also works.
+    Check if loading a service module from a file works.
     """
 
     with caplog.at_level(logging.DEBUG):


### PR DESCRIPTION
Hi there,

after removing a call to `os.chdir()` with #490, I tried to dive in a bit and came up with an idea to _support loading auxiliary files with **relative** paths_. When doing so, they should be treated to use the directory of the `.ini` configuration file as the base directory. This applies to both the function file as well as external service module files.

The feature was implemented in a backward-compatible manner in order not to break existing configurations. Both scenarios are supported by respective tests multiplexing the current ones.

With kind regards,
Andreas.

/cc @psyciknz, @tg44 
