### PR TITLE
Improve Apprise notification machinery. Add `apprise_multi` plugin.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ in progress
 - ``apprise_single`` service: Accept omitted/empty `addrs` attribute.
 - ``apprise_single`` service: Improve query parameter serialization.
 - ``apprise_multi`` service: New plugin. Thanks, @psyciknz!
+  The idea behind this variant is to publish messages to different Apprise
+  plugins within a single configuration snippet, containing multiple recipients.
 
 
 2021-10-17 0.27.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,9 @@ in progress
   This helps for service plugins like Apprise to make the configuration
   snippet more compact. Now, service configurations can omit the ``targets``
   option altogether.
-- Apprise service: Accept omitted/empty `addrs` attribute.
-- Apprise service: Improve query parameter serialization.
+- ``apprise_single`` service: Accept omitted/empty `addrs` attribute.
+- ``apprise_single`` service: Improve query parameter serialization.
+- ``apprise_multi`` service: New plugin. Thanks, @psyciknz!
 
 
 2021-10-17 0.27.0

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -533,7 +533,7 @@ launch    = apprise-mail, apprise-json, apprise-discord
 [config:apprise-mail]
 ; Dispatch message as e-mail.
 ; https://github.com/caronc/apprise/wiki/Notify_email
-module   = 'apprise'
+module   = 'apprise_single'
 baseuri  = 'mailtos://smtp_username:smtp_password@mail.example.org'
 sender   = 'monitoring@example.org'
 sender_name = 'Example Monitoring'
