### PR TITLE
CI: Phase out CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,0 @@
-version: 2
-jobs:
-  build:
-    docker:
-      - image: mikicz/tox-base
-    steps:
-      - checkout
-      - run: tox

--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,6 @@
 .. image:: https://codecov.io/gh/jpmens/mqttwarn/branch/main/graph/badge.svg
    :target: https://codecov.io/gh/jpmens/mqttwarn
 
-.. image:: https://circleci.com/gh/jpmens/mqttwarn/tree/main.svg?style=svg
-    :target: https://circleci.com/gh/jpmens/mqttwarn/tree/main
-
 .. image:: https://img.shields.io/pypi/pyversions/mqttwarn.svg
     :target: https://pypi.org/project/mqttwarn/
 


### PR DESCRIPTION
Hi there,

recently, we added a comprehensive CI configuration using GitHub Actions (GHA). As it works reasonably, let's stop wasting additional resources by running the test suite twice.

Additionally, one of us would have to press the "Stop Building" button on [1], right?

With kind regards,
Andreas.

[1] https://app.circleci.com/settings/project/github/jpmens/mqttwarn