### PR TITLE
Fix documentation about Docker images

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ mqttwarn changelog
 
 in progress
 ===========
+- Fix documentation about Docker images
 
 
 2021-10-19 0.28.0

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -22,9 +22,6 @@ export IMAGE=ghcr.io/jpmens/mqttwarn-standard:latest
 
 # The full image on GHCR.
 export IMAGE=ghcr.io/jpmens/mqttwarn-full:latest
-
-# The standard image on Docker Hub.
-export IMAGE=jpmens/mqttwarn
 ```
 
 ## Interactively

--- a/README.rst
+++ b/README.rst
@@ -114,8 +114,8 @@ For running ``mqttwarn`` on a container infrastructure like Docker or
 Kubernetes, corresponding images are automatically published to the
 GitHub Container Registry (GHCR).
 
-- ``ghcr.io/earthobservations/wetterdienst-standard:latest``
-- ``ghcr.io/earthobservations/wetterdienst-full:latest``
+- ``ghcr.io/jpmens/mqttwarn-standard:latest``
+- ``ghcr.io/jpmens/mqttwarn-full:latest``
 
 To learn more about this topic, please follow up reading the `Docker handbook`_.
 


### PR DESCRIPTION
Hi there,

@psyciknz reported a flaw about the Docker images within the documentation at #561, this patch resolves it. Apparently, I made a mistake by copying over the image names from [wetterdienst](https://github.com/earthobservations/wetterdienst) - I must have been tired. Apologies.

With kind regards,
Andreas.