@@ -544,7 +544,7 @@ targets  = {
 [config:apprise-json]
 ; Dispatch message to HTTP endpoint, in JSON format.
 ; https://github.com/caronc/apprise/wiki/Notify_Custom_JSON
-module   = 'apprise'
+module   = 'apprise_single'
 baseuri  = 'json://localhost:1234/mqtthook'
 
 [config:apprise-discord]

--- a/mqttwarn/model.py
+++ b/mqttwarn/model.py
@@ -12,7 +12,7 @@ class ProcessorItem:
 
     service: str = None
     target: str = None
-    config: Dict = None
+    config: Dict = field(default_factory=dict)
     addrs: List[str] = field(default_factory=list)
     priority: int = None
     topic: str = None

--- a/mqttwarn/services/apprise.py
+++ b/mqttwarn/services/apprise.py
@@ -1,0 +1,1 @@
+from mqttwarn.services.apprise_single import plugin

--- a/mqttwarn/services/apprise_multi.py
+++ b/mqttwarn/services/apprise_multi.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+__author__    = 'Andreas Motl <andreas.motl@panodata.org>'
+__copyright__ = 'Copyright 2021 Andreas Motl'
+__license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
+
+# https://github.com/caronc/apprise#developers
+from urllib.parse import urlencode
+from collections import OrderedDict
+
+import apprise
+
+
+def plugin(srv, item):
+    """Send a message to multiple Apprise plugins."""
+
+    srv.logging.debug("*** MODULE=%s: service=%s, target=%s", __file__, item.service, item.target)
+
+    addresses = item.addrs
+    title = item.title
+    body = item.message
+
+    try:
+        srv.logging.debug("Sending notification to Apprise. target=%s, addresses=%s" % (item.target, addresses))
+
+        # Create an Apprise instance.
+        apobj = apprise.Apprise(asset=apprise.AppriseAsset(async_mode=False))
+
+        for address in addresses:
+            baseuri = address["baseuri"]
+
+            # Collect URL parameters.
+            params = OrderedDict()
+
+            if "recipients" in address:
+                to = ','.join(address["recipients"])
+                if to:
+                    params["to"] = to
+
+            if "sender" in address:
+                params["from"] = address["sender"]
+            if "sender_name" in address:
+                params["name"] = address["sender_name"]
+
+            # Add notification services by server url.
+            uri = baseuri
+            if params:
+                uri += '?' + urlencode(params)
+            srv.logging.info("Adding notification to: {}".format(uri))
+            apobj.add(uri)
+
+        # Submit notification.
+        outcome = apobj.notify(
+            body=body,
+            title=title,
+        )
+
+        if outcome:
+            srv.logging.info("Successfully sent message using Apprise")
+            return True
+
+        else:
+            srv.logging.error("Sending message using Apprise failed")
+            return False
+
+    except Exception as e:
+        srv.logging.error("Sending message using Apprise failed. target=%s, error=%s" % (item.target, e))
+        return False

--- a/mqttwarn/services/apprise_single.py
+++ b/mqttwarn/services/apprise_single.py
@@ -12,7 +12,7 @@ import apprise
 
 
 def plugin(srv, item):
-    """Send a message to Apprise plugin(s)."""
+    """Send a message to a single Apprise plugin."""
 
     srv.logging.debug("*** MODULE=%s: service=%s, target=%s", __file__, item.service, item.target)
 
@@ -60,5 +60,5 @@ def plugin(srv, item):
             return False
 
     except Exception as e:
-        srv.logging.error("Error sending message to %s: %s" % (item.target, e))
+        srv.logging.error("Sending message using Apprise failed. target=%s, error=%s" % (item.target, e))
         return False

--- a/tests/acme/foobar.py
+++ b/tests/acme/foobar.py
@@ -1,3 +1,3 @@
 def plugin(srv, item):
     srv.logging.debug("*** MODULE=%s: service=%s, target=%s", __file__, item.service, item.target)
-    srv.logging.info("Plugin invoked.")
+    srv.logging.info("Plugin invoked")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import pytest
 # Import fixtures
 from mqttwarn.testing.fixtures import mqttwarn_service as srv  # noqa
 
+
 @pytest.fixture
 def fake_filesystem(fs):  # pylint:disable=invalid-name
     try:

--- a/tests/services/test_apprise_multi.py
+++ b/tests/services/test_apprise_multi.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+# (c) 2021 The mqttwarn developers
+import logging
+from unittest import mock
+from unittest.mock import call
+
+from mqttwarn.model import ProcessorItem as Item
+from mqttwarn.util import load_module_by_name
+from surrogate import surrogate
+
+
+@surrogate("apprise")
+@mock.patch("apprise.Apprise", create=True)
+@mock.patch("apprise.AppriseAsset", create=True)
+def test_apprise_multi_basic_success(apprise_asset, apprise_mock, srv, caplog):
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_by_name("mqttwarn.services.apprise_multi")
+
+        item = Item(
+            addrs=[
+                {"baseuri": "json://localhost:1234/mqtthook"},
+                {"baseuri": "json://daq.example.org:5555/foobar"},
+            ],
+            title="⚽ Message title ⚽",
+            message="⚽ Notification message ⚽",
+        )
+
+        outcome = module.plugin(srv, item)
+
+        assert apprise_mock.mock_calls == [
+            call(asset=mock.ANY),
+            call().add("json://localhost:1234/mqtthook"),
+            call().add("json://daq.example.org:5555/foobar"),
+            call().notify(body="⚽ Notification message ⚽", title="⚽ Message title ⚽"),
+            call().notify().__bool__(),
+        ]
+
+        assert outcome is True
+        assert (
+            "Sending notification to Apprise. target=None, addresses=[{'baseuri': 'json://localhost:1234/mqtthook'}, {'baseuri': 'json://daq.example.org:5555/foobar'}]"
+            in caplog.messages
+        )
+        assert "Successfully sent message using Apprise" in caplog.messages
+
+
+@surrogate("apprise")
+@mock.patch("apprise.Apprise", create=True)
+@mock.patch("apprise.AppriseAsset", create=True)
+def test_apprise_multi_mailto_success(apprise_asset, apprise_mock, srv, caplog):
+
+    with caplog.at_level(logging.DEBUG):
+
+        module = load_module_by_name("mqttwarn.services.apprise_multi")
+
+        item = Item(
+            addrs=[
+                {
+                    "baseuri": "mailtos://smtp_username:smtp_password@mail.example.org",
+                    "recipients": ["foo@example.org", "bar@example.org"],
+                    "sender": "monitoring@example.org",
+                    "sender_name": "Example Monitoring",
+                }
+            ],
+            title="⚽ Message title ⚽",
+            message="⚽ Notification message ⚽",
+        )
+
+        outcome = module.plugin(srv, item)
+
+        assert apprise_mock.mock_calls == [
+            call(asset=mock.ANY),
+            call().add(
+                "mailtos://smtp_username:smtp_password@mail.example.org?to=foo%40example.org%2Cbar%40example.org&from=monitoring%40example.org&name=Example+Monitoring"
+            ),
+            call().notify(body="⚽ Notification message ⚽", title="⚽ Message title ⚽"),
+            call().notify().__bool__(),
+        ]
+
+        assert outcome is True
+        assert (
+            "Sending notification to Apprise. target=None, addresses=[{'baseuri': 'mailtos://smtp_username:smtp_password@mail.example.org', 'recipients': ['foo@example.org', 'bar@example.org'], 'sender': 'monitoring@example.org', 'sender_name': 'Example Monitoring'}]"
+            in caplog.messages
+        )
+        assert "Successfully sent message using Apprise" in caplog.messages
+
+
+@surrogate("apprise")
+def test_apprise_multi_failure_notify(srv, caplog):
+
+    with caplog.at_level(logging.DEBUG):
+
+        mock_connection = mock.MagicMock()
+
+        # Make the call to `notify` signal failure.
+        def error(*args, **kwargs):
+            return False
+
+        mock_connection.notify = error
+
+        with mock.patch(
+            "apprise.Apprise", side_effect=[mock_connection], create=True
+        ) as mock_client:
+            with mock.patch("apprise.AppriseAsset", create=True) as mock_asset:
+                module = load_module_by_name("mqttwarn.services.apprise_multi")
+
+                item = Item(
+                    addrs=[{"baseuri": "json://localhost:1234/mqtthook"}],
+                    title="⚽ Message title ⚽",
+                    message="⚽ Notification message ⚽",
+                )
+
+                outcome = module.plugin(srv, item)
+
+                assert mock_client.mock_calls == [
+                    mock.call(asset=mock.ANY),
+                ]
+                assert mock_connection.mock_calls == [
+                    call.add("json://localhost:1234/mqtthook"),
+                ]
+
+                assert outcome is False
+                assert (
+                    "Sending notification to Apprise. target=None, addresses=[{'baseuri': 'json://localhost:1234/mqtthook'}]"
+                    in caplog.messages
+                )
+                assert "Sending message using Apprise failed" in caplog.messages
+
+
+@surrogate("apprise")
+def test_apprise_multi_error(srv, caplog):
+
+    with caplog.at_level(logging.DEBUG):
+
+        mock_connection = mock.MagicMock()
+
+        # Make the call to `notify` raise an exception.
+        def error(*args, **kwargs):
+            raise Exception("something failed")
+
+        mock_connection.notify = error
+
+        with mock.patch(
+            "apprise.Apprise", side_effect=[mock_connection], create=True
+        ) as mock_client:
+            with mock.patch("apprise.AppriseAsset", create=True) as mock_asset:
+                module = load_module_by_name("mqttwarn.services.apprise_multi")
+
+                item = Item(
+                    addrs=[{"baseuri": "json://localhost:1234/mqtthook"}],
+                    title="⚽ Message title ⚽",
+                    message="⚽ Notification message ⚽",
+                )
+
+                outcome = module.plugin(srv, item)
+
+                assert mock_client.mock_calls == [
+                    mock.call(asset=mock.ANY),
+                ]
+                assert mock_connection.mock_calls == [
+                    call.add("json://localhost:1234/mqtthook"),
+                ]
+
+                assert outcome is False
+                assert (
+                    "Sending notification to Apprise. target=None, addresses=[{'baseuri': 'json://localhost:1234/mqtthook'}]"
+                    in caplog.messages
+                )
+                assert (
+                    "Sending message using Apprise failed. target=None, error=something failed"
+                    in caplog.messages
+                )

--- a/tests/services/test_apprise_single.py
+++ b/tests/services/test_apprise_single.py
@@ -16,7 +16,7 @@ def test_apprise_success(apprise_asset, apprise_mock, srv, caplog):
 
     with caplog.at_level(logging.DEBUG):
 
-        module = load_module_from_file("mqttwarn/services/apprise.py")
+        module = load_module_from_file("mqttwarn/services/apprise_single.py")
 
         item = Item(
             config={"baseuri": "mailtos://smtp_username:smtp_password@mail.example.org"},
@@ -57,7 +57,7 @@ def test_apprise_success_no_addresses(apprise_asset, apprise_mock, srv, caplog):
 
     with caplog.at_level(logging.DEBUG):
 
-        module = load_module_from_file("mqttwarn/services/apprise.py")
+        module = load_module_from_file("mqttwarn/services/apprise_single.py")
 
         item = Item(
             config={"baseuri": "json://localhost:1234/mqtthook"},
@@ -69,18 +69,13 @@ def test_apprise_success_no_addresses(apprise_asset, apprise_mock, srv, caplog):
 
         assert apprise_mock.mock_calls == [
             call(asset=mock.ANY),
-            call().add(
-                "json://localhost:1234/mqtthook"
-            ),
+            call().add("json://localhost:1234/mqtthook"),
             call().notify(body="⚽ Notification message ⚽", title="⚽ Message title ⚽"),
             call().notify().__bool__(),
         ]
 
         assert outcome is True
-        assert (
-            "Sending notification to Apprise. target=None, addresses=[]"
-            in caplog.messages
-        )
+        assert "Sending notification to Apprise. target=None, addresses=[]" in caplog.messages
         assert "Successfully sent message using Apprise" in caplog.messages
 
 
@@ -101,7 +96,7 @@ def test_apprise_failure_notify(srv, caplog):
             "apprise.Apprise", side_effect=[mock_connection], create=True
         ) as mock_client:
             with mock.patch("apprise.AppriseAsset", create=True) as mock_asset:
-                module = load_module_from_file("mqttwarn/services/apprise.py")
+                module = load_module_from_file("mqttwarn/services/apprise_single.py")
 
                 item = Item(
                     config={"baseuri": "mailtos://smtp_username:smtp_password@mail.example.org"},
@@ -147,7 +142,7 @@ def test_apprise_error(srv, caplog):
             "apprise.Apprise", side_effect=[mock_connection], create=True
         ) as mock_client:
             with mock.patch("apprise.AppriseAsset", create=True) as mock_asset:
-                module = load_module_from_file("mqttwarn/services/apprise.py")
+                module = load_module_from_file("mqttwarn/services/apprise_single.py")
 
                 item = Item(
                     config={"baseuri": "mailtos://smtp_username:smtp_password@mail.example.org"},
@@ -171,9 +166,12 @@ def test_apprise_error(srv, caplog):
                 assert outcome is False
                 assert (
                     "Sending notification to Apprise. target=test, addresses=['foo@example.org', 'bar@example.org']"
-                    in caplog.text
+                    in caplog.messages
                 )
-                assert "Error sending message to test: something failed" in caplog.text
+                assert (
+                    "Sending message using Apprise failed. target=test, error=something failed"
+                    in caplog.messages
+                )
 
 
 @surrogate("apprise")
@@ -183,7 +181,7 @@ def test_apprise_success_with_sender(apprise_asset, apprise_mock, srv, caplog):
 
     with caplog.at_level(logging.DEBUG):
 
-        module = load_module_from_file("mqttwarn/services/apprise.py")
+        module = load_module_from_file("mqttwarn/services/apprise_single.py")
 
         item = Item(
             config={

--- a/tests/services/test_file.py
+++ b/tests/services/test_file.py
@@ -4,9 +4,8 @@ import logging
 import os
 from unittest import mock
 
-import pytest as pytest
-
 import mqttwarn.services.file
+import pytest as pytest
 from mqttwarn.model import ProcessorItem as Item
 
 
@@ -41,7 +40,10 @@ def test_file_success(fake_filesystem, srv, caplog, item):
 
         assert outcome is True
         assert "Writing to file `/tmp/testdrive.log'" in caplog.messages
-        assert open("/tmp/testdrive.log", mode="r", encoding="utf-8").read() == "\u26bd Notification message \u26bd"
+        assert (
+            open("/tmp/testdrive.log", mode="r", encoding="utf-8").read()
+            == "\u26bd Notification message \u26bd"
+        )
 
 
 @mock.patch("io.open", side_effect=Exception("something failed"))
@@ -66,10 +68,7 @@ def test_file_failure(fake_filesystem, srv, caplog):
         assert not os.path.exists("/tmp/testdrive.log")
 
         assert outcome is False
-        assert (
-            "Cannot write to file `/tmp/testdrive.log': something failed"
-            in caplog.messages
-        )
+        assert "Cannot write to file `/tmp/testdrive.log': something failed" in caplog.messages
 
 
 @pytest.mark.parametrize(
@@ -107,7 +106,10 @@ def test_file_append_newline_success(fake_filesystem, srv, caplog, item):
         assert outcome1 is True
         assert outcome2 is True
         assert "Writing to file `/tmp/testdrive.log'" in caplog.messages
-        assert open("/tmp/testdrive.log", mode="r", encoding="utf-8").read() == "\u26bd Notification message \u26bd\n\u26bd Notification message \u26bd\n"
+        assert (
+            open("/tmp/testdrive.log", mode="r", encoding="utf-8").read()
+            == "\u26bd Notification message \u26bd\n\u26bd Notification message \u26bd\n"
+        )
 
 
 @pytest.mark.parametrize(
@@ -146,4 +148,7 @@ def test_file_overwrite_success(fake_filesystem, srv, caplog, item):
         assert outcome1 is True
         assert outcome2 is True
         assert "Writing to file `/tmp/testdrive.log'" in caplog.messages
-        assert open("/tmp/testdrive.log", mode="r", encoding="utf-8").read() == "\u26bd Notification message \u26bd"
+        assert (
+            open("/tmp/testdrive.log", mode="r", encoding="utf-8").read()
+            == "\u26bd Notification message \u26bd"
+        )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -194,7 +194,7 @@ def test_plugin_module(caplog, configfile):
         )
 
         # Proof that the message has been routed to the "log" plugin properly
-        assert "Plugin invoked" in caplog.text, caplog.text
+        assert "Plugin invoked" in caplog.messages
 
 
 @pytest.mark.parametrize("configfile", [configfile_full, configfile_service_loading])
@@ -212,7 +212,7 @@ def test_plugin_file(caplog, configfile):
         send_message(topic="test/plugin-file", payload='{"name": "temperature", "value": 42.42}')
 
         # Proof that the message has been routed to the "log" plugin properly
-        assert "Plugin invoked" in caplog.text, caplog.text
+        assert "Plugin invoked" in caplog.messages
 
 
 def test_xform_func(caplog):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,8 +16,6 @@ from tests import (
     configfile_service_loading,
     configfile_unknown_functions,
 )
-
-
 from tests.util import core_bootstrap, send_message
 
 
@@ -296,7 +294,8 @@ def inactive_test_status_publish(caplog):
     """
 
     from unittest import mock
-    from unittest.mock import call, PropertyMock
+    from unittest.mock import PropertyMock, call
+
     from mqttwarn.core import connect
 
     with caplog.at_level(logging.DEBUG):
@@ -311,4 +310,4 @@ def inactive_test_status_publish(caplog):
         outcome = connect().mqttc = mqtt_publish_mock
 
         # Proof that the message has been routed to the "log" plugin properly
-        #assert assertion here to verify the connection
+        # assert assertion here to verify the connection


### PR DESCRIPTION
Hi there,

based on #557, it brings notifications using Apprise closer to what @psyciknz was requesting at https://github.com/jpmens/mqttwarn/issues/555#issuecomment-946094962.

The idea behind this variant is to publish messages to different Apprise plugins within a single configuration snippet, containing multiple recipients in form of regular _mqttwarn targets_.

A corresponding configuration snippet would look like:
```ini
[defaults]
launch    = apprise-multi

[config:apprise-multi]
; Dispatch message to multiple Apprise plugins.
module   = 'apprise_multi'
targets = {
   'demo-http'        : [ { 'baseuri':  'json://localhost:1234/mqtthook' }, { 'baseuri':  'json://daq.example.org:5555/foobar' } ],
   'demo-discord'     : [ { 'baseuri':  'discord://4174216298/JHMHI8qBe7bk2ZwO5U711o3dV_js' } ],
   'demo-mailto'      : [ {
          'baseuri':  'mailtos://smtp_username:smtp_password@mail.example.org',
          'recipients': ['foo@example.org', 'bar@example.org'],
          'sender': 'monitoring@example.org',
          'sender_name': 'Example Monitoring',
          } ],
   }

[apprise-multi-test]
topic    = apprise/multi/#
targets  = apprise-multi:demo-http, apprise-multi:demo-discord, apprise-multi:demo-mailto
```

With kind regards,
Andreas.
