### PR TITLE
Start using GitHub Actions (GHA) for some CI tasks

### DIFF
--- a/.github/workflows/release-docker-full.yml
+++ b/.github/workflows/release-docker-full.yml
@@ -2,7 +2,7 @@
 #
 # Derived from:
 # https://github.com/crate/cratedb-prometheus-adapter/blob/main/.github/workflows/release.yml
-name: Release Docker Standard
+name: Release Docker Full
 
 on:
   schedule:
@@ -15,7 +15,7 @@ on:
     branches: [ master ]
 
 env:
-  GHCR_IMAGE_NAME: jpmens/mqttwarn-standard
+  GHCR_IMAGE_NAME: jpmens/mqttwarn-full
 
 jobs:
   docker:
@@ -77,7 +77,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: Dockerfile
+          file: Dockerfile.full
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-docker-standard.yml
+++ b/.github/workflows/release-docker-standard.yml
@@ -1,0 +1,91 @@
+# Stage Docker images through GitHub Actions (GHA) to GitHub Container Registry (GHCR).
+#
+# Derived from:
+# https://github.com/crate/cratedb-prometheus-adapter/blob/main/.github/workflows/release.yml
+name: Release
+
+on:
+  schedule:
+    - cron: '0 10 * * *' # everyday at 10am
+  push:
+    tags:
+      - '*.*.*'
+  workflow_dispatch:
+  pull_request:
+    branches: [ master ]
+
+env:
+  GHCR_IMAGE_NAME: jpmens/mqttwarn-standard
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # List of Docker images to use as base name for tags
+          images: |
+            ghcr.io/${{ env.GHCR_IMAGE_NAME }}
+          # Generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule,pattern=nightly
+            type=ref,event=tag
+      -
+        name: Inspect meta
+        run: |
+          echo "Tags:      ${{ steps.meta.outputs.tags }}"
+          echo "Labels:    ${{ steps.meta.outputs.labels }}"
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        if: matrix.platforms != 'linux/amd64'
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      -
+        name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+      -
+        name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      -
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,67 @@
+name: Tests
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]  # macos-latest, windows-latest
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        include:
+        - os: ubuntu-latest
+          path: ~/.cache/pip
+        #- os: macos-latest
+        #  path: ~/Library/Caches/pip
+        #- os: windows-latest
+        #  path: ~\AppData\Local\pip\Cache
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
+
+    defaults:
+      run:
+        shell: bash
+
+    name: Python ${{ matrix.python-version }} on OS ${{ matrix.os }}
+    steps:
+
+    - name: Acquire sources
+      uses: actions/checkout@v2
+
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
+
+    - uses: actions/cache@v2
+      with:
+        path: ${{ matrix.path }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
+        restore-keys: |
+         ${{ runner.os }}-pip-
+
+    - name: Run tests
+      run: |
+        pip install .[test]
+        pytest tests
+
+    - name: Generate coverage report
+      if: matrix.python-version == '3.9'
+      run: |
+        pytest --cov=mqttwarn tests
+        coverage xml
+
+    - name: Upload coverage to Codecov
+      if: matrix.python-version == '3.9'
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        env_vars: OS,PYTHON
+        name: codecov-umbrella
+        fail_ci_if_error: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,15 +9,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]  # macos-latest, windows-latest
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.6", "3.7", "3.8", "3.9"]
         include:
         - os: ubuntu-latest
           path: ~/.cache/pip
-        #- os: macos-latest
-        #  path: ~/Library/Caches/pip
-        #- os: windows-latest
-        #  path: ~\AppData\Local\pip\Cache
+        - os: macos-latest
+          path: ~/Library/Caches/pip
+        - os: windows-latest
+          path: ~\AppData\Local\pip\Cache
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
@@ -57,7 +57,7 @@ jobs:
         coverage xml
 
     - name: Upload coverage to Codecov
-      if: matrix.python-version == '3.9'
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
       uses: codecov/codecov-action@v1
       with:
         file: ./coverage.xml

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@ in progress
 ===========
 
 
