### PR TITLE
Rename "http.py" module to reduce conflicts with stdlib

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,14 @@ in progress
 ===========
 
 
+2021-06-03 0.23.0
+=================
+
+- [http] Rename ``http.py`` module to ``http_urllib.py`` to reduce conflicts with stdlib.
+  For backward compatibility reasons, it is still available by the same name, so no
+  configurations will break.
+
+
 2021-06-03 0.22.0
 =================
 

--- a/mqttwarn/core.py
+++ b/mqttwarn/core.py
@@ -552,8 +552,13 @@ def load_services(services):
 
         # Load built-in service module.
         else:
+            # Backward-compatibility patch for honoring the renaming of the `http.py` module.
+            if module == "http":
+                module = "http_urllib"
+            logger.debug('Trying to load built-in service "{}" from "{}"'.format(service, module))
             modulefile_candidates = [ resource_filename('mqttwarn.services', module + '.py') ]
 
+        success = False
         for modulefile in modulefile_candidates:
             if not os.path.isfile(modulefile):
                 continue
@@ -561,8 +566,13 @@ def load_services(services):
             try:
                 service_plugins[service]['module'] = load_module_from_file(modulefile)
                 logger.info('Successfully loaded service "{}"'.format(service))
+                success = True
             except Exception as ex:
                 logger.exception('Unable to load service "{}" from file "{}": {}'.format(service, modulefile, ex))
+
+        if not success:
+            logger.critical('Unable to load service "{}"'.format(service))
+            sys.exit(1)
 
 
 def connect():

--- a/mqttwarn/services/http_urllib.py
+++ b/mqttwarn/services/http_urllib.py
@@ -59,7 +59,7 @@ def plugin(srv, item):
                 try:
                     params[key] = params[key].format(**item.data).encode('utf-8')
                 except Exception as e:
-                    srv.logging.debug("Parameter %s cannot be formatted: %s" % (key, e))
+                    srv.logging.exception("Parameter %s cannot be formatted" % key)
                     return False
 
     message  = item.message
@@ -82,6 +82,7 @@ def plugin(srv, item):
 
             resp = urllib.request.urlopen(request, timeout=timeout)
             data = resp.read()
+            #srv.logging.debug("HTTP response:\n%s" % data)
         except Exception as e:
             srv.logging.warn("Cannot GET %s: %s" % (resource, e))
             return False
@@ -112,7 +113,7 @@ def plugin(srv, item):
             srv.logging.debug("before send")
             resp = urllib.request.urlopen(request, timeout=timeout)
             data = resp.read()
-            # print "POST returns ", data
+            #srv.logging.debug("HTTP response:\n%s" % data)
         except Exception as e:
             srv.logging.warn("Cannot POST %s: %s" % (url, e))
             return False


### PR DESCRIPTION
Hi there,

this patch renames the `http.py` module to `http_urllib.py` in order to reduce conflicts with stdlib. It will resolve #436.
For backward compatibility reasons, the module is still known by the same name `"http"`, so no configurations will break.

With kind regards,
Andreas.