### PR TITLE
When title is not set in configuration settings, use "mqttwarn: {topic}"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ mqttwarn changelog
 in progress
 ===========
 
+- When title is not set in configuration settings, use ``mqttwarn: {topic}``
+  instead of ``mqttwarn`` only. Thanks, Rob!
+
 
 2021-06-18 0.25.0
 =================

--- a/mqttwarn/core.py
+++ b/mqttwarn/core.py
@@ -470,7 +470,8 @@ def processor(worker_id=None):
         transform_data = job.data
         item['data'] = dict(list(transform_data.items()))
 
-        item['title'] = xform(context.get_config(section, 'title'), SCRIPTNAME, transform_data)
+        origin_title = "{}: {}".format(SCRIPTNAME, topic)
+        item['title'] = xform(context.get_config(section, 'title'), origin_title, transform_data)
         item['image'] = xform(context.get_config(section, 'image'), '', transform_data)
         item['message'] = xform(context.get_config(section, 'format'), job.payload, transform_data)
 


### PR DESCRIPTION
Hi there,

this patch implements the outcome from the discussion of @robdejonge with @jpmens happening at #333 the other day. Now, when no title is defined in the configuration settings, `mqttwarn: {topic}` will be used as default value.

With kind regards,
Andreas.