+2021-06-08 0.23.1
+=================
+
+- [ci] Run software tests and Docker image building on GitHub Actions (GHA)
+- [ci] Publish Docker images to GitHub Container Registry (GHCR)
+
 2021-06-03 0.23.0
 =================
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -7,6 +7,26 @@ You need to install only the Docker executable.
 You can run the image as a service, i.e. in the background, or you can 
 run it interactively, perhaps to help diagnose a problem.
 
+Docker images are automatically published to:
+
+- https://hub.docker.com/r/jpmens/mqttwarn
+- https://github.com/orgs/jpmens/packages/container/package/mqttwarn-standard
+- https://github.com/orgs/jpmens/packages/container/package/mqttwarn-full
+
+## Choosing the Docker image
+
+Choose one of those Docker images.
+```shell
+# The standard image on Docker Hub.
+export IMAGE=jpmens/mqttwarn
+
+# The standard image on GHCR.
+export IMAGE=ghcr.io/earthobservations/mqttwarn-standard:latest
+
+# The full image on GHCR.
+export IMAGE=ghcr.io/earthobservations/mqttwarn-full:latest
+```
+
 ## Interactively
 
 In order to verify `mqttwarn` works appropriately with the current
@@ -17,8 +37,8 @@ the necessary steps needed to create a configuration and run it.
 
 Within an empty folder, create a baseline `mqttwarn.ini` file:
 ```shell
-docker run -it --rm --volume=$PWD:/etc/mqttwarn jpmens/mqttwarn mqttwarn make-config > mqttwarn.ini
-docker run -it --rm --volume=$PWD:/etc/mqttwarn jpmens/mqttwarn mqttwarn make-samplefuncs > samplefuncs.py
+docker run -it --rm --volume=$PWD:/etc/mqttwarn $IMAGE mqttwarn make-config > mqttwarn.ini
+docker run -it --rm --volume=$PWD:/etc/mqttwarn $IMAGE mqttwarn make-samplefuncs > samplefuncs.py
 ```
 
 Then, assuming your MQTT broker runs on `localhost`, amend the `mqttwarn.ini` like:
@@ -28,14 +48,14 @@ hostname     = 'host.docker.internal'
 
 Now, invoke `mqttwarn`:
 ```shell
-docker run -it --rm --volume=$PWD:/etc/mqttwarn jpmens/mqttwarn
+docker run -it --rm --volume=$PWD:/etc/mqttwarn $IMAGE
 ```
 
 `Ctrl-C` will stop it. You can start and stop it as often as you like, here,
 probably editing the `.ini` file as you go.
 
 Note that you can run a local copy of the image, if you've built one (see below),
-by replacing `jpmens/mqttwarn` with `mqttwarn-local` in the following examples.
+by replacing `$IMAGE` with `mqttwarn-local` in the following examples.
 
 
 ## As a service
@@ -45,7 +65,7 @@ This is the typical way of running `mqttwarn`.
 From the folder containing your `mqttwarn.ini` file, run `mqttwarn` in the
 background:
 ```shell
-docker run --name=mqttwarn --detach --rm --volume=$PWD:/etc/mqttwarn jpmens/mqttwarn
+docker run --name=mqttwarn --detach --rm --volume=$PWD:/etc/mqttwarn $IMAGE
 ```
 
 Follow the log:
