### PR TITLE
Begin adding software tests for service plugins

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
         include:
         - os: ubuntu-latest
           path: ~/.cache/pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ in progress
 - Fix "http" service plugin
 - Improve machinery to launch a notification service plugin standalone.
   Now, it works without any ``mqttwarn.ini`` configuration file at all.
+- Begin adding tests for services
+- Drop official support for Python 2
+
 
 2021-06-12 0.24.0
 =================
@@ -17,6 +20,7 @@ in progress
 - [prowl] Update service plugin to use "pyprowl" instead of "prowlpy"
 - [core] Make "functions" setting in configuration file optional
 - [ci] Build and publish Docker multi-platform images
+
 
 2021-06-08 0.23.1
 =================

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -2161,7 +2161,6 @@ and one or more _application keys_ which you configure in the targets definition
 ```ini
 [config:pushover]
 callback = None
-device = cellphone1,cellphone2
 targets = {
     'nagios'     : ['userkey1', 'appkey1', 'sound1'],
     'alerts'     : ['userkey2', 'appkey2'],

--- a/README.rst
+++ b/README.rst
@@ -215,7 +215,7 @@ Requirements
 ============
 You'll need at least the following components:
 
-* Python. The program should work on Python 2, Python 3 and PyPy.
+* Python. The program should work on Python 3 and PyPy3.
 * An MQTT broker. We recommend Mosquitto_.
 * Some more Python modules to satisfy service dependencies defined in the ``setup.py`` file.
 

--- a/mqttwarn/services/alexa-notify-me.py
+++ b/mqttwarn/services/alexa-notify-me.py
@@ -29,12 +29,13 @@ def plugin(srv, item):
             "accessCode": item.addrs[0]
         })
 
-        requests.post(url="https://api.notifymyecho.com/v1/NotifyMe", data=body)
+        response = requests.post(url="https://api.notifymyecho.com/v1/NotifyMe", data=body)
+        response.raise_for_status()
 
         srv.logging.debug("Successfully sent to NotifyMe service.")
 
     except Exception as e:
-        srv.logging.warning("Failed to send message to NotifyMe service." % e)
+        srv.logging.warning("Failed to send message to NotifyMe service: %s" % e)
         return False
 
     return True

--- a/mqttwarn/services/amqp.py
+++ b/mqttwarn/services/amqp.py
@@ -36,7 +36,7 @@ def plugin(srv, item):
 
         srv.logging.debug("Successfully published AMQP notification")
     except Exception as e:
-        srv.logging.warn("Error on AMQP publish to %s [%s/%s]: %s" % (item.target, exchange, routing_key, e))
+        srv.logging.warning("Error on AMQP publish to %s [%s/%s]: %s" % (item.target, exchange, routing_key, e))
         return False
 
     return True

--- a/mqttwarn/services/apns.py
+++ b/mqttwarn/services/apns.py
@@ -19,18 +19,18 @@ def plugin(srv, item):
     try:
         cert_file, key_file = addrs
     except:
-        srv.logging.warn("Incorrect service configuration")
+        srv.logging.warning("Incorrect service configuration")
         return False
 
-    if 'payload' not in data or 'apns_token' not in data:
-        srv.logging.warn("Cannot notify via APNS: payload or apns_token are missing")
+    if 'apns_token' not in data:
+        srv.logging.warning("Cannot notify via APNS: apns_token is missing")
         return False
 
     apns_token = data['apns_token']
-    payload = data['payload']
 
     custom = {}
     try:
+        payload = data['payload']
         mdata = json.loads(payload)
         if 'custom' in mdata:
             custom = mdata['custom']
@@ -41,5 +41,7 @@ def plugin(srv, item):
 
     pload = Payload(alert=text, custom=custom, sound="default", badge=1)
     apns.gateway_server.send_notification(apns_token, pload)
+
+    srv.logging.debug("Successfully published APNS notification to %s" % apns_token)
 
     return True

--- a/mqttwarn/services/apprise.py
+++ b/mqttwarn/services/apprise.py
@@ -16,8 +16,8 @@ def plugin(srv, item):
     addresses = item.addrs
 
     if not addresses:
-        srv.logging.warn("Skipped sending notification to Apprise %s, "
-                         "no addresses configured" % (item.target))
+        srv.logging.warning("Skipped sending notification to Apprise %s, "
+                            "no addresses configured" % (item.target))
         return False
 
     sender = item.config.get('sender')

--- a/mqttwarn/services/asterisk.py
+++ b/mqttwarn/services/asterisk.py
@@ -36,17 +36,20 @@ def plugin(srv, item):
         srv.logging.info("Call {}".format(response))
         manager.logoff()
     except asterisk.manager.ManagerSocketException as e:
-        srv.logging.error("Error connecting to the manage: {}".format(e))
+        srv.logging.error("Error connecting to the manager: {}".format(e))
+        return False
     except asterisk.manager.ManagerAuthException as e:
         srv.logging.error("Error logging in to the manager: {}".format(e))
+        return False
     except asterisk.manager.ManagerException as e:
         srv.logging.error("Error: {}".format(e))
+        return False
 
+    # Remember to clean up
     finally:
-    # remember to clean up
         try:
             manager.close()
-        except asterisk.manager.ManagerSocketException:
+        except asterisk.manager.ManagerSocketException:  # pragma: no cover
             pass
     
     return True

--- a/mqttwarn/services/autoremote.py
+++ b/mqttwarn/services/autoremote.py
@@ -36,7 +36,7 @@ def plugin(srv, item):
         srv.logging.debug("Successfully sent to autoremote service")
 
     except Exception as e:
-        srv.logging.warning("Failed to send message to autoremote service" % e)
+        srv.logging.warning("Failed to send message to autoremote service: %s" % e)
         return False
 
     return True

--- a/mqttwarn/services/carbon.py
+++ b/mqttwarn/services/carbon.py
@@ -35,20 +35,22 @@ def plugin(srv, item):
         srv.logging.error("target `carbon': cannot split string")
         return False
 
-    if len(parts) == 1:
+    parts_count = len(parts)
+    if parts_count == 1:
         metric_name = item.data.get('topic', 'ohno').replace('/', '.')
         value = parts[0]
         tics = int(time.time())
+    elif parts_count == 2:
+        metric_name = parts[0]
+        value = parts[1]
+        tics = int(time.time())
+    elif parts_count == 3:
+        metric_name = parts[0]
+        value = parts[1]
+        tics = int(parts[2])
     else:
-        if len(parts) == 2:
-            metric_name = parts[0]
-            value = parts[1]
-            tics = int(time.time())
-        else:
-            if len(parts) == 3:
-                metric_name = parts[0]
-                value = parts[1]
-                tics = int(parts[2])
+        srv.logging.error("target `carbon': error decoding message")
+        return False
 
     if metric_name.startswith('.'):     # omit dot there caused by useless leading slash in topic
         metric_name = metric_name[1:]

--- a/mqttwarn/services/chromecast.py
+++ b/mqttwarn/services/chromecast.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-""" Text To Speach (TSS) for Chromecast devices, including Google Home Speakers
+"""
+Text To Speech (TTS) for Chromecast devices, including Google Home Speakers
 
-NOTE at the time of this plugin creation, pychromecast is Python3 ONLY
-pip install pychromecast - results in a zeroconf install that is
-not supported under Python 2.7; `def current_time_millis() -> float:`
+pip install pychromecast
 
