### PR TITLE
Force `futures` version to be at least 0.18

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requires = [
     'attrs<23',
     'docopt<1',
     'requests<3',
-    'future<1',
+    'future>=0.18.0,<1',
 ]
 
 extras = {


### PR DESCRIPTION
I had some issues installing mqttwarn in an existing venv. This fixes #584 which is my issue.

I tested my change on my dev machine with these commands:
```
 pyenv install 3.10.4
 pyenv shell 3.10.4
 git clone git@github.com:arieroos/mqttwarn.git
 cd mqttwarn
 pip --version
 > pip 22.0.4 from /Users/arieroos/.pyenv/versions/3.10.4/lib/python3.10/site-packages/pip (python 3.10)
 pip install future==0.17.1
 pip install .
 mqttwarn make-config > mqttwarn.ini
 cat mqttwarn.ini
``` 
All commands succeeded