### PR TITLE
Improve machinery to launch a notification service plugin standalone

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ in progress
 
 - Rename repository default branch to "main"
 - Fix "http" service plugin
+- Improve machinery to launch a notification service plugin standalone.
+  Now, it works without any ``mqttwarn.ini`` configuration file at all.
 
 2021-06-12 0.24.0
 =================

--- a/README.rst
+++ b/README.rst
@@ -154,9 +154,12 @@ To supply a different configuration file or log file, optionally use::
 
 Running notification plugins
 ============================
-For debugging or other purposes, you might want to directly run a notification plugin
-without the dispatching and transformation machinery of *mqttwarn*.
-We have you covered, just try this to launch the plugin standalone by passing essential information using JSON::
+For debugging, or other purposes, you might want to directly run an individual
+notification plugin without the dispatching and transformation machinery of
+*mqttwarn*.
+
+We have you covered. To launch a plugin standalone, those commands will give
+you an idea how to pass relevant information on the command line using JSON::
 
     # Launch "log" service plugin
     mqttwarn --plugin=log --data='{"message": "Hello world", "addrs": ["crit"]}'
@@ -164,8 +167,10 @@ We have you covered, just try this to launch the plugin standalone by passing es
     # Launch "file" service plugin
     mqttwarn --plugin=file --data='{"message": "Hello world\n", "addrs": ["/tmp/mqttwarn.err"]}'
 
+    # Launch "pushover" service plugin
+    mqttwarn --plugin=pushover --data='{"title": "About", "message": "Hello world", "addrs": ["userkey", "token"], "priority": 6}'
 
-Please note this feature is a work in progress, so expect there to be dragons.
+The ``--config`` parameter can be used to optionally specify a configuration file.
 
 
 Running as system daemon

--- a/mqttwarn/configuration.py
+++ b/mqttwarn/configuration.py
@@ -26,16 +26,19 @@ class Config(RawConfigParser):
             'NONE'  : None,
         }
 
-    def __init__(self, configuration_file, defaults=None):
+    def __init__(self, configuration_file=None, defaults=None):
 
         defaults = defaults or {}
 
-        RawConfigParser.__init__(self)
-        f = codecs.open(configuration_file, 'r', encoding='utf-8')
-        self.read_file(f)
-        f.close()
+        self.configuration_path = None
 
-        self.configuration_path = os.path.dirname(configuration_file)
+        RawConfigParser.__init__(self)
+        if configuration_file is not None:
+            f = codecs.open(configuration_file, 'r', encoding='utf-8')
+            self.read_file(f)
+            f.close()
+
+            self.configuration_path = os.path.dirname(configuration_file)
 
         ''' set defaults '''
         self.hostname     = 'localhost'
@@ -48,8 +51,8 @@ class Config(RawConfigParser):
         self.cleansession = False
         self.protocol     = 3
 
-        self.logformat    = '%(asctime)-15s %(levelname)-8s [%(name)-25s] %(message)s'
-        self.logfile      = None
+        self.logformat    = '%(asctime)-15s %(levelname)-8s [%(name)-26s] %(message)s'
+        self.logfile      = "stream://sys.stderr"
         self.loglevel     = 'DEBUG'
 
         self.functions    = None
@@ -170,7 +173,7 @@ class Config(RawConfigParser):
             Cannot use config.items() because I want each value to be
             retrieved with g() as above '''
 
-        d = None
+        d = {}
         if self.has_section(section):
             d = dict((key, self.g(section, key))
                 for (key) in self.options(section) if key not in ['targets', 'module'])
@@ -183,7 +186,7 @@ def load_configuration(configfile=None, name='mqttwarn'):
         configfile = os.getenv(name.upper() + 'INI', name + '.ini')
 
     if not os.path.exists(configfile):
-        raise ValueError('Configuration file "{}" does not exist'.format(configfile))
+        raise FileNotFoundError('Configuration file "{}" does not exist'.format(configfile))
 
     defaults = {
         'clientid': name,

--- a/mqttwarn/core.py
+++ b/mqttwarn/core.py
@@ -751,3 +751,5 @@ def run_plugin(config=None, name=None, data=None):
     module = service_plugins[name]['module']
     response = module.plugin(srv, item)
     logger.info('Plugin response: {}'.format(response))
+    if response is False:
+        sys.exit(1)


### PR DESCRIPTION
Hi again,

when writing down #526, I discovered:

> For this to work, you will still have to configure a `[config:pushover]` section within your `mqttwarn.ini`.

With this patch, launching a service plugin from the command line for development or other purposes no longer needs a `mqttwarn.ini` configuration file, but uses the default settings instead. That was actually the original intention of 8596c14, but it apparently hasn't come so far yet.

Now, this will also work:
```shell
mqttwarn --plugin=pushover --data='{"title": "About", "message": "Hello world", "addrs": ["userkey", "token"], "priority": 6}'
```

If you still want to use a configuration file, you can use the `--config` parameter.

With kind regards,
Andreas.