@@ -109,7 +129,7 @@ Then add this argument to `docker run`:
 ### A full example
 
 ```shell
-docker run -it --rm --volume=$PWD:/etc/mqttwarn --link=mosquitto jpmens/mqttwarn
+docker run -it --rm --volume=$PWD:/etc/mqttwarn --link=mosquitto $IMAGE
 ```
 
 

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -1,0 +1,36 @@
+# Docker build file for mqttwarn.
+# Based on https://github.com/pfichtner/docker-mqttwarn.
+#
+# Invoke like:
+#
+#   docker build --tag=mqttwarn-local-full --file=Dockerfile.full .
+#
+FROM python:3.9-slim-buster
+
+# Install additional requirements
+# FIXME: Skip all packages needing compilation
+#RUN apt-get update && apt-get install --yes librrd-dev
+
+# Create /etc/mqttwarn
+RUN mkdir -p /etc/mqttwarn
+WORKDIR /etc/mqttwarn
+
+# Add user "mqttwarn"
+RUN groupadd -r mqttwarn && useradd -r -g mqttwarn mqttwarn
+RUN chown -R mqttwarn:mqttwarn /etc/mqttwarn
+
+# Install mqttwarn
+COPY . /src
+RUN pip install /src[all]
+
+# Make process run as "mqttwarn" user
+USER mqttwarn
+
+# Use configuration file from host
+VOLUME ["/etc/mqttwarn"]
+
+# Set default configuration path
+ENV MQTTWARNINI="/etc/mqttwarn/mqttwarn.ini"
+
+# Invoke program
+CMD mqttwarn

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,9 @@
+.. image:: https://github.com/jpmens/mqttwarn/workflows/Tests/badge.svg
+   :target: https://github.com/jpmens/mqttwarn/actions?workflow=Tests
+
+.. image:: https://codecov.io/gh/jpmens/mqttwarn/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/jpmens/mqttwarn
+
 .. image:: https://circleci.com/gh/jpmens/mqttwarn/tree/master.svg?style=svg
     :target: https://circleci.com/gh/jpmens/mqttwarn/tree/master
 

--- a/mqttwarn/services/file.py
+++ b/mqttwarn/services/file.py
@@ -6,6 +6,7 @@ __copyright__ = 'Copyright 2014 Jan-Piet Mens'
 __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
 import io
+import tempfile
 
 
 def plugin(srv, item):
@@ -21,6 +22,9 @@ def plugin(srv, item):
     # While it may contain more than one item (e.g. pushover)
     # the `file' service carries one only, i.e. a path name
     filename = item.addrs[0].format(**item.data)
+
+    # Interpolate some variables into filename.
+    filename = filename.replace("$TMPDIR", tempfile.gettempdir())
 
     srv.logging.info("Writing to file `%s'" % (filename))
 

--- a/setup.py
+++ b/setup.py
@@ -63,11 +63,13 @@ extras = {
         'Pastebin>=1.1.2',
     ],
     'postgres': [
-        'psycopg2>=2.7.4',
+        'psycopg2-binary>=2.7.4',
     ],
-    'prowl': [
-        'prowlpy>=0.52',
-    ],
+    # `prowlpy` is not on PyPI, let's migrate to `pyprowl`.
+    # https://github.com/jpmens/mqttwarn/issues/507
+    #'prowl': [
+    #    'prowlpy>=0.52',
+    #],
     'pushbullet': [
         'PushbulletPythonLibrary>=2.3',
     ],
@@ -107,12 +109,6 @@ extras = {
     ],
     'slixmpp': [
         'slixmpp>=1.5.2',
-    ],
-    'test': [
-        'pytest>=4.6.7',
-        'pytest-cov>=2.8.1',
-        'lovely.testlayers>=0.7.1',
-        'tox>=3.14.2',
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (c) 2014-2019 The mqttwarn developers
+# (c) 2014-2021 The mqttwarn developers
 import os
 from setuptools import setup, find_packages
 
@@ -115,6 +115,24 @@ extras = {
         'tox>=3.14.2',
     ],
 }
+
+# Convenience extra to install all dependencies
+extras_all = []
+for extra, packages in extras.items():
+    # FIXME: Skip all packages needing compilation.
+    # https://github.com/commx/python-rrdtool/issues/36
+    if extra in ["mysql", "rrdtool"]:
+        continue
+    for package in packages:
+        extras_all.append(package)
+extras["all"] = extras_all
+
+extras["test"] = [
+    'pytest>=4.6.7',
+    'pytest-cov>=2.8.1',
+    'lovely.testlayers>=0.7.1',
+    'tox>=3.14.2',
+]
 
 setup(name='mqttwarn',
       version='0.23.0',

--- a/tests/selftest.ini
+++ b/tests/selftest.ini
@@ -69,8 +69,8 @@ targets = {
 [config:file]
 append_newline = True
 targets = {
-    'test-1'   : ['/tmp/mqttwarn-test.01'],
-    'test-2'   : ['/tmp/mqttwarn-test.02'],
+    'test-1'   : ['$TMPDIR/mqttwarn-test.01'],
+    'test-2'   : ['$TMPDIR/mqttwarn-test.02'],
   }
 
 [config:tests.acme.foobar]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,6 +3,7 @@
 import io
 import os
 import json
+import tempfile
 
 from builtins import str
 import logging
@@ -124,7 +125,8 @@ def test_message_file():
         'value': 42.42,
     }
 
-    outputfile = '/tmp/mqttwarn-test.01'
+    tmpdir = tempfile.gettempdir()
+    outputfile = os.path.join(tmpdir, 'mqttwarn-test.01')
     if os.path.exists(outputfile):
         os.unlink(outputfile)
 
@@ -153,7 +155,8 @@ def test_message_file_unicode():
         'item': 'Räuber Hotzenplotz'
     }
 
