### PR TITLE
[config] Make "functions" setting in configuration file optional

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9"]
         include:
         - os: ubuntu-latest
           path: ~/.cache/pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ in progress
 ===========
 
 - [prowl] Update service plugin to use "pyprowl" instead of "prowlpy"
+- [core] Make "functions" setting in configuration file optional
 
 2021-06-08 0.23.1
 =================

--- a/mqttwarn/configuration.py
+++ b/mqttwarn/configuration.py
@@ -84,20 +84,23 @@ class Config(RawConfigParser):
 
         self.loglevelnumber = self.level2number(self.loglevel)
 
-        # Load function file as given (backward-compatibility).
-        if os.path.isfile(self.functions):
-            functions_file = self.functions
+        if self.functions is not None and self.functions.strip() != "":
 
-        # Load function file as given if path is absolute.
-        elif os.path.isabs(self.functions):
-            functions_file = self.functions
+            logger.info("Loading user-defined functions from %s" % self.functions)
 
-        # Load function file relative to path of configuration file if path is relative.
-        else:
-            functions_file = os.path.join(self.configuration_path, self.functions)
+            # Load function file as given (backward-compatibility).
+            if os.path.isfile(self.functions):
+                functions_file = self.functions
 
-        self.functions = load_functions(functions_file)
+            # Load function file as given if path is absolute.
+            elif os.path.isabs(self.functions):
+                functions_file = self.functions
 
+            # Load function file relative to path of configuration file if path is relative.
+            else:
+                functions_file = os.path.join(self.configuration_path, self.functions)
+
+            self.functions = load_functions(functions_file)
 
     def level2number(self, level):
 

--- a/mqttwarn/util.py
+++ b/mqttwarn/util.py
@@ -206,6 +206,7 @@ def import_module(name, path=None):
 
 
 def load_functions(filepath=None):
+
     if not filepath:
         return None
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,5 +4,8 @@
 # Configuration- and function files used by the test harness
 configfile = 'tests/selftest.ini'
 configfile_v2 = 'tests/selftest_v2.ini'
+configfile_no_functions = 'tests/etc/no-functions.ini'
+configfile_empty_functions = 'tests/etc/empty-functions.ini'
+configfile_bad_functions = 'tests/etc/bad-functions.ini'
 funcfile = 'tests/selftest.py'
 bad_funcfile = 'tests/bad_funcs.py'

--- a/tests/etc/bad-functions.ini
+++ b/tests/etc/bad-functions.ini
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# (c) 2014-2021 The mqttwarn developers
+#
+# mqttwarn configuration file for testing with invalid user defined functions.
+#
+
+; ------------------------------------------
+;             Base configuration
+; ------------------------------------------
+
+[defaults]
+
+
+; --------
+; Services
+; --------
+
+; This is an *invalid* `functions` setting.
+functions = 'UNKNOWN FILE REFERENCE'
+
+; name the service providers you will be using.
+launch    = log
+
+
+[config:log]
+targets = {
+    'debug'  : [ 'debug' ],
+    'info'   : [ 'info' ],
+    'warn'   : [ 'warn' ],
+    'crit'   : [ 'crit' ],
+    'error'  : [ 'error' ]
+  }
+
+
+
+; -------
+; Targets
+; -------
+
+[test/log-1]
+; echo '{"name": "temperature", "value": 42.42}' | mosquitto_pub -h localhost -t test/log-1 -l
+targets = log:info
+format = {name}: {value}

--- a/tests/etc/empty-functions.ini
+++ b/tests/etc/empty-functions.ini
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# (c) 2014-2021 The mqttwarn developers
+#
+# mqttwarn configuration file for testing with empty user defined functions.
+#
+
+; ------------------------------------------
+;             Base configuration
+; ------------------------------------------
+
+[defaults]
+
+
+; --------
+; Services
+; --------
+
+; This is an *empty* `functions` setting.
+functions =
+
+; name the service providers you will be using.
+launch    = log
+
+
+[config:log]
+targets = {
+    'debug'  : [ 'debug' ],
+    'info'   : [ 'info' ],
+    'warn'   : [ 'warn' ],
+    'crit'   : [ 'crit' ],
+    'error'  : [ 'error' ]
+  }
+
+
+
+; -------
+; Targets
+; -------
+
+[test/log-1]
+; echo '{"name": "temperature", "value": 42.42}' | mosquitto_pub -h localhost -t test/log-1 -l
+targets = log:info
+format = {name}: {value}

--- a/tests/etc/no-functions.ini
+++ b/tests/etc/no-functions.ini
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# (c) 2014-2021 The mqttwarn developers
+#
+# mqttwarn configuration file for testing without user defined functions.
+#
+
+; ------------------------------------------
+;             Base configuration
+; ------------------------------------------
+
+[defaults]
+
+
+; --------
+; Services
+; --------
+
+; This is *without* a `functions` setting.
+;functions = 'DO NOT SET'
+
+; name the service providers you will be using.
+launch    = log
+
+
+[config:log]
+targets = {
+    'debug'  : [ 'debug' ],
+    'info'   : [ 'info' ],
+    'warn'   : [ 'warn' ],
+    'crit'   : [ 'crit' ],
+    'error'  : [ 'error' ]
+  }
+
+
+
+; -------
+; Targets
+; -------
+
+[test/log-1]
+; echo '{"name": "temperature", "value": 42.42}' | mosquitto_pub -h localhost -t test/log-1 -l
+targets = log:info
+format = {name}: {value}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -272,7 +272,7 @@ def test_config_bad_functions(caplog):
     with caplog.at_level(logging.DEBUG):
 
         # Bootstrapping the machinery with invalid path to functions file should croak.
-        with pytest.raises(OSError) as excinfo:
+        with pytest.raises(IOError) as excinfo:
             core_bootstrap(configfile=configfile_bad_functions)
 
         error_message = str(excinfo.value)


### PR DESCRIPTION
Hi there,

this patch essentially makes the `functions` setting in `mttwarn.ini` completely optional. In turn, it will slightly improve mqttwarn's behavior on respective configuration files. Apparently, as reported by @aerrow5 at #510, this might actually have been a regression introduced with one of the recent commits.

With kind regards,
Andreas.

Resolve #510.