### PR TITLE
Fix HTTP basic authentication for Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,13 @@ in progress
 ===========
 
 
+2021-09-29 0.26.2
+=================
+
+- Fix HTTP basic authentication for Python 3 in plugins for HTTP, XBMC and Ionic.
+  Thanks, @sumnerboy12!
+
+
 2021-06-19 0.26.1
 =================
 

--- a/mqttwarn/services/http_urllib.py
+++ b/mqttwarn/services/http_urllib.py
@@ -27,10 +27,11 @@ def plugin(srv, item):
     params = item.addrs[2]
     timeout = item.config.get('timeout', 60)
 
-    auth = None
+    basicauth_token = None
     try:
         username, password = item.addrs[3]
-        auth = base64.encodestring('%s:%s' % (username, password)).replace('\n', '')
+        credentials = '%s:%s' % (username, password)
+        basicauth_token = base64.b64encode(credentials.encode('utf-8')).decode()
     except:
         pass
 
@@ -78,8 +79,8 @@ def plugin(srv, item):
 
             if srv.SCRIPTNAME is not None:
                 request.add_header('User-agent', srv.SCRIPTNAME)
-            if auth is not None:
-                request.add_header("Authorization", "Basic %s" % auth)
+            if basicauth_token is not None:
+                request.add_header("Authorization", "Basic %s" % basicauth_token)
 
             resp = urllib.request.urlopen(request, timeout=timeout)
             data = resp.read()
@@ -111,8 +112,8 @@ def plugin(srv, item):
 
             if srv.SCRIPTNAME is not None:
                 request.add_header('User-agent', srv.SCRIPTNAME)
-            if auth is not None:
-                request.add_header("Authorization", "Basic %s" % auth)
+            if basicauth_token is not None:
+                request.add_header("Authorization", "Basic %s" % basicauth_token)
 
             srv.logging.debug("before send")
             resp = urllib.request.urlopen(request, timeout=timeout)

--- a/mqttwarn/services/ionic.py
+++ b/mqttwarn/services/ionic.py
@@ -60,10 +60,13 @@ def plugin(srv, item):
         handler = urllib.request.HTTPHandler()
         opener = urllib.request.build_opener(handler)
 
+        credentials = '%s:' % (appsecret)
+        basicauth_token = base64.b64encode(credentials.encode('utf-8')).decode()
+
         data = json.dumps(data)
         request = urllib.request.Request(resource, data=data.encode("utf-8"))
         request.add_header('X-Ionic-Application-Id', appid)
-        request.add_header("Authorization", "Basic %s" % base64.encodestring('%s:' % appsecret).replace('\n', ''))
+        request.add_header("Authorization", "Basic %s" % basicauth_token)
         request.add_header("Content-Type", 'application/json')
 
         connection = opener.open(request, timeout=5)

--- a/mqttwarn/services/xbmc.py
+++ b/mqttwarn/services/xbmc.py
@@ -52,8 +52,8 @@ def plugin(srv, item):
         req.add_header("Content-type", "application/json")
         if xbmcpassword is not None:
             credentials = '%s:%s' % (xbmcusername, xbmcpassword)
-            base64string = base64.b64encode(credentials.encode('utf-8')).decode()
-            authheader = "Basic %s" % base64string
+            basicauth_token = base64.b64encode(credentials.encode('utf-8')).decode()
+            authheader = "Basic %s" % basicauth_token
             req.add_header("Authorization", authheader)
         response = urllib.request.urlopen(req, timeout = 2)
         srv.logging.debug("Successfully sent XBMC notification")


### PR DESCRIPTION
Hi there,

@sumnerboy12 already contributed #542 in order to fix an issue with missing compatibility for Python 3. This patch applies his fix to other plugins as well.

With kind regards,
Andreas.