-    outputfile = '/tmp/mqttwarn-test.02'
+    tmpdir = tempfile.gettempdir()
+    outputfile = os.path.join(tmpdir, 'mqttwarn-test.02')
     if os.path.exists(outputfile):
         os.unlink(outputfile)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -52,28 +52,24 @@ def test_parse_cron_options():
     assert parse_cron_options('60; now=true') == {'now': 'true', 'interval': 60.0}
 
 
-#@pytest.mark.slow
 def test_timeout():
 
-    duration = 0.1
-    below_duration = duration - old_div(duration, 2)
-    above_duration = duration + old_div(duration, 2)
-
     def func():
-        time.sleep(duration)
+        time.sleep(0.3)
         return 42
 
     def errfunc():
         raise ValueError('Something went wrong')
 
-    assert timeout(func, timeout_secs=below_duration) is False
-    assert timeout(func, timeout_secs=above_duration) == 42
+    assert timeout(func, timeout_secs=0.1) is False
+    assert timeout(func, timeout_secs=0.5) == 42
 
     # FIXME: Better catch and report the exception?
     # FIXME: Derive "timeout_secs" from "duration"
     with pytest.raises(ValueError) as excinfo:
-        timeout(errfunc, timeout_secs=0.3, default='foobar')
-        excinfo.message == 'Something went wrong'
+        timeout(errfunc, timeout_secs=0.1, default='foobar')
+
+    assert str(excinfo.value) == 'Something went wrong'
 
 
 def test_sanitize_function_name():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -55,7 +55,7 @@ def test_parse_cron_options():
 #@pytest.mark.slow
 def test_timeout():
 
-    duration = 0.005
+    duration = 0.1
     below_duration = duration - old_div(duration, 2)
     above_duration = duration + old_div(duration, 2)
 
@@ -72,7 +72,7 @@ def test_timeout():
     # FIXME: Better catch and report the exception?
     # FIXME: Derive "timeout_secs" from "duration"
     with pytest.raises(ValueError) as excinfo:
-        timeout(errfunc, timeout_secs=0.10, default='foobar')
+        timeout(errfunc, timeout_secs=0.3, default='foobar')
         excinfo.message == 'Something went wrong'
 
 


### PR DESCRIPTION
Hi there,

while I like CircleCI in general, this patch will start bringing more CI jobs to GHA. We are using it all over the place for maintaining [Wetterdienst](https://github.com/earthobservations/wetterdienst) and enjoy that very much (/cc @gutzbenj).

The improvements coming from this patch are:

- Run the test suite on GitHub Actions (GHA).
  We will start running the tests on Linux but will progressively add macOS and Windows right away.
- Use GHA to stage Docker images, published to the GitHub Container Registry (GHCR).
  Let's build two variants: `mqttwarn-standard` and `mqttwarn-full`, attaching to @rgitzel's work [1].

With kind regards,
Andreas.

[1] A `mqttwarn-full` Docker image will include _all_ needed dependencies for _all_ of mqttwarn's built-in service plugins, as discussed within #344 and #419 and implemented by @rgitzel at https://hub.docker.com/r/rgitzel/mqttwarn-full the other day.

/cc @tinuva, @rgitzel, @lenny1972, @koenvervloesem, @darksupremo, @psyciknz, @sumnerboy12 
