### PR TITLE
Improve launching service plugins interactively from the command line

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ in progress
 - Use STDERR as default log target
 - Stop including the "tests" folder into the sdist package
 - Add "mqttwarn-contrib" package to the list of "extra" dependencies
+- Improve launching service plugins interactively from the command line
+  Now, there are two options "--config" and "--options" to be able to
+  obtain all relevant bits of information from the command line.
 
 
 2021-06-18 0.25.0

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -638,9 +638,10 @@ targets  = {
     'speaker' : ['Living Room'],
     }
 
+# Command line test
+# mqttwarn --plugin=chromecast --options='{"message": "Hello world", "addrs": ["Living Room"]}'
 # echo 'Hello world' | mosquitto_pub -t 'chromecast/say' -l
 # echo '{"message": "Hello world", "addrs": ["Living Room"]}' | mosquitto_pub -t 'chromecast/say' -l
-# command line test;  mqttwarn --plugin=chromecast --data='{"message": "Hello world", "addrs": ["Living Room"]}'
 [chromecast/say]
 targets = chromecast:speaker
 

--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,9 @@ you an idea how to pass relevant information on the command line using JSON::
     # Launch "pushover" service plugin
     mqttwarn --plugin=pushover --options='{"title": "About", "message": "Hello world", "addrs": ["userkey", "token"], "priority": 6}'
 
+    # Launch "ssh" service plugin from the command line
+    mqttwarn --plugin=ssh --config='{"host": "ssh.example.org", "port": 22, "user": "foo", "password": "bar"}' --options='{"addrs": ["command with substitution %s"], "payload": "{\"args\": \"192.168.0.1\"}"}'
+
     # Launch "cloudflare_zone" service plugin from "mqttwarn-contrib", passing "--config" parameters via command line
     mqttwarn --plugin=mqttwarn_contrib.services.cloudflare_zone --config='{"auth-email": "foo", "auth-key": "bar"}' --options='{"addrs": ["0815", "www.example.org", ""], "message": "192.168.0.1"}'
 

--- a/README.rst
+++ b/README.rst
@@ -162,15 +162,20 @@ We have you covered. To launch a plugin standalone, those commands will give
 you an idea how to pass relevant information on the command line using JSON::
 
     # Launch "log" service plugin
-    mqttwarn --plugin=log --data='{"message": "Hello world", "addrs": ["crit"]}'
+    mqttwarn --plugin=log --options='{"message": "Hello world", "addrs": ["crit"]}'
 
     # Launch "file" service plugin
-    mqttwarn --plugin=file --data='{"message": "Hello world\n", "addrs": ["/tmp/mqttwarn.err"]}'
+    mqttwarn --plugin=file --options='{"message": "Hello world\n", "addrs": ["/tmp/mqttwarn.err"]}'
 
     # Launch "pushover" service plugin
-    mqttwarn --plugin=pushover --data='{"title": "About", "message": "Hello world", "addrs": ["userkey", "token"], "priority": 6}'
+    mqttwarn --plugin=pushover --options='{"title": "About", "message": "Hello world", "addrs": ["userkey", "token"], "priority": 6}'
 
-The ``--config`` parameter can be used to optionally specify a configuration file.
+    # Launch "cloudflare_zone" service plugin from "mqttwarn-contrib", passing "--config" parameters via command line
+    mqttwarn --plugin=mqttwarn_contrib.services.cloudflare_zone --config='{"auth-email": "foo", "auth-key": "bar"}' --options='{"addrs": ["0815", "www.example.org", ""], "message": "192.168.0.1"}'
+
+
+Also, the ``--config-file`` parameter can be used to optionally specify the
+path to a configuration file.
 
 
 Running as system daemon

--- a/README.rst
+++ b/README.rst
@@ -174,6 +174,7 @@ you an idea how to pass relevant information on the command line using JSON::
     mqttwarn --plugin=ssh --config='{"host": "ssh.example.org", "port": 22, "user": "foo", "password": "bar"}' --options='{"addrs": ["command with substitution %s"], "payload": "{\"args\": \"192.168.0.1\"}"}'
 
     # Launch "cloudflare_zone" service plugin from "mqttwarn-contrib", passing "--config" parameters via command line
+    pip install mqttwarn-contrib
     mqttwarn --plugin=mqttwarn_contrib.services.cloudflare_zone --config='{"auth-email": "foo", "auth-key": "bar"}' --options='{"addrs": ["0815", "www.example.org", ""], "message": "192.168.0.1"}'
 
 

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -50,7 +50,7 @@ Goals for 0.21.0
 Goals for 1.0.0
 ***************
 - [o] Make mqttwarn completely unicode-safe
-- [o] Make "mqttwarn --plugin=log --data=" obtain JSON data from STDIN
+- [o] Make "mqttwarn --plugin=log --options=" obtain JSON data from STDIN
 - [o] Translate documentation into reStructuredText format,
       render it using Sphinx and optionally publish to readthedocs.org.
 - [o] Add support for Python 3

--- a/mqttwarn/configuration.py
+++ b/mqttwarn/configuration.py
@@ -124,7 +124,7 @@ class Config(RawConfigParser):
     def g(self, section, key, default=None):
         try:
             val = self.get(section, key)
