### PR TITLE
Make parts of the test infrastructure reusable

### DIFF
--- a/mqttwarn/model.py
+++ b/mqttwarn/model.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# (c) 2021 The mqttwarn developers
+from dataclasses import dataclass
+from typing import Dict, List, Union
+
+
+@dataclass
+class ProcessorItem:
+    """
+    A processor item for feeding information into service handlers.
+    """
+
+    service: str = None
+    target: str = None
+    config: Dict = None
+    addrs: List[str] = None
+    priority: int = None
+    topic: str = None
+    title: str = None
+    message: Union[str, bytes] = None
+    data: Dict = None

--- a/mqttwarn/testing/fixtures.py
+++ b/mqttwarn/testing/fixtures.py
@@ -1,0 +1,14 @@
+import logging
+
+import pytest
+
+from mqttwarn.core import Service
+
+
+@pytest.fixture
+def mqttwarn_service():
+    """
+    A service instance for propagating to the plugin.
+    """
+    logger = logging.getLogger(__name__)
+    return Service(mqttc=None, logger=logger)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,2 @@
-import logging
-
-import pytest
-
-from mqttwarn.core import Service
-
-
-@pytest.fixture
-def srv():
-    """
-    A service instance for propagating to the plugin.
-    """
-    logger = logging.getLogger(__name__)
-    return Service(mqttc=None, logger=logger)
+# Import fixtures
+from mqttwarn.testing.fixtures import mqttwarn_service as srv  # noqa

--- a/tests/test_pushover.py
+++ b/tests/test_pushover.py
@@ -7,7 +7,7 @@ import responses
 from requests_toolbelt import MultipartDecoder
 
 from mqttwarn.util import load_module_from_file
-from tests.util import ProcessorItem as Item
+from mqttwarn.model import ProcessorItem as Item
 
 
 def add_successful_mock_response():

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -7,7 +7,7 @@ from unittest.mock import call, PropertyMock
 from surrogate import surrogate
 
 from mqttwarn.util import load_module_by_name, load_module_from_file
-from tests.util import ProcessorItem as Item
+from mqttwarn.model import ProcessorItem as Item
 
 
 def test_alexa_notify_me_success(srv, caplog):

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) 2018-2021 The mqttwarn developers
 import time
-from dataclasses import dataclass
-from typing import Dict, Union, List
 
 from paho.mqtt.client import MQTTMessage
 
@@ -41,20 +39,3 @@ def send_message(topic=None, payload=None):
 
     # Give the machinery some time to process the message
     time.sleep(0.10)
-
-
-@dataclass
-class ProcessorItem:
-    """
-    A surrogate processor item for feeding into service handlers.
-    """
-
-    service: str = None
-    target: str = None
-    config: Dict = None
-    addrs: List[str] = None
-    priority: int = None
-    topic: str = None
-    title: str = None
-    message: Union[str, bytes] = None
-    data: Dict = None


### PR DESCRIPTION
Hi again,

this refactors parts of the testing code to make it more reusable. In that manner, the relevant code has not to be duplicated into "mqttwarn-contrib".

With kind regards,
Andreas.
