### PR TITLE
Use STDERR as default log target

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ in progress
 - When title is not set in configuration settings, use ``mqttwarn: {topic}``
   instead of ``mqttwarn`` only. Thanks, Rob!
 - Add launch configuration for VSCode. Thanks, David!
+- Use STDERR as default log target
 
 
 2021-06-18 0.25.0

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -110,9 +110,19 @@ I've written an introductory post, explaining [what mqttwarn can be used for](ht
   cleansession = False
   
   ; logging
+
+  ; Log format
   logformat = '%(asctime)-15s %(levelname)-5s [%(module)s] %(message)s'
-  logfile   = 'mqttwarn.log'
+
+  ; Send log to STDERR (default)
+  logfile   = 'stream://sys.stderr'
   
+  ; Write log output to file
+  ; logfile   = 'mqttwarn.log'
+
+  ; Turn off logging completely
+  ; logfile   = false
+
   ; one of: CRITICAL, DEBUG, ERROR, INFO, WARN
   loglevel     = DEBUG
   

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,5 +5,9 @@ coverage:
   status:
     project:
       default:
-        target: 14%    # the required coverage value
-        threshold: 3%  # the leniency in hitting the target
+        target: auto   # the required coverage value
+        threshold: 4%  # the leniency in hitting the target
+    patch:
+      default:
+        target: 0%
+        informational: true

--- a/mqttwarn/commands.py
+++ b/mqttwarn/commands.py
@@ -130,7 +130,10 @@ def setup_logging(config):
     LOGFORMAT = config.logformat
 
     # Send log messages to sys.stderr by configuring "logfile = stream://sys.stderr"
-    if LOGFILE.startswith('stream://'):
+    if not LOGFILE:
+        pass
+
+    elif LOGFILE.startswith('stream://'):
         LOGFILE = LOGFILE.replace('stream://', '')
         logging.basicConfig(stream=eval(LOGFILE), level=LOGLEVEL, format=LOGFORMAT)
 

--- a/mqttwarn/configuration.py
+++ b/mqttwarn/configuration.py
@@ -191,7 +191,6 @@ def load_configuration(configfile=None, name='mqttwarn'):
     defaults = {
         'clientid': name,
         'lwt': 'clients/{}'.format(name),
-        'logfile': os.getenv(name.upper() + 'LOG', name + '.log'),
     }
 
     return Config(configfile, defaults=defaults)


### PR DESCRIPTION
Hi there,

after reviewing the current state of the onion, following up on a conversation with @ktaragorn at #439, I found that STDERR was not selected as a default log target yet.

Because I think this is reasonable, in general and in the context of #526, this patch accounts for this and makes `logfile = 'stream://sys.stderr'` the default option. At the same time, it adds an option to turn off logging completely by using `logfile = false`.

With kind regards,
Andreas.

/cc @psyciknz 