-            if val.upper() in self.specials:
+            if isinstance(val, str) and val.upper() in self.specials:
                 return self.specials[val.upper()]
             return ast.literal_eval(val)
         except NoOptionError:

--- a/mqttwarn/core.py
+++ b/mqttwarn/core.py
@@ -713,7 +713,7 @@ def bootstrap(config=None, scriptname=None):
         SCRIPTNAME = scriptname
 
 
-def run_plugin(config=None, name=None, data=None):
+def run_plugin(config=None, name=None, options=None):
     """
     Run service plugins directly without the
     dispatching and transformation machinery.
@@ -723,9 +723,9 @@ def run_plugin(config=None, name=None, data=None):
     the innards of mqttwarn interact so it might also please
     newcomers as a "learning the guts of mqttwarn" example.
 
-    :param config: The configuration object
-    :param name:   The name of the service plugin, e.g. "log" or "file"
-    :param data:   The data to be converged into an appropriate item Struct object instance
+    :param config:   The configuration object
+    :param name:     The name of the service plugin, e.g. "log" or "file"
+    :param options:  The data to be converged into an appropriate item Struct object instance
     """
 
     # Bootstrap mqttwarn core
@@ -741,7 +741,7 @@ def run_plugin(config=None, name=None, data=None):
     srv = make_service(mqttc=None, name=service_logger_name)
 
     # Build a mimikry item instance for feeding to the service plugin
-    item = Struct(**data)
+    item = Struct(**options)
     # TODO: Read configuration optionally from data.
     item.config = config.config('config:' + name)
     item.service = srv

--- a/mqttwarn/services/ssh.py
+++ b/mqttwarn/services/ssh.py
@@ -68,7 +68,7 @@ def plugin(srv, item):
         _, stdout, stderr = ssh.exec_command(command)
 
     except Exception as e:
-        srv.logging.warning("Cannot run command %s on host %s" % (command, host))
+        srv.logging.warning("Cannot run command '%s' on host '%s'" % (command, host))
         srv.logging.warning("%s" % e)
         return False
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,33 @@
+import os
+
+
+def test_command_dump_config(capfd):
+
+    command = "mqttwarn make-config"
+
+    os.system(command)
+    stdout = capfd.readouterr().out
+
+    assert 'mqttwarn example configuration file "mqttwarn.ini"' in stdout, stdout
+
+
+def test_command_dump_samplefuncs(capfd):
+
+    command = "mqttwarn make-samplefuncs"
+
+    os.system(command)
+    stdout = capfd.readouterr().out
+
+    assert '# mqttwarn example function extensions' in stdout, stdout
+
+
+def test_command_standalone_plugin(capfd):
+
+    command = """mqttwarn --plugin=log --options='{"message": "Hello world", "addrs": ["crit"]}'"""
+
+    os.system(command)
+    stderr = capfd.readouterr().err
+
+    assert 'Successfully loaded service "log"' in stderr, stderr
+    assert 'Hello world' in stderr, stderr
+    assert 'Plugin response: True' in stderr, stderr

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,4 +1,7 @@
 import os
+import sys
+
+import pytest
 
 
 def test_command_dump_config(capfd):
@@ -22,6 +25,10 @@ def test_command_dump_samplefuncs(capfd):
 
 
 def test_command_standalone_plugin(capfd):
+
+    # FIXME: Make it work on Windows.
+    if sys.platform.startswith("win"):
+        raise pytest.xfail("Skipping test, fails on Windows")
 
     command = """mqttwarn --plugin=log --options='{"message": "Hello world", "addrs": ["crit"]}'"""
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -40,7 +40,7 @@ def send_message(topic=None, payload=None):
     on_message(None, None, message)
 
     # Give the machinery some time to process the message
-    time.sleep(0.05)
+    time.sleep(0.10)
 
 
 @dataclass


### PR DESCRIPTION
Hi,

some people, including me, enjoy to [run notification plugins interactively](https://github.com/jpmens/mqttwarn/blob/main/README.rst#running-notification-plugins).

Unfortunately, some service plugins need section-wide top-level configuration settings and there was currently no way to obtain them from the command line. I reported that flaw at https://github.com/jpmens/mqttwarn/issues/526#issuecomment-864408942.

This patch improves the situation. Now, there are two options `--config` and `--options` to be able to obtain all relevant bits of information from the command line.

Those two examples will demonstrate how this works.
```shell
# Launch "ssh" service plugin from the command line
mqttwarn \
    --plugin=ssh \
    --config='{"host": "ssh.example.org", "port": 22, "user": "foo", "password": "bar"}' \
    --options='{"addrs": ["command with substitution %s"], "payload": "{\"args\": \"192.168.0.1\"}"}'

# Launch "cloudflare_zone" service plugin from "mqttwarn-contrib"
pip install mqttwarn-contrib
mqttwarn \
    --plugin=mqttwarn_contrib.services.cloudflare_zone \
    --config='{"auth-email": "foo", "auth-key": "bar"}' \
    --options='{"addrs": ["0815", "www.example.org", ""], "message": "192.168.0.1"}'
```

With kind regards,
Andreas.