-Old versions may be possible, see https://github.com/skorokithakis/catt
-version 0.5.6, which may help with exact requirements
+See also https://github.com/skorokithakis/catt.
 """
 
 __author__ = 'Chris Clark <clach04()gmail.com>'
@@ -16,11 +14,7 @@ __license__ = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-
 
 
 import os
-try:
-    from urllib.parse import urlencode
-except ImportError:
-    # Probably Python2
-    from urllib import urlencode
+from urllib.parse import urlencode
 
 
 def plugin(srv, item):

--- a/mqttwarn/services/execute.py
+++ b/mqttwarn/services/execute.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 __author__    = 'Tobias Brunner <tobias()tobru.ch>'

--- a/mqttwarn/services/ssh.py
+++ b/mqttwarn/services/ssh.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 from six import string_types
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ extras = {
     'celery': [
         'celery',
     ],
+    'chromecast': [
+        'pychromecast>=7.5.0',
+    ],
     'dnsupdate': [
         'dnspython>=1.15.0',
     ],
@@ -144,6 +147,8 @@ extras["test"] = [
     'pytest-cov>=2.8.1',
     'lovely.testlayers>=0.7.1',
     'tox>=3.14.2',
+    'surrogate==0.1',
+    'dataclasses; python_version<"3.7"',
 ]
 
 
@@ -168,7 +173,6 @@ setup(name='mqttwarn',
         "Operating System :: Unix",
         "Operating System :: MacOS",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/setup.py
+++ b/setup.py
@@ -149,6 +149,8 @@ extras["test"] = [
     'tox>=3.14.2',
     'surrogate==0.1',
     'dataclasses; python_version<"3.7"',
+    'requests-toolbelt>=0.9.1,<1',
+    'responses>=0.13.3,<1',
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import logging
+
+import pytest
+
+from mqttwarn.core import Service
+
+
+@pytest.fixture
+def srv():
+    """
+    A service instance for propagating to the plugin.
+    """
+    logger = logging.getLogger(__name__)
+    return Service(mqttc=None, logger=logger)

--- a/tests/test_pushover.py
+++ b/tests/test_pushover.py
@@ -1,0 +1,526 @@
+import base64
+import logging
+import os
+from unittest import mock
+
+import responses
+from requests_toolbelt import MultipartDecoder
+
+from mqttwarn.util import load_module_from_file
+from tests.util import ProcessorItem as Item
+
+
+def add_successful_mock_response():
+    responses.add(
+        responses.POST,
+        "https://api.pushover.net/1/messages.json",
+        json={"status": 1},
+        status=200,
+    )
+
+
+def add_failed_mock_response():
+    responses.add(
+        responses.POST,
+        "https://api.pushover.net/1/messages.json",
+        json={"status": 999},
+        status=400,
+    )
+
+
+@responses.activate
+def test_pushover_success(srv, caplog):
+
+    module = load_module_from_file("mqttwarn/services/pushover.py")
+
+    item = Item(
+        config={},
+        target="test",
+        addrs=["userkey2", "appkey2"],
+        message="⚽ Notification message ⚽",
+        data={},
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        add_successful_mock_response()
+        outcome = module.plugin(srv, item)
+
+        assert len(responses.calls) == 1
+        assert (
+            responses.calls[0].request.url == "https://api.pushover.net/1/messages.json"
+        )
+        assert (
+            responses.calls[0].request.body
+            == "user=userkey2&token=appkey2&retry=60&expire=3600&message=%E2%9A%BD+Notification+message+%E2%9A%BD"
+        )
+        assert responses.calls[0].request.headers["User-Agent"] == "mqttwarn"
+
+        assert responses.calls[0].response.status_code == 200
+        assert responses.calls[0].response.text == '{"status": 1}'
+
+        assert outcome is True
+        assert "Sending pushover notification to test" in caplog.text
+        assert "Successfully sent pushover notification" in caplog.text
+
+
+@responses.activate
+@mock.patch.dict(os.environ, {"PUSHOVER_USER": "userkey2", "PUSHOVER_TOKEN": "appkey2"})
+def test_pushover_success_with_credentials_from_environment(srv, caplog):
+
+    module = load_module_from_file("mqttwarn/services/pushover.py")
+
+    item = Item(
+        config={},
+        target="test",
+        addrs=[None, None],
+        message="⚽ Notification message ⚽",
+        data={},
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        add_successful_mock_response()
+        outcome = module.plugin(srv, item)
+
+        assert len(responses.calls) == 1
+        assert (
+            responses.calls[0].request.url == "https://api.pushover.net/1/messages.json"
+        )
+        assert (
+            responses.calls[0].request.body
+            == "user=userkey2&token=appkey2&retry=60&expire=3600&message=%E2%9A%BD+Notification+message+%E2%9A%BD"
+        )
+        assert responses.calls[0].request.headers["User-Agent"] == "mqttwarn"
+
+        assert responses.calls[0].response.status_code == 200
+        assert responses.calls[0].response.text == '{"status": 1}'
+
+        assert outcome is True
+        assert "Sending pushover notification to test" in caplog.text
+        assert "Successfully sent pushover notification" in caplog.text
+
+
+@responses.activate
+def test_pushover_success_with_sound(srv, caplog):
+
+    module = load_module_from_file("mqttwarn/services/pushover.py")
+
+    item = Item(
+        config={},
+        target="test",
+        addrs=["userkey2", "appkey2", "sound1"],
+        message="⚽ Notification message ⚽",
+        data={},
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        add_successful_mock_response()
+        outcome = module.plugin(srv, item)
+
+        assert (
+            responses.calls[0].request.body
+            == "user=userkey2&token=appkey2&retry=60&expire=3600&sound=sound1&message=%E2%9A%BD+Notification+message+%E2%9A%BD"
+        )
+
+        assert responses.calls[0].response.status_code == 200
+        assert responses.calls[0].response.text == '{"status": 1}'
+
+        assert outcome is True
+        assert "Sending pushover notification to test" in caplog.text
+        assert "Successfully sent pushover notification" in caplog.text
+
+
+@responses.activate
+def test_pushover_success_with_devices(srv, caplog):
+
+    module = load_module_from_file("mqttwarn/services/pushover.py")
+
+    item = Item(
+        config={},
+        target="test",
+        addrs=["userkey2", "appkey2", None, "cellphone1,cellphone2"],
+        message="⚽ Notification message ⚽",
+        data={},
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        add_successful_mock_response()
+        outcome = module.plugin(srv, item)
+
+        assert (
+            responses.calls[0].request.body
+            == "user=userkey2&token=appkey2&retry=60&expire=3600&devices=cellphone1%2Ccellphone2&message=%E2%9A%BD+Notification+message+%E2%9A%BD"
+        )
+
+        assert responses.calls[0].response.status_code == 200
+        assert responses.calls[0].response.text == '{"status": 1}'
+
+        assert outcome is True
+        assert "Sending pushover notification to test" in caplog.text
+        assert "Successfully sent pushover notification" in caplog.text
+
+
+@responses.activate
+def test_pushover_success_with_callback_and_title_and_priority_and_alternative_message(
+    srv, caplog
+):
+
+    module = load_module_from_file("mqttwarn/services/pushover.py")
+
+    item = Item(
+        config={"callback": "https://example.org/pushover-callback"},
+        target="test",
+        addrs=["userkey2", "appkey2"],
+        priority=555,
+        title="⚽ Message title ⚽",
+        message="⚽ Notification message ⚽",
+        data={"message": "⚽ Alternative notification message ⚽"},
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        add_successful_mock_response()
+        outcome = module.plugin(srv, item)
+
+        assert (
+            responses.calls[0].request.body
+            == "user=userkey2&token=appkey2&retry=60&expire=3600&title=%E2%9A%BD+Message+title+%E2%9A%BD&priority=555&callback=https%3A%2F%2Fexample.org%2Fpushover-callback&message=%E2%9A%BD+Alternative+notification+message+%E2%9A%BD"
+        )
+
+        assert responses.calls[0].response.status_code == 200
+        assert responses.calls[0].response.text == '{"status": 1}'
+
+        assert outcome is True
+        assert "Sending pushover notification to test" in caplog.text
+        assert "Successfully sent pushover notification" in caplog.text
+
+
+@responses.activate
+def test_pushover_success_with_imageurl(srv, caplog):
+
+    module = load_module_from_file("mqttwarn/services/pushover.py")
+
+    item = Item(
+        config={},
+        target="test",
+        addrs=["userkey2", "appkey2"],
+        message="⚽ Notification message ⚽",
+        data={"imageurl": "https://example.org/image"},
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        add_successful_mock_response()
+
+        image = open("./assets/pushover.png", "rb").read()
+        responses.add(
+            responses.GET,
+            "https://example.org/image",
+            body=image,
+            stream=True,
+            status=200,
+        )
+
+        outcome = module.plugin(srv, item)
+
+        # Check response status.
+        assert responses.calls[1].response.status_code == 200
+        assert responses.calls[1].response.text == '{"status": 1}'
+
+        # Decode multipart request.
+        request = responses.calls[1].request
+        decoder = MultipartDecoder(request.body, request.headers["Content-Type"])
+
+        content_disposition_headers = []
+        contents = {}
+        for part in decoder.parts:
+            content_disposition_headers.append(part.headers[b"Content-Disposition"])
+
+            key = part.headers[b"Content-Disposition"]
+            contents[key] = part.content
+
+        # Proof request has all body parts.
+        assert content_disposition_headers == [
+            b'form-data; name="user"',
+            b'form-data; name="token"',
+            b'form-data; name="retry"',
+            b'form-data; name="expire"',
+            b'form-data; name="message"',
+            b'form-data; name="attachment"; filename="image.jpg"',
+        ]
+
+        # Proof parameter body parts, modulo image content, have correct values.
+        assert list(contents.values())[:-1] == [
+            b"userkey2",
+            b"appkey2",
+            b"60",
+            b"3600",
+            b"\xe2\x9a\xbd Notification message \xe2\x9a\xbd",
+        ]
+
+        # Proof image has content.
+        assert len(decoder.parts[-1].content) == 45628
+
+        assert outcome is True
+        assert "Sending pushover notification to test" in caplog.text
+        assert "Successfully sent pushover notification" in caplog.text
+
+
+@responses.activate
+def test_pushover_success_with_imageurl_and_basic_authentication(srv, caplog):
+
+    module = load_module_from_file("mqttwarn/services/pushover.py")
+
+    item = Item(
+        config={},
+        target="test",
+        addrs=["userkey2", "appkey2"],
+        message="⚽ Notification message ⚽",
+        data={
+            "imageurl": "https://example.org/image",
+            "auth": "basic",
+            "user": "foo",
+            "password": "bar",
+        },
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        add_successful_mock_response()
+
+        image = open("./assets/pushover.png", "rb").read()
+        responses.add(
+            responses.GET,
+            "https://example.org/image",
+            body=image,
+            stream=True,
+            status=200,
+        )
+
+        outcome = module.plugin(srv, item)
+
+        # Proof authentication on image request.
+        assert (
+            responses.calls[0].request.headers["Authorization"] == "Basic Zm9vOmJhcg=="
+        )
+
+        # Check response status.
+        assert responses.calls[1].response.status_code == 200
+        assert responses.calls[1].response.text == '{"status": 1}'
+
+        assert outcome is True
+        assert "Sending pushover notification to test" in caplog.text
+        assert "Successfully sent pushover notification" in caplog.text
+
+
+@responses.activate
+def test_pushover_success_with_imageurl_and_digest_authentication(srv, caplog):
+
+    module = load_module_from_file("mqttwarn/services/pushover.py")
+
+    item = Item(
+        config={},
+        target="test",
+        addrs=["userkey2", "appkey2"],
+        message="⚽ Notification message ⚽",
+        data={
+            "imageurl": "https://example.org/image",
+            "auth": "digest",
+            "user": "foo",
+            "password": "bar",
+        },
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        add_successful_mock_response()
+
+        image = open("./assets/pushover.png", "rb").read()
+        responses.add(
+            responses.GET,
+            "https://example.org/image",
+            body=image,
+            stream=True,
+            status=200,
+        )
+
+        outcome = module.plugin(srv, item)
+
+        # Proof authentication on image request.
+        # FIXME: Currently not possible because Digest auth will only work if
+        #        the server answers with 4xx.
+        # assert (
+        #    responses.calls[0].request.headers["Authorization"] == "Digest something"
+        # )
+
+        # Check response status.
+        assert responses.calls[1].response.status_code == 200
+        assert responses.calls[1].response.text == '{"status": 1}'
+
+        assert outcome is True
+        assert "Sending pushover notification to test" in caplog.text
+        assert "Successfully sent pushover notification" in caplog.text
+
+
+@responses.activate
+def test_pushover_success_with_imagebase64(srv, caplog):
+
+    module = load_module_from_file("mqttwarn/services/pushover.py")
+
+    image = open("./assets/pushover.png", "rb").read()
+    item = Item(
+        config={},
+        target="test",
+        addrs=["userkey2", "appkey2"],
+        message="⚽ Notification message ⚽",
+        data={"imagebase64": base64.encodebytes(image)},
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        add_successful_mock_response()
+        outcome = module.plugin(srv, item)
+
+        # Check response status.
+        assert responses.calls[0].response.status_code == 200
+        assert responses.calls[0].response.text == '{"status": 1}'
+
+        # Decode multipart request.
+        request = responses.calls[0].request
+        decoder = MultipartDecoder(request.body, request.headers["Content-Type"])
+
+        content_disposition_headers = []
+        contents = {}
+        for part in decoder.parts:
+            content_disposition_headers.append(part.headers[b"Content-Disposition"])
+
+            key = part.headers[b"Content-Disposition"]
+            contents[key] = part.content
+
+        # Proof request has all body parts.
+        assert content_disposition_headers == [
+            b'form-data; name="user"',
+            b'form-data; name="token"',
+            b'form-data; name="retry"',
+            b'form-data; name="expire"',
+            b'form-data; name="message"',
+            b'form-data; name="attachment"; filename="image.jpg"',
+        ]
+
+        # Proof parameter body parts, modulo image content, have correct values.
+        assert list(contents.values())[:-1] == [
+            b"userkey2",
+            b"appkey2",
+            b"60",
+            b"3600",
+            b"\xe2\x9a\xbd Notification message \xe2\x9a\xbd",
+        ]
+
+        # Proof image has content.
+        assert len(decoder.parts[-1].content) == 45628
+
+        assert outcome is True
+        assert "Sending pushover notification to test" in caplog.text
+        assert "Successfully sent pushover notification" in caplog.text
+
+
+def test_pushover_failure_invalid_configuration(srv, caplog):
+
+    module = load_module_from_file("mqttwarn/services/pushover.py")
+
+    item = Item(
+        config={},
+        target="test",
+        addrs=[None],
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        outcome = module.plugin(srv, item)
+
+        assert outcome is False
+        assert "Invalid address configuration for target `test'" in caplog.text
+
+
+def test_pushover_failure_missing_credentials(srv, caplog):
+
+    module = load_module_from_file("mqttwarn/services/pushover.py")
+
+    item = Item(
+        config={},
+        target="test",
+        addrs=[None, None],
+        data={},
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        outcome = module.plugin(srv, item)
+
+        assert outcome is False
+        assert "No pushover credentials configured for target `test'" in caplog.text
+
+
+@responses.activate
+def test_pushover_failure_request_error(srv, caplog):
+
+    module = load_module_from_file("mqttwarn/services/pushover.py")
+
+    item = Item(
+        config={},
+        target="test",
+        addrs=["userkey2", "appkey2"],
+        message="⚽ Notification message ⚽",
+        data={},
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        # Make remote call bail out.
+        module.pushover = mock.MagicMock(side_effect=Exception("something failed"))
+
+        outcome = module.plugin(srv, item)
+
+        assert outcome is False
+        assert "Sending pushover notification to test" in caplog.text
+        assert "Error sending pushover notification: something failed" in caplog.text
+
+
+@responses.activate
+def test_pushover_failure_response_error(srv, caplog):
+
+    module = load_module_from_file("mqttwarn/services/pushover.py")
+
+    item = Item(
+        config={},
+        target="test",
+        addrs=["userkey2", "appkey2"],
+        message="⚽ Notification message ⚽",
+        data={},
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        add_failed_mock_response()
+        outcome = module.plugin(srv, item)
+
+        assert len(responses.calls) == 1
+
+        assert (
+            responses.calls[0].request.url == "https://api.pushover.net/1/messages.json"
+        )
+        assert (
+            responses.calls[0].request.body
+            == "user=userkey2&token=appkey2&retry=60&expire=3600&message=%E2%9A%BD+Notification+message+%E2%9A%BD"
+        )
+        assert responses.calls[0].request.headers["User-Agent"] == "mqttwarn"
+
+        assert responses.calls[0].response.status_code == 400
+        assert responses.calls[0].response.text == '{"status": 999}'
+
+        assert outcome is False
+        assert "Sending pushover notification to test" in caplog.text
+        assert (
+            "Error sending pushover notification: b'{\"status\": 999}'" in caplog.text
+        )

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,1168 @@
+# -*- coding: utf-8 -*-
+# (c) 2021 The mqttwarn developers
+import logging
+from unittest import mock
+from unittest.mock import call, PropertyMock
+
+from surrogate import surrogate
+
+from mqttwarn.util import load_module_by_name, load_module_from_file
+from tests.util import ProcessorItem as Item
+
+
+def test_alexa_notify_me_success(srv, caplog):
+
+    module = load_module_from_file("mqttwarn/services/alexa-notify-me.py")
+
+    accessCode = "myToken"
+    item = Item(addrs=[accessCode], message="⚽ Notification message ⚽")
+
+    with caplog.at_level(logging.DEBUG):
+        with mock.patch("requests.post") as requests_mock:
+            outcome = module.plugin(srv, item)
+            requests_mock.assert_called_once_with(
+                url="https://api.notifymyecho.com/v1/NotifyMe",
+                data='{"notification": "\\u26bd Notification message \\u26bd", "accessCode": "myToken"}',
+            )
+
+        assert outcome is True
+        assert "Sending to NotifyMe service" in caplog.text
+        assert "Successfully sent to NotifyMe service" in caplog.text
+
+
+def test_alexa_notify_me_real_auth_failure(srv, caplog):
+    module = load_module_from_file("mqttwarn/services/alexa-notify-me.py")
+
+    accessCode = "myToken"
+    item = Item(addrs=[accessCode], message="⚽ Notification message ⚽")
+
+    with caplog.at_level(logging.DEBUG):
+        outcome = module.plugin(srv, item)
+
+        assert outcome is False
+        assert "Sending to NotifyMe service" in caplog.text
+        assert "Failed to send message to NotifyMe service" in caplog.text
+
+
+@surrogate("puka")
+@mock.patch("puka.Client", create=True)
+def test_amqp_success(mock_puka_client, srv, caplog):
+    module = load_module_by_name("mqttwarn.services.amqp")
+
+    exchange, routing_key = ["name_of_exchange", "my_routing_key"]
+    item = Item(
+        config={"uri": "amqp://user:password@localhost:5672/"},
+        target="test",
+        addrs=[exchange, routing_key],
+        message="⚽ Notification message ⚽",
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        outcome = module.plugin(srv, item)
+
+        assert mock_puka_client.mock_calls == [
+            mock.call("amqp://user:password@localhost:5672/"),
+            call().connect(),
+            call().wait(mock.ANY),
+            call().basic_publish(
+                exchange="name_of_exchange",
+                routing_key="my_routing_key",
+                headers={
+                    "content_type": "text/plain",
+                    "x-agent": "mqttwarn",
+                    "delivery_mode": 1,
+                },
+                body="⚽ Notification message ⚽",
+            ),
+            call().wait(mock.ANY),
+            call().close(),
+        ]
+
+        assert outcome is True
+        assert "AMQP publish to test [name_of_exchange/my_routing_key]" in caplog.text
+        assert "Successfully published AMQP notification" in caplog.text
+
+
+@surrogate("puka")
+def test_amqp_failure(srv, caplog):
+    module = load_module_by_name("mqttwarn.services.amqp")
+
+    exchange, routing_key = ["name_of_exchange", "my_routing_key"]
+    item = Item(
+        config={"uri": "amqp://user:password@localhost:5672/"},
+        target="test",
+        addrs=[exchange, routing_key],
+        message="⚽ Notification message ⚽",
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        mock_connection = mock.MagicMock()
+
+        # Make the call to `basic_publish` raise an exception.
+        def error(*args, **kwargs):
+            raise Exception("something failed")
+
+        mock_connection.basic_publish = error
+
+        with mock.patch(
+            "puka.Client", side_effect=[mock_connection], create=True
+        ) as mock_client:
+
+            outcome = module.plugin(srv, item)
+
+            assert mock_client.mock_calls == [
+                mock.call("amqp://user:password@localhost:5672/"),
+            ]
+            assert mock_connection.mock_calls == [
+                call.connect(),
+                call.wait(mock.ANY),
+            ]
+
+            assert outcome is False
+            assert (
+                "AMQP publish to test [name_of_exchange/my_routing_key]" in caplog.text
+            )
+            assert (
+                "Error on AMQP publish to test [name_of_exchange/my_routing_key]: something failed"
+                in caplog.text
+            )
+
+
+@surrogate("apns")
+@mock.patch("apns.APNs", create=True)
+@mock.patch("apns.Payload", create=True)
+def test_apns_success(mock_apns_payload, mock_apns, srv, caplog):
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/apns.py")
+
+        cert_file, key_file = ["cert_file", "key_file"]
+        item = Item(
+            target="test",
+            addrs=[cert_file, key_file],
+            message="⚽ Notification message ⚽",
+            data={"apns_token": "foobar", "payload": "{}"},
+        )
+
+        outcome = module.plugin(srv, item)
+
+        assert mock_apns_payload.mock_calls == [
+            call(
+                alert="⚽ Notification message ⚽",
+                custom={},
+                sound="default",
+                badge=1,
+            ),
+        ]
+        assert mock_apns.mock_calls == [
+            mock.call(use_sandbox=False, cert_file="cert_file", key_file="key_file"),
+            call().gateway_server.send_notification("foobar", mock.ANY),
+        ]
+
+        assert outcome is True
+        assert "Successfully published APNS notification to foobar" in caplog.text
+
+
+@surrogate("apns")
+@mock.patch("apns.APNs", create=True)
+@mock.patch("apns.Payload", create=True)
+def test_apns_success_no_payload(mock_apns_payload, mock_apns, srv, caplog):
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/apns.py")
+
+        cert_file, key_file = ["cert_file", "key_file"]
+        item = Item(
+            target="test",
+            addrs=[cert_file, key_file],
+            message="⚽ Notification message ⚽",
+            data={"apns_token": "foobar"},
+        )
+
+        outcome = module.plugin(srv, item)
+
+        assert mock_apns_payload.mock_calls == [
+            call(
+                alert="⚽ Notification message ⚽",
+                custom={},
+                sound="default",
+                badge=1,
+            ),
+        ]
+        assert mock_apns.mock_calls == [
+            mock.call(use_sandbox=False, cert_file="cert_file", key_file="key_file"),
+            call().gateway_server.send_notification("foobar", mock.ANY),
+        ]
+
+        assert outcome is True
+        assert "Successfully published APNS notification to foobar" in caplog.text
+
+
+@surrogate("apns")
+@mock.patch("apns.APNs", create=True)
+@mock.patch("apns.Payload", create=True)
+def test_apns_success_custom_payload(mock_apns_payload, mock_apns, srv, caplog):
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/apns.py")
+
+        cert_file, key_file = ["cert_file", "key_file"]
+        item = Item(
+            target="test",
+            addrs=[cert_file, key_file],
+            message="⚽ Notification message ⚽",
+            data={
+                "apns_token": "foobar",
+                "payload": '{"custom": {"baz": "qux"}}',
+            },
+        )
+
+        outcome = module.plugin(srv, item)
+
+        assert mock_apns_payload.mock_calls == [
+            call(
+                alert="⚽ Notification message ⚽",
+                custom={"baz": "qux"},
+                sound="default",
+                badge=1,
+            ),
+        ]
+        assert mock_apns.mock_calls == [
+            mock.call(use_sandbox=False, cert_file="cert_file", key_file="key_file"),
+            call().gateway_server.send_notification("foobar", mock.ANY),
+        ]
+
+        assert outcome is True
+        assert "Successfully published APNS notification to foobar" in caplog.text
+
+
+@surrogate("apns")
+@mock.patch("apns.APNs", create=True)
+@mock.patch("apns.Payload", create=True)
+def test_apns_failure_invalid_config(mock_apns_payload, mock_apns, srv, caplog):
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/apns.py")
+
+        item = Item(
+            target="test",
+            addrs=[None],
+            message="⚽ Notification message ⚽",
+            data={"apns_token": "foobar", "payload": "{}"},
+        )
+
+        outcome = module.plugin(srv, item)
+
+        assert outcome is False
+        assert "Incorrect service configuration" in caplog.text
+
+
+@surrogate("apns")
+@mock.patch("apns.APNs", create=True)
+@mock.patch("apns.Payload", create=True)
+def test_apns_failure_apns_token_missing(mock_apns_payload, mock_apns, srv, caplog):
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/apns.py")
+
+        cert_file, key_file = ["cert_file", "key_file"]
+        item = Item(
+            target="test",
+            addrs=[cert_file, key_file],
+            message="⚽ Notification message ⚽",
+            data={},
+        )
+
+        outcome = module.plugin(srv, item)
+
+        assert outcome is False
+        assert "Cannot notify via APNS: apns_token is missing" in caplog.text
+
+
+@surrogate("apprise")
+@mock.patch("apprise.Apprise", create=True)
+@mock.patch("apprise.AppriseAsset", create=True)
+def test_apprise_success(apprise_asset, apprise_mock, srv, caplog):
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/apprise.py")
+
+        item = Item(
+            config={
+                "baseuri": "mailtos://smtp_username:smtp_password@mail.example.org"
+            },
+            target="test",
+            addrs=["foo@example.org", "bar@example.org"],
+            title="⚽ Message title ⚽",
+            message="⚽ Notification message ⚽",
+        )
+
+        outcome = module.plugin(srv, item)
+
+        assert apprise_mock.mock_calls == [
+            call(asset=mock.ANY),
+            call().add(
+                "mailtos://smtp_username:smtp_password@mail.example.org?from=None&to=foo@example.org,bar@example.org"
+            ),
+            call().notify(body="⚽ Notification message ⚽", title="⚽ Message title ⚽"),
+            call().notify().__bool__(),
+        ]
+
+        assert outcome is True
+        assert (
+            "Sending notification to Apprise test, addresses: ['foo@example.org', 'bar@example.org']"
+            in caplog.text
+        )
+        assert "Successfully sent message using Apprise" in caplog.text
+
+
+@surrogate("apprise")
+@mock.patch("apprise.Apprise", create=True)
+@mock.patch("apprise.AppriseAsset", create=True)
+def test_apprise_failure_no_addresses(apprise_asset, apprise_mock, srv, caplog):
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/apprise.py")
+
+        item = Item(
+            config={
+                "baseuri": "mailtos://smtp_username:smtp_password@mail.example.org"
+            },
+            target="test",
+            addrs=[],
+            title="⚽ Message title ⚽",
+            message="⚽ Notification message ⚽",
+        )
+
+        outcome = module.plugin(srv, item)
+
+        assert apprise_mock.mock_calls == []
+
+        assert outcome is False
+        assert (
+            "Skipped sending notification to Apprise test, no addresses configured"
+            in caplog.text
+        )
+
+
+@surrogate("apprise")
+def test_apprise_failure_notify(srv, caplog):
+
+    with caplog.at_level(logging.DEBUG):
+
+        mock_connection = mock.MagicMock()
+
+        # Make the call to `notify` signal failure.
+        def error(*args, **kwargs):
+            return False
+
+        mock_connection.notify = error
+
+        with mock.patch(
+            "apprise.Apprise", side_effect=[mock_connection], create=True
+        ) as mock_client:
+            with mock.patch("apprise.AppriseAsset", create=True) as mock_asset:
+                module = load_module_from_file("mqttwarn/services/apprise.py")
+
+                item = Item(
+                    config={
+                        "baseuri": "mailtos://smtp_username:smtp_password@mail.example.org"
+                    },
+                    target="test",
+                    addrs=["foo@example.org", "bar@example.org"],
+                    title="⚽ Message title ⚽",
+                    message="⚽ Notification message ⚽",
+                )
+
+                outcome = module.plugin(srv, item)
+
+                assert mock_client.mock_calls == [
+                    mock.call(asset=mock.ANY),
+                ]
+                assert mock_connection.mock_calls == [
+                    call.add(
+                        "mailtos://smtp_username:smtp_password@mail.example.org?from=None&to=foo@example.org,bar@example.org"
+                    ),
+                ]
+
+                assert outcome is False
+                assert (
+                    "Sending notification to Apprise test, addresses: ['foo@example.org', 'bar@example.org']"
+                    in caplog.text
+                )
+                assert "Sending message using Apprise failed" in caplog.text
+
+
+@surrogate("apprise")
+def test_apprise_error(srv, caplog):
+
+    with caplog.at_level(logging.DEBUG):
+
+        mock_connection = mock.MagicMock()
+
+        # Make the call to `notify` raise an exception.
+        def error(*args, **kwargs):
+            raise Exception("something failed")
+
+        mock_connection.notify = error
+
+        with mock.patch(
+            "apprise.Apprise", side_effect=[mock_connection], create=True
+        ) as mock_client:
+            with mock.patch("apprise.AppriseAsset", create=True) as mock_asset:
+                module = load_module_from_file("mqttwarn/services/apprise.py")
+
+                item = Item(
+                    config={
+                        "baseuri": "mailtos://smtp_username:smtp_password@mail.example.org"
+                    },
+                    target="test",
+                    addrs=["foo@example.org", "bar@example.org"],
+                    title="⚽ Message title ⚽",
+                    message="⚽ Notification message ⚽",
+                )
+
+                outcome = module.plugin(srv, item)
+
+                assert mock_client.mock_calls == [
+                    mock.call(asset=mock.ANY),
+                ]
+                assert mock_connection.mock_calls == [
+                    call.add(
+                        "mailtos://smtp_username:smtp_password@mail.example.org?from=None&to=foo@example.org,bar@example.org"
+                    ),
+                ]
+
+                assert outcome is False
+                assert (
+                    "Sending notification to Apprise test, addresses: ['foo@example.org', 'bar@example.org']"
+                    in caplog.text
+                )
+                assert "Error sending message to test: something failed" in caplog.text
+
+
+@surrogate("apprise")
+@mock.patch("apprise.Apprise", create=True)
+@mock.patch("apprise.AppriseAsset", create=True)
+def test_apprise_success_with_sender(apprise_asset, apprise_mock, srv, caplog):
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/apprise.py")
+
+        item = Item(
+            config={
+                "baseuri": "mailtos://smtp_username:smtp_password@mail.example.org",
+                "sender": "example@example.org",
+                "sender_name": "Max Mustermann",
+            },
+            target="test",
+            addrs=["foo@example.org", "bar@example.org"],
+            title="⚽ Message title ⚽",
+            message="⚽ Notification message ⚽",
+        )
+
+        outcome = module.plugin(srv, item)
+
+        assert apprise_mock.mock_calls == [
+            call(asset=mock.ANY),
+            call().add(
+                "mailtos://smtp_username:smtp_password@mail.example.org?from=example@example.org&to=foo@example.org,bar@example.org&name=Max Mustermann"
+            ),
+            call().notify(body="⚽ Notification message ⚽", title="⚽ Message title ⚽"),
+            call().notify().__bool__(),
+        ]
+
+        assert outcome is True
+        assert "Successfully sent message using Apprise" in caplog.text
+
+
+@surrogate("asterisk.manager")
+@mock.patch("asterisk.manager.Manager", create=True)
+def test_asterisk_success(asterisk_mock, srv, caplog):
+
+    with caplog.at_level(logging.DEBUG):
+
+        attrs = {"login.return_value": 42, "originate.return_value": 42}
+        asterisk_mock.return_value = mock.MagicMock(**attrs)
+
+        module = load_module_from_file("mqttwarn/services/asterisk.py")
+
+        item = Item(
+            config={
+                "host": "asterisk.example.org",
+                "port": 5038,
+                "username": "foobar",
+                "password": "bazqux",
+                "extension": 2222,
+                "context": "default",
+            },
+            target="test",
+            addrs=["SIP/avaya/", "0123456789"],
+            message="⚽ Notification message ⚽",
+        )
+
+        outcome = module.plugin(srv, item)
+
+        assert asterisk_mock.mock_calls == [
+            call(),
+            call().connect("asterisk.example.org", 5038),
+            call().login("foobar", "bazqux"),
+            call().originate(
+                "SIP/avaya/0123456789",
+                2222,
+                context="default",
+                priority="1",
+                caller_id=2222,
+                variables={"text": "⚽ Notification message ⚽"},
+            ),
+            call().logoff(),
+            call().close(),
+        ]
+
+        assert outcome is True
+        assert "Authentication 42" in caplog.text
+        assert "Call 42" in caplog.text
+
+
+class ManagerSocketException(Exception):
+    pass
+
+
+class ManagerAuthException(Exception):
+    pass
+
+
+class ManagerException(Exception):
+    pass
+
+
+@surrogate("asterisk.manager")
+@mock.patch("asterisk.manager.Manager", create=True)
+@mock.patch(
+    "asterisk.manager.ManagerSocketException", ManagerSocketException, create=True
+)
+def test_asterisk_failure_no_connection(asterisk_mock, srv, caplog):
+
+    with caplog.at_level(logging.DEBUG):
+
+        attrs = {"connect.side_effect": ManagerSocketException("something failed")}
+        asterisk_mock.return_value = mock.MagicMock(**attrs)
+
+        module = load_module_from_file("mqttwarn/services/asterisk.py")
+
+        item = Item(
+            config={
+                "host": "asterisk.example.org",
+                "port": 5038,
+                "username": "foobar",
+                "password": "bazqux",
+                "extension": 2222,
+                "context": "default",
+            },
+            target="test",
+            addrs=["SIP/avaya/", "0123456789"],
+            message="⚽ Notification message ⚽",
+        )
+
+        outcome = module.plugin(srv, item)
+
+        assert asterisk_mock.mock_calls == [
+            call(),
+            call().connect("asterisk.example.org", 5038),
+            call().close(),
+        ]
+
+        assert outcome is False
+        assert "Error connecting to the manager: something failed" in caplog.text
+
+
+@surrogate("asterisk.manager")
+@mock.patch("asterisk.manager.Manager", create=True)
+@mock.patch(
+    "asterisk.manager.ManagerSocketException", ManagerSocketException, create=True
+)
+@mock.patch("asterisk.manager.ManagerAuthException", ManagerAuthException, create=True)
+def test_asterisk_failure_login_invalid(asterisk_mock, srv, caplog):
+
+    with caplog.at_level(logging.DEBUG):
+
+        attrs = {"login.side_effect": ManagerAuthException("something failed")}
+        asterisk_mock.return_value = mock.MagicMock(**attrs)
+
+        module = load_module_from_file("mqttwarn/services/asterisk.py")
+
+        item = Item(
+            config={
+                "host": "asterisk.example.org",
+                "port": 5038,
+                "username": "foobar",
+                "password": "bazqux",
+                "extension": 2222,
+                "context": "default",
+            },
+            target="test",
+            addrs=["SIP/avaya/", "0123456789"],
+            message="⚽ Notification message ⚽",
+        )
+
+        outcome = module.plugin(srv, item)
+
+        assert asterisk_mock.mock_calls == [
+            call(),
+            call().connect("asterisk.example.org", 5038),
+            call().login("foobar", "bazqux"),
+            call().close(),
+        ]
+
+        assert outcome is False
+        assert "Error logging in to the manager: something failed" in caplog.text
+
+
+@surrogate("asterisk.manager")
+@mock.patch("asterisk.manager.Manager", create=True)
+@mock.patch(
+    "asterisk.manager.ManagerSocketException", ManagerSocketException, create=True
+)
+@mock.patch("asterisk.manager.ManagerAuthException", ManagerAuthException, create=True)
+@mock.patch("asterisk.manager.ManagerException", ManagerException, create=True)
+def test_asterisk_failure_originate_croaks(asterisk_mock, srv, caplog):
+
+    with caplog.at_level(logging.DEBUG):
+
+        attrs = {
+            "login.return_value": 42,
+            "originate.side_effect": ManagerException("something failed"),
+        }
+        asterisk_mock.return_value = mock.MagicMock(**attrs)
+
+        module = load_module_from_file("mqttwarn/services/asterisk.py")
+
+        item = Item(
+            config={
+                "host": "asterisk.example.org",
+                "port": 5038,
+                "username": "foobar",
+                "password": "bazqux",
+                "extension": 2222,
+                "context": "default",
+            },
+            target="test",
+            addrs=["SIP/avaya/", "0123456789"],
+            message="⚽ Notification message ⚽",
+        )
+
+        outcome = module.plugin(srv, item)
+
+        assert asterisk_mock.mock_calls == [
+            call(),
+            call().connect("asterisk.example.org", 5038),
+            call().login("foobar", "bazqux"),
+            call().originate(
+                "SIP/avaya/0123456789",
+                2222,
+                context="default",
+                priority="1",
+                caller_id=2222,
+                variables={"text": "⚽ Notification message ⚽"},
+            ),
+            call().close(),
+        ]
+
+        assert outcome is False
+        assert "Error: something failed" in caplog.text
+
+
+@surrogate("asterisk.manager")
+@mock.patch("asterisk.manager.Manager", create=True)
+@mock.patch(
+    "asterisk.manager.ManagerSocketException", ManagerSocketException, create=True
+)
+@mock.patch("asterisk.manager.ManagerAuthException", ManagerAuthException, create=True)
+@mock.patch("asterisk.manager.ManagerException", ManagerException, create=True)
+def test_asterisk_success_with_broken_close(asterisk_mock, srv, caplog):
+
+    with caplog.at_level(logging.DEBUG):
+
+        attrs = {
+            "login.return_value": 42,
+            "originate.return_value": 42,
+            "close.side_effect": ManagerSocketException("something failed"),
+        }
+        asterisk_mock.return_value = mock.MagicMock(**attrs)
+
+        module = load_module_from_file("mqttwarn/services/asterisk.py")
+
+        item = Item(
+            config={
+                "host": "asterisk.example.org",
+                "port": 5038,
+                "username": "foobar",
+                "password": "bazqux",
+                "extension": 2222,
+                "context": "default",
+            },
+            target="test",
+            addrs=["SIP/avaya/", "0123456789"],
+            message="⚽ Notification message ⚽",
+        )
+
+        outcome = module.plugin(srv, item)
+
+        assert asterisk_mock.mock_calls == [
+            call(),
+            call().connect("asterisk.example.org", 5038),
+            call().login("foobar", "bazqux"),
+            call().originate(
+                "SIP/avaya/0123456789",
+                2222,
+                context="default",
+                priority="1",
+                caller_id=2222,
+                variables={"text": "⚽ Notification message ⚽"},
+            ),
+            call().logoff(),
+            call().close(),
+        ]
+
+        assert outcome is True
+
+
+def test_autoremote_success(srv, caplog):
+
+    item = Item(
+        target="test",
+        addrs=["ApiKey", "Password", "Target", "Group", "TTL"],
+        topic="autoremote/user",
+        message="⚽ Notification message ⚽",
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/autoremote.py")
+
+        with mock.patch("requests.get") as requests_mock:
+            outcome = module.plugin(srv, item)
+            requests_mock.assert_called_once_with(
+                "https://autoremotejoaomgcd.appspot.com/sendmessage",
+                params={
+                    "key": "ApiKey",
+                    "message": "⚽ Notification message ⚽",
+                    "target": "Target",
+                    "sender": "autoremote/user",
+                    "password": "Password",
+                    "ttl": "TTL",
+                    "collapseKey": "Group",
+                },
+            )
+
+        assert outcome is True
+        assert "Sending to autoremote service" in caplog.text
+        assert "Successfully sent to autoremote service" in caplog.text
+
+
+def test_autoremote_failure(srv, caplog):
+
+    item = Item(
+        target="test",
+        addrs=["ApiKey", "Password", "Target", "Group", "TTL"],
+        topic="autoremote/user",
+        message="⚽ Notification message ⚽",
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/autoremote.py")
+
+        with mock.patch(
+            "requests.get", side_effect=Exception("something failed")
+        ) as requests_mock:
+            outcome = module.plugin(srv, item)
+            requests_mock.assert_called_once_with(
+                "https://autoremotejoaomgcd.appspot.com/sendmessage",
+                params={
+                    "key": "ApiKey",
+                    "message": "⚽ Notification message ⚽",
+                    "target": "Target",
+                    "sender": "autoremote/user",
+                    "password": "Password",
+                    "ttl": "TTL",
+                    "collapseKey": "Group",
+                },
+            )
+
+        assert outcome is False
+        assert "Sending to autoremote service" in caplog.text
+        assert (
+            "Failed to send message to autoremote service: something failed"
+            in caplog.text
+        )
+
+
+def test_azure_iot_success_string(srv, caplog):
+
+    item = Item(
+        config={"iothubname": "acmehub"},
+        target="test",
+        addrs=["device-id", "SharedAccessSignature sr=..."],
+        message="⚽ Notification message ⚽",
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/azure_iot.py")
+
+        mqtt_publish_mock = mock.MagicMock()
+        module.mqtt = mqtt_publish_mock
+
+        outcome = module.plugin(srv, item)
+        mqtt_publish_mock.single.assert_called_once_with(
+            "devices/device-id/messages/events/",
+            bytearray(b"\xe2\x9a\xbd Notification message \xe2\x9a\xbd"),
+            auth={
+                "username": "acmehub.azure-devices.net/device-id/?api-version=2018-06-30",
+                "password": "SharedAccessSignature sr=...",
+            },
+            tls={
+                "ca_certs": None,
+                "certfile": None,
+                "keyfile": None,
+                "tls_version": mock.ANY,
+                "ciphers": None,
+                "cert_reqs": mock.ANY,
+            },
+            hostname="acmehub.azure-devices.net",
+            port=8883,
+            protocol=4,
+            qos=0,
+            retain=False,
+            client_id="device-id",
+        )
+
+        assert outcome is True
+        assert (
+            "Publishing to Azure IoT Hub for target=test (device-id): devices/device-id/messages/events/ 'bytearray(b'\\xe2\\x9a\\xbd Notification message \\xe2\\x9a\\xbd')'"
+            in caplog.text
+        )
+
+
+def test_azure_iot_success_bytes(srv, caplog):
+
+    item = Item(
+        config={"iothubname": "acmehub"},
+        target="test",
+        addrs=["device-id", "SharedAccessSignature sr=..."],
+        message=b"### Notification message ###",
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/azure_iot.py")
+
+        mqtt_publish_mock = mock.MagicMock()
+        module.mqtt = mqtt_publish_mock
+
+        outcome = module.plugin(srv, item)
+        mqtt_publish_mock.single.assert_called_once_with(
+            "devices/device-id/messages/events/",
+            bytearray(b"### Notification message ###"),
+            auth={
+                "username": "acmehub.azure-devices.net/device-id/?api-version=2018-06-30",
+                "password": "SharedAccessSignature sr=...",
+            },
+            tls={
+                "ca_certs": None,
+                "certfile": None,
+                "keyfile": None,
+                "tls_version": mock.ANY,
+                "ciphers": None,
+                "cert_reqs": mock.ANY,
+            },
+            hostname="acmehub.azure-devices.net",
+            port=8883,
+            protocol=4,
+            qos=0,
+            retain=False,
+            client_id="device-id",
+        )
+
+        assert outcome is True
+        assert (
+            "Publishing to Azure IoT Hub for target=test (device-id): devices/device-id/messages/events/ 'b'### Notification message ###''"
+            in caplog.text
+        )
+
+
+def test_azure_iot_failure_wrong_qos(srv, caplog):
+
+    item = Item(
+        config={"iothubname": "acmehub", "qos": 999},
+        target="test",
+        addrs=["device-id", "SharedAccessSignature sr=..."],
+        message="⚽ Notification message ⚽",
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/azure_iot.py")
+
+        outcome = module.plugin(srv, item)
+
+        assert outcome is False
+        assert "Only QoS 0 or 1 allowed for Azure IoT Hub, not '999'" in caplog.text
+
+
+def test_azure_iot_failure_invalid_message(srv, caplog):
+
+    item = Item(
+        config={"iothubname": "acmehub"},
+        target="test",
+        addrs=["device-id", "SharedAccessSignature sr=..."],
+    )
+
+    with mock.patch.object(Item, "message", new_callable=PropertyMock) as msg_mock:
+        msg_mock.side_effect = Exception("something failed")
+
+        with caplog.at_level(logging.DEBUG):
+
+            module = load_module_from_file("mqttwarn/services/azure_iot.py")
+
+            outcome = module.plugin(srv, item)
+
+            assert outcome is False
+            assert (
+                "Unable to prepare message for target=test: something failed"
+                in caplog.text
+            )
+
+
+def test_azure_iot_failure_mqtt_publish(srv, caplog):
+
+    item = Item(
+        config={"iothubname": "acmehub"},
+        target="test",
+        addrs=["device-id", "SharedAccessSignature sr=..."],
+        message="⚽ Notification message ⚽",
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/azure_iot.py")
+
+        mqtt_publish_mock = mock.MagicMock(side_effect=Exception("something failed"))
+        module.mqtt.single = mqtt_publish_mock
+
+        outcome = module.plugin(srv, item)
+
+        assert outcome is False
+        assert (
+            "Unable to publish to Azure IoT Hub for target=test (device-id): something failed"
+            in caplog.text
+        )
+
+
+def test_carbon_success_metric_value_timestamp(srv, caplog):
+
+    item = Item(
+        target="test", addrs=["localhost", 2003], message="foo 42.42 1623887596", data={}
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/carbon.py")
+
+        socket_mock = mock.MagicMock()
+        module.socket.socket = socket_mock
+
+        outcome = module.plugin(srv, item)
+        assert socket_mock.mock_calls == [
+            call(),
+            call().connect(("localhost", 2003)),
+            call().sendall("foo 42.42 1623887596\n"),
+            call().close(),
+        ]
+
+        assert outcome is True
+        assert "Sending to carbon: foo 42.42 1623887596" in caplog.text
+
+
+def test_carbon_success_metric_value(srv, caplog):
+
+    item = Item(
+        target="test", addrs=["localhost", 2003], message="foo 42.42", data={}
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/carbon.py")
+
+        socket_mock = mock.MagicMock()
+        module.socket.socket = socket_mock
+
+        outcome = module.plugin(srv, item)
+        assert socket_mock.mock_calls == [
+            call(),
+            call().connect(("localhost", 2003)),
+            call().sendall(mock.ANY),
+            call().close(),
+        ]
+
+        assert outcome is True
+        assert "Sending to carbon: foo 42.42" in caplog.text
+
+
+def test_carbon_success_value(srv, caplog):
+
+    item = Item(
+        target="test", addrs=["localhost", 2003], message="42.42", data={}
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/carbon.py")
+
+        socket_mock = mock.MagicMock()
+        module.socket.socket = socket_mock
+
+        outcome = module.plugin(srv, item)
+        assert socket_mock.mock_calls == [
+            call(),
+            call().connect(("localhost", 2003)),
+            call().sendall(mock.ANY),
+            call().close(),
+        ]
+
+        assert outcome is True
+        assert "Sending to carbon: ohno 42.42" in caplog.text
+
+
+def test_carbon_success_value_metric_from_topic(srv, caplog):
+
+    item = Item(
+        target="test", addrs=["localhost", 2003], message="42.42", data={"topic": "foo/bar"}
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/carbon.py")
+
+        socket_mock = mock.MagicMock()
+        module.socket.socket = socket_mock
+
+        outcome = module.plugin(srv, item)
+        assert socket_mock.mock_calls == [
+            call(),
+            call().connect(("localhost", 2003)),
+            call().sendall(mock.ANY),
+            call().close(),
+        ]
+
+        assert outcome is True
+        assert "Sending to carbon: foo.bar 42.42" in caplog.text
+
+
+def test_carbon_success_value_metric_from_topic_with_leading_slash(srv, caplog):
+
+    item = Item(
+        target="test", addrs=["localhost", 2003], message="42.42", data={"topic": "/foo/bar"}
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/carbon.py")
+
+        socket_mock = mock.MagicMock()
+        module.socket.socket = socket_mock
+
+        outcome = module.plugin(srv, item)
+        assert socket_mock.mock_calls == [
+            call(),
+            call().connect(("localhost", 2003)),
+            call().sendall(mock.ANY),
+            call().close(),
+        ]
+
+        assert outcome is True
+        assert "Sending to carbon: foo.bar 42.42" in caplog.text
+
+
+def test_carbon_failure_invalid_configuration(srv, caplog):
+
+    item = Item(target="test", addrs=["172.16.153.110", "foobar"])
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/carbon.py")
+
+        outcome = module.plugin(srv, item)
+
+        assert outcome is False
+        assert "Configuration for target `carbon' is incorrect" in caplog.text
+
+
+def test_carbon_failure_empty_message(srv, caplog):
+
+    item = Item(target="test", addrs=["172.16.153.110", 2003])
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/carbon.py")
+
+        outcome = module.plugin(srv, item)
+
+        assert outcome is False
+        assert "target `carbon': cannot split string" in caplog.text
+
+
+def test_carbon_failure_invalid_message_format(srv, caplog):
+
+    item = Item(
+        target="test",
+        addrs=["172.16.153.110", 2003],
+        message="foo bar baz qux",
+        data={},
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/carbon.py")
+
+        outcome = module.plugin(srv, item)
+
+        assert outcome is False
+        assert "target `carbon': error decoding message" in caplog.text
+
+
+def test_carbon_failure_connect(srv, caplog):
+
+    item = Item(
+        target="test", addrs=["localhost", 2003], message="foo 42.42 1623887596", data={}
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_from_file("mqttwarn/services/carbon.py")
+
+        attrs = {"connect.side_effect": Exception("something failed")}
+        socket_mock = mock.MagicMock()
+        socket_mock.return_value = mock.MagicMock(**attrs)
+        module.socket.socket = socket_mock
+
+        outcome = module.plugin(srv, item)
+        assert socket_mock.mock_calls == [call(), call().connect(("localhost", 2003))]
+
+        assert outcome is False
+        assert "Sending to carbon: foo 42.42 1623887596" in caplog.text
+        assert (
+            "Cannot send to carbon service localhost:2003: something failed"
+            in caplog.text
+        )

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
-# (c) 2018 The mqttwarn developers
+# (c) 2018-2021 The mqttwarn developers
 import time
+from dataclasses import dataclass
+from typing import Dict, Union, List
+
 from paho.mqtt.client import MQTTMessage
 
 from mqttwarn.configuration import load_configuration
@@ -38,3 +41,19 @@ def send_message(topic=None, payload=None):
 
     # Give the machinery some time to process the message
     time.sleep(0.05)
+
+
+@dataclass
+class ProcessorItem:
+    """
+    A surrogate processor item for feeding into service handlers.
+    """
+
+    service: str = None
+    target: str = None
+    config: Dict = None
+    addrs: List[str] = None
+    topic: str = None
+    title: str = None
+    message: Union[str, bytes] = None
+    data: Dict = None

--- a/tests/util.py
+++ b/tests/util.py
@@ -53,6 +53,7 @@ class ProcessorItem:
     target: str = None
     config: Dict = None
     addrs: List[str] = None
+    priority: int = None
     topic: str = None
     title: str = None
     message: Union[str, bytes] = None


### PR DESCRIPTION
Hi there,

this patch starts adding software tests for all service plugins.

The tests will not be integration tests, all domain-specific outbound calls or libraries will be mocked instead. Modulo that detail, we aim for 100% test coverage. More work will have to go into this endeavor, currently only 11% of all plugins are being tested.

While adding some tests, minor issues with individual service plugins have been fixed. At the same time, this patch drops official support for Python 2.

With kind regards,
Andreas.
