### PR TITLE
Allow parameters of the "file" service to be defined on a per-file basis

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ in progress
 - CI: Run tests on Python 3.10
 - Allow parameters of the ``file`` service to be defined on a per-file basis.
   Thanks, @Gulaschcowboy!
+- Add software tests for ``file`` service.
 
 
 2021-09-29 0.26.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ in progress
 - IRCcat: Fix and improve service. Thanks, @JanKoppe.
 - IRCcat: Add newline character after message. Thanks again, @JanKoppe.
 - CI: Run tests on Python 3.10
+- Allow parameters of the ``file`` service to be defined on a per-file basis.
+  Thanks, @Gulaschcowboy!
 
 
 2021-09-29 0.26.2

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -814,9 +814,12 @@ Requires:
 
 ### `file`
 
-The `file` service can be used for logging incoming topics, archiving, etc. Each message is written to a path specified in the targets list. Note that files are opened for appending and then closed on each notification.
+The `file` service can be used for logging incoming topics, archiving, etc.
+Each message is written to a path specified in the targets list. Note that
+files are opened for appending and then closed on each notification.
 
-Supposing we wish to archive all incoming messages to the branch `arch/#` to a file `/data/arch`, we could configure the following:
+Supposing we wish to archive all incoming messages to the branch `arch/#`
+to a file `/data/arch`, we could configure the following:
 
 ```ini
 [config:file]
@@ -827,8 +830,21 @@ targets = {
    }
 ```
 
-If `append_newline` is True, a newline character is unconditionally appended to the string written to the file. If `overwrite` is True, the file is opened for truncation upon writing (i.e. the file will contain the last message only).
+If `append_newline` is `True`, a newline character is unconditionally appended
+to the string written to the file. If `overwrite` is `True`, the file is opened
+for truncation upon writing (i.e. the file will contain the last message only).
 
+Both parameters can also be specified on a per-file basis. In order to do that,
+the corresponding configuration snippet would look like this:
+
+```ini
+[config:file]
+targets = {
+    'log-me'    : {'path': '/data/arch', 'append_newline': True, 'overwrite': False},
+   }
+```
+
+Per-item parameters take precedence over global parameters.
 
 ### `freeswitch`
 

--- a/mqttwarn/services/file.py
+++ b/mqttwarn/services/file.py
@@ -40,7 +40,8 @@ def plugin(srv, item):
         filename = item.addrs[0].format(**item.data)
 
     # Interpolate some variables into filename.
-    filename = filename.replace("$TMPDIR", tempfile.gettempdir())
+    if "$TMPDIR" in filename:
+        filename = filename.replace("$TMPDIR", tempfile.gettempdir())
 
     srv.logging.info("Writing to file `%s'" % (filename))
 

