### PR TITLE
Enable passing of more Pushover API parameters.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ in progress
 - SMTP service plugin: Add support for minimal configuration w/o TLS and AUTH
 - Update dependencies: Use Jinja2 3.x; Remove configparser, it is built into Python 3
 - Add support for Python 3.11
+- Pushover service plugin: Enable passing of parameters ``html``, ``url``, ``url_title``
 
 
 2021-10-31 0.28.1

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -2281,6 +2281,21 @@ NOTE: `callback` is an optional URL for pushover to [ack messages](https://pusho
 | `title`       |   O    | application title (dflt: pushover dflt) |
 | `priority`    |   O    | priority. (dflt: pushover setting)     |
 
+Users can enable Pushover's [HTML styling](https://pushover.net/api#html) or [Supplementary URLs](https://pushover.net/api#urls) support in messages by adding the `html`, `url`, and `url_title` keys to the data object:
+
+```ini
+[config:pushover]
+callback = None
+alldata = PushoverAllData()
+```
+
+```
+def PushoverAllData(topic, data, srv=None):
+	return {
+		'url': 'https://somedomain/path',
+	}
+```
+
 The pushover service will accept a payload with either a simple text message, or a json payload which contains
 a `message` and either an `imageurl` or `imagebase64` encoded image.
 

--- a/mqttwarn/services/pushover.py
+++ b/mqttwarn/services/pushover.py
@@ -105,6 +105,11 @@ def plugin(srv, item):
     else:
         params['message'] = item.message
 
+    # Check for a few more Pushover API parameters
+    for key in ['html', 'url', 'url_title']:
+        if key in item.data:
+            params[key] = item.data[key]
+
     # check if there is an image contained in a JSON payload
     # (support either an image URL or base64 encoded image)
     image = None


### PR DESCRIPTION
Allow users to specify more of the parameters allowed by the [Pushover API](https://pushover.net/api).  In particular, add support for the embedded URL and HTML formatting options.