### PR TITLE
Add "mqttwarn-contrib" package to the list of "extra" dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ in progress
 - Add launch configuration for VSCode. Thanks, David!
 - Use STDERR as default log target
 - Stop including the "tests" folder into the sdist package
+- Add "mqttwarn-contrib" package to the list of "extra" dependencies
 
 
 2021-06-18 0.25.0

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,11 @@ extras = {
     'slixmpp': [
         'slixmpp>=1.5.2',
     ],
+    # More notification plugins from the community.
+    # https://github.com/daq-tools/mqttwarn-contrib
+    'contrib': [
+        'mqttwarn-contrib',
+    ],
 }
 
 


### PR DESCRIPTION
Hi again,

#506 and #509 improved the packaging pipeline to build Docker images in two variants: `mqttwarn-standard` vs. `mqttwarn-full`. In this manner, when operating mqttwarn in Docker environments, we found a way to better support the community running custom installations of mqttwarn, without sacrificing the slimness of a regular mqttwarn installation in any way.

Now, by introducing the [mqttwarn-contrib] package (#435), this situation can be further improved by including this package into the list of optional ("extra") dependencies.

By doing this, the package will also be installed into the `mqttwarn-full` Docker image, thus making operating mqttwarn with
custom extensions on Docker-compatible environments way easier.

With kind regards,
Andreas.

[mqttwarn-contrib]: https://github.com/daq-tools/mqttwarn-contrib

/cc @psyciknz 