### PR TITLE
Update documentation

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -9,22 +9,22 @@ run it interactively, perhaps to help diagnose a problem.
 
 Docker images are automatically published to:
 
-- https://hub.docker.com/r/jpmens/mqttwarn
 - https://github.com/orgs/jpmens/packages/container/package/mqttwarn-standard
 - https://github.com/orgs/jpmens/packages/container/package/mqttwarn-full
+- ~~https://hub.docker.com/r/jpmens/mqttwarn~~ (not automatically updated)
 
 ## Choosing the Docker image
 
 Choose one of those Docker images.
 ```shell
-# The standard image on Docker Hub.
-export IMAGE=jpmens/mqttwarn
-
 # The standard image on GHCR.
 export IMAGE=ghcr.io/jpmens/mqttwarn-standard:latest
 
 # The full image on GHCR.
 export IMAGE=ghcr.io/jpmens/mqttwarn-full:latest
+
+# The standard image on Docker Hub.
+export IMAGE=jpmens/mqttwarn
 ```
 
 ## Interactively
@@ -157,7 +157,7 @@ images.
 
 In order to use `mqttwarn` with additional Python modules not included in the
 baseline image, you will need to build custom Docker images based on the
-canonical `jpmens/mqttwarn`.
+canonical `ghcr.io/jpmens/mqttwarn-standard:latest`.
 
 We prepared an example which outlines how this would work with the Slack SDK.
 By using the `Dockerfile.mqttwarn-slack`, this command will build a Docker
@@ -166,3 +166,11 @@ image called `mqttwarn-slack`, which includes the Slack SDK:
 ```shell
 docker build --tag=mqttwarn-slack --file=Dockerfile.mqttwarn-slack .
 ```
+
+## The "full" image, including all dependencies
+
+If you prefer not to fiddle with those details, but instead want to run a full
+image including dependencies for all modules, we have you covered. Alongside
+the standard image, there is also `ghcr.io/jpmens/mqttwarn-full:latest`.
+
+The `standard` image weighs in with about 130 MB, the `full` image has 230 MB.

--- a/README.rst
+++ b/README.rst
@@ -111,8 +111,13 @@ Container image
 ***************
 
 For running ``mqttwarn`` on a container infrastructure like Docker or
-Kubernetes, there are images on Docker Hub called ``jpmens/mqttwarn``.
-To read more about this topic, please follow up on the `Docker handbook`_.
+Kubernetes, corresponding images are automatically published to the
+GitHub Container Registry (GHCR).
+
+- ``ghcr.io/earthobservations/wetterdienst-standard:latest``
+- ``ghcr.io/earthobservations/wetterdienst-full:latest``
+
+To learn more about this topic, please follow up reading the `Docker handbook`_.
 
 
 *************

--- a/doc/sandbox.rst
+++ b/doc/sandbox.rst
@@ -17,6 +17,10 @@ Invoke software tests::
 
     make test
 
+Invoke software tests, with coverage::
+
+    make test-coverage
+
 Install extras::
 
     source .venv/bin/activate
@@ -31,7 +35,7 @@ You can also add multiple extras, all at once::
 Using VSCode
 ************
 
-To install the free, non-telemetry version of Microsoft VSCode::
+For installing the free, non-telemetry version of Microsoft VSCode, invoke::
 
     brew install --cask vscodium
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,11 +12,11 @@
 # 4. Define the location to the custom functions file within "mqttwarn.ini":
 #
 # functions = 'funcs.py'
-version: '3.7'
+version: '3'
 
 services:
   mqttwarn:
-    image: jpmens/mqttwarn
+    image: ghcr.io/jpmens/mqttwarn-full:latest
     container_name: mqttwarn
     restart: always
     volumes:


### PR DESCRIPTION
This patch is mostly about clarifying which is currently the recommended Docker image, until automatic publishing to Docker Hub will be implemented. See also #544.

/cc @jpmens, @sumnerboy12 