### PR TITLE
[prowl] Update service plugin to use "pyprowl" instead of "prowlpy"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ mqttwarn changelog
 in progress
 ===========
 
+- [prowl] Update service plugin to use "pyprowl" instead of "prowlpy"
 
 2021-06-08 0.23.1
 =================

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -2089,10 +2089,10 @@ targets = {
 ![Prowl](assets/prowl.jpg)
 
 Requires:
-* [prowlpy](https://github.com/jacobb/prowlpy). Setup:
+* [pyprowl](https://pypi.org/project/pyprowl/). Setup:
 
 ```
-pip install --upgrade 'https://github.com/jacobb/prowlpy/archive/master.tar.gz#egg=prowlpy'
+pip install pyprowl
 ```
 
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+# https://docs.codecov.io/docs/common-recipe-list
+# https://docs.codecov.io/docs/commit-status#patch-status
+
+coverage:
+  status:
+    project:
+      default:
+        #target: 85%    # the required coverage value
+        threshold: 3%  # the leniency in hitting the target

--- a/mqttwarn/services/prowl.py
+++ b/mqttwarn/services/prowl.py
@@ -2,10 +2,10 @@
 # -*- coding: utf-8 -*-
 
 __author__    = 'Jan-Piet Mens <jpmens()gmail.com>'
-__copyright__ = 'Copyright 2014 Jan-Piet Mens'
+__copyright__ = 'Copyright 2014-2021 Jan-Piet Mens'
 __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
-import prowlpy
+import pyprowl
 
 
 def plugin(srv, item):
@@ -17,18 +17,23 @@ def plugin(srv, item):
 
     title = item.get('title', srv.SCRIPTNAME)
     text = item.message
-    priority = item.get('priority', 0)
+    priority = int(item.get('priority', 0))
 
     try:
-        p = prowlpy.Prowl(apikey)
-        p.post(application=title,
-            event=application,
-            description=text,
-            priority=priority,
-            providerkey=None,
-            url=None)
+        p = pyprowl.Prowl(apikey)
+        p.verify_key()
+        srv.logging.info("Prowl API key successfully verified")
     except Exception as e:
-        srv.logging.warning("Cannot prowl: %s" % e)
+        srv.logging.error("Error verifying Prowl API key: {}".format(e))
+        return False
+
+    try:
+        p.notify(event=title, description=text,
+                 priority=priority, url=None,
+                 appName=application)
+        srv.logging.debug("Sending notification to Prowl succeeded")
+    except Exception as e:
+        srv.logging.warning("Sending notification to Prowl failed: %s" % e)
         return False
 
     return True

--- a/setup.py
+++ b/setup.py
@@ -65,11 +65,9 @@ extras = {
     'postgres': [
         'psycopg2-binary>=2.7.4',
     ],
-    # `prowlpy` is not on PyPI, let's migrate to `pyprowl`.
-    # https://github.com/jpmens/mqttwarn/issues/507
-    #'prowl': [
-    #    'prowlpy>=0.52',
-    #],
+    'prowl': [
+        'pyprowl>=3.0.1',
+    ],
     'pushbullet': [
         'PushbulletPythonLibrary>=2.3',
     ],
@@ -191,9 +189,6 @@ setup(name='mqttwarn',
       install_requires=requires,
       extras_require=extras,
       tests_require=extras['test'],
-      dependency_links=[
-          'https://github.com/jacobb/prowlpy/archive/master.tar.gz#egg=prowlpy'
-      ],
       entry_points={
           'console_scripts': [
               'mqttwarn = mqttwarn.commands:run',


### PR DESCRIPTION
Hi there,

this patch might resolve #507 by updating the Prowl service plugin to use the `pyprowl` package instead of `prowlpy`. This code is currently completely untested. Is anyone in the community able to verify this before or after the merge?

With kind regards,
Andreas.

/cc @jacobb, @martinjo, @MansM
