### PR TITLE
Stop including the "tests" folder into the sdist package

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ in progress
   instead of ``mqttwarn`` only. Thanks, Rob!
 - Add launch configuration for VSCode. Thanks, David!
 - Use STDERR as default log target
+- Stop including the "tests" folder into the sdist package
 
 
 2021-06-18 0.25.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,5 @@ exclude .bumpversion.cfg
 recursive-include mqttwarn *.ini *.py
 prune examples
 prune vendor
+prune templates
+prune tests


### PR DESCRIPTION
Hi there,

this patch fixes a flaw with packaging.

Beforehand, the `tests` folder was included into the sdist package and, afterwards, was installed into the top-level directory under "site-packages", which is definitively a misbehaviour.

With kind regards,
Andreas.
