### PR TITLE
Add example Dockerfile outlining how to add additional Python modules

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -131,3 +131,18 @@ The name `mqttwarn-local` is not meaningful, other than making it obvious when
 you run it that you are using your own personal image. You can use any name you
 like, but avoid `mqttwarn` otherwise it's easily confused with the official
 images.
+
+
+## Installing additional Python packages into Docker image
+
+In order to use `mqttwarn` with additional Python modules not included in the
+baseline image, you will need to build custom Docker images based on the
+canonical `jpmens/mqttwarn`.
+
+We prepared an example which outlines how this would work with the Slack SDK.
+By using the `Dockerfile.mqttwarn-slack`, this command will build a Docker
+image called `mqttwarn-slack`, which includes the Slack SDK:
+
+```shell
+docker build --tag=mqttwarn-slack --file=Dockerfile.mqttwarn-slack .
+```

--- a/Dockerfile.mqttwarn-slack
+++ b/Dockerfile.mqttwarn-slack
@@ -1,0 +1,19 @@
+# Docker build file for mqttwarn, with Slack SDK.
+# Based on https://hub.docker.com/r/jpmens/mqttwarn.
+#
+# Invoke like:
+#
+#   docker build --tag=mqttwarn-slack --file=Dockerfile.mqttwarn-slack .
+#
+
+# Derive from upstream image.
+FROM jpmens/mqttwarn:0.23.0
+
+# Make package installation run as "root" user
+USER root
+
+# Install Slack SDK.
+RUN pip install mqttwarn[slack]
+
+# Make process run as "mqttwarn" user
+USER mqttwarn


### PR DESCRIPTION
Hi there,

this patch adds a `Dockerfile.mqttwarn-slack` file, based on the discussion started by @psyciknz at #503, so it will
install the Python Slack SDK into a custom Docker image called `mqttwarn-slack`.

With kind regards,
Andreas.