--- a/setup.py
+++ b/setup.py
@@ -156,6 +156,7 @@ extras["test"] = [
     'dataclasses; python_version<"3.7"',
     'requests-toolbelt>=0.9.1,<1',
     'responses>=0.13.3,<1',
+    'pyfakefs>=4.5,<5',
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,12 @@
+import pytest
+
 # Import fixtures
 from mqttwarn.testing.fixtures import mqttwarn_service as srv  # noqa
+
+@pytest.fixture
+def fake_filesystem(fs):  # pylint:disable=invalid-name
+    try:
+        fs.create_dir("/tmp")
+    except:
+        pass
+    yield fs

--- a/tests/services/test_file.py
+++ b/tests/services/test_file.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+# (c) 2021 The mqttwarn developers
+import logging
+import os
+from unittest import mock
+
+import pytest as pytest
+
+import mqttwarn.services.file
+from mqttwarn.model import ProcessorItem as Item
+
+
+@pytest.mark.parametrize(
+    "item",
+    [
+        Item(
+            target="test",
+            addrs=["/tmp/testdrive.log"],
+            message="⚽ Notification message ⚽",
+            data={},
+        ),
+        Item(
+            target="test",
+            addrs={"path": "/tmp/testdrive.log"},
+            message="⚽ Notification message ⚽",
+            data={},
+        ),
+    ],
+    ids=["basic", "advanced"],
+)
+def test_file_success(fake_filesystem, srv, caplog, item):
+    """
+    Dispatch a single message and prove it is stored in the designated file.
+    """
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = mqttwarn.services.file
+        outcome = module.plugin(srv, item)
+        assert os.path.exists("/tmp/testdrive.log")
+
+        assert outcome is True
+        assert "Writing to file `/tmp/testdrive.log'" in caplog.messages
+        assert open("/tmp/testdrive.log", mode="r", encoding="utf-8").read() == "\u26bd Notification message \u26bd"
+
+
+@mock.patch("io.open", side_effect=Exception("something failed"))
+def test_file_failure(fake_filesystem, srv, caplog):
+    """
+    When `io.open` fails, prove that the corresponding error code path is
+    invoked.
+    """
+
+    item = Item(
+        target="test",
+        addrs=["/tmp/testdrive.log"],
+        message="⚽ Notification message ⚽",
+        data={},
+    )
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = mqttwarn.services.file
+
+        outcome = module.plugin(srv, item)
+        assert not os.path.exists("/tmp/testdrive.log")
+
+        assert outcome is False
+        assert (
+            "Cannot write to file `/tmp/testdrive.log': something failed"
+            in caplog.messages
+        )
+
+
+@pytest.mark.parametrize(
+    "item",
+    [
+        Item(
+            target="test",
+            addrs=["/tmp/testdrive.log"],
+            message="⚽ Notification message ⚽",
+            data={},
+            config={"append_newline": True},
+        ),
+        Item(
+            target="test",
+            addrs={"path": "/tmp/testdrive.log", "append_newline": True},
+            message="⚽ Notification message ⚽",
+            data={},
+        ),
+    ],
+    ids=["basic", "advanced"],
+)
+def test_file_append_newline_success(fake_filesystem, srv, caplog, item):
+    """
+    Dispatch **two** messages and prove they are **both** stored into the
+    designated file, seperated by a newline character.
+    """
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = mqttwarn.services.file
+        outcome1 = module.plugin(srv, item)
+        outcome2 = module.plugin(srv, item)
+        assert os.path.exists("/tmp/testdrive.log")
+
+        assert outcome1 is True
+        assert outcome2 is True
+        assert "Writing to file `/tmp/testdrive.log'" in caplog.messages
+        assert open("/tmp/testdrive.log", mode="r", encoding="utf-8").read() == "\u26bd Notification message \u26bd\n\u26bd Notification message \u26bd\n"
+
+
+@pytest.mark.parametrize(
+    "item",
+    [
+        Item(
+            target="test",
+            addrs=["/tmp/testdrive.log"],
+            message="⚽ Notification message ⚽",
+            data={},
+            config={"overwrite": True},
+        ),
+        Item(
+            target="test",
+            addrs={"path": "/tmp/testdrive.log", "overwrite": True},
+            message="⚽ Notification message ⚽",
+            data={},
+        ),
+    ],
+    ids=["basic", "advanced"],
+)
+def test_file_overwrite_success(fake_filesystem, srv, caplog, item):
+    """
+    Dispatch **two** messages and prove only **one** is stored into the
+    designated file, because the service has been configured with
+    `overwrite: True`.
+    """
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = mqttwarn.services.file
+        outcome1 = module.plugin(srv, item)
+        outcome2 = module.plugin(srv, item)
+        assert os.path.exists("/tmp/testdrive.log")
+
+        assert outcome1 is True
+        assert outcome2 is True
+        assert "Writing to file `/tmp/testdrive.log'" in caplog.messages
+        assert open("/tmp/testdrive.log", mode="r", encoding="utf-8").read() == "\u26bd Notification message \u26bd"


### PR DESCRIPTION
Hi there,

if this is actually correct, it will resolve #545, requested by @Gulaschcowboy. The patch will add the possibility to use an alternative configuration section for the `file` service, in order to have per-file parameters of `append_newline` and `overwrite`.

```ini
[config:file]
targets = {
    'f01'       : {'path': '/tmp/f.01', 'append_newline': True, 'overwrite': True},
    'log-me'    : ['/tmp/log.me'],
    'mqttwarn'  : ['/tmp/mqttwarn.err'],
    }
```

With kind regards,
Andreas.
