### PR TITLE
Add tests for `osxnotify` plugin, fix evaluating `sound` config setting

### DIFF
--- a/mqttwarn/services/osxnotify.py
+++ b/mqttwarn/services/osxnotify.py
@@ -27,8 +27,8 @@ def plugin(srv, item):
 
     # Play Sound ?
     playSound = True
-    if config == dict and config['sound']:
-       playSound = config['sound']
+    if isinstance(config, dict):
+       playSound = config.get('sound', True)
 
     # Get Message
     message = item.message
@@ -40,6 +40,7 @@ def plugin(srv, item):
          "message": message
        }
 
+    srv.logging.debug("Sending desktop notification")
     try:
         # Synchronous Notification (allows no callbacks in OSX)
         # Asynchronous would require asyncio and require some changes to the plugin handler

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ markers = [
 ]
 
 [tool.coverage.run]
-branch = true
+branch = false
 source = ["mqttwarn"]
 
 [tool.coverage.report]

--- a/setup.py
+++ b/setup.py
@@ -149,6 +149,7 @@ extras["all"] = extras_all
 extras["test"] = [
     'pytest<8',
     'pytest-cov<4',
+    'pytest-mock<4',
     'lovely.testlayers<1',
     'tox<4',
     'surrogate==0.1',

--- a/tests/services/test_osxnotify.py
+++ b/tests/services/test_osxnotify.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+# (c) 2022 The mqttwarn developers
+import json
+import logging
+from unittest import mock
+from unittest.mock import call
+
+import pytest
+from mqttwarn.model import ProcessorItem as Item
+from mqttwarn.util import Struct, load_module_by_name
+from surrogate import surrogate
+
+
+@pytest.fixture
+def desktop_notifier_mock(mocker):
+    with surrogate("desktop_notifier"):
+        notifier = mocker.patch("desktop_notifier.DesktopNotifier", create=True)
+        mocker.patch("desktop_notifier.Urgency", create=True)
+        mocker.patch("desktop_notifier.Button", create=True)
+        mocker.patch("desktop_notifier.ReplyField", create=True)
+        yield notifier
+
+
+def test_osxnotify_vanilla_success(desktop_notifier_mock, srv, caplog):
+
+    module = load_module_by_name("mqttwarn.services.osxnotify")
+
+    item = Item(
+        title="⚽ Notification title ⚽",
+        message="⚽ Notification message ⚽",
+    )
+
+    # Plugin needs a real `Struct`.
+    item = Struct(**item.asdict())
+
+    with caplog.at_level(logging.DEBUG):
+
+        outcome = module.plugin(srv, item)
+
+        assert desktop_notifier_mock.mock_calls == [
+            call(),
+            call().send_sync(
+                message="⚽ Notification message ⚽", title="⚽ Notification title ⚽", sound=True
+            ),
+        ]
+
+        assert outcome is True
+        assert "Sending desktop notification" in caplog.messages
+
+
+def test_osxnotify_vanilla_failure(desktop_notifier_mock, srv, caplog):
+
+    module = load_module_by_name("mqttwarn.services.osxnotify")
+
+    item = Item(
+        title="⚽ Notification title ⚽",
+        message="⚽ Notification message ⚽",
+    )
+
+    # Plugin needs a real `Struct`.
+    item = Struct(**item.asdict())
+
+    with caplog.at_level(logging.DEBUG):
+
+        # Make the `send_sync` method fail.
+        attrs = {"send_sync.side_effect": Exception("Something failed")}
+        notifier_mock = mock.MagicMock(**attrs)
+        module.notify = notifier_mock
+
+        outcome = module.plugin(srv, item)
+
+        assert outcome is False
+        assert "Sending desktop notification" in caplog.messages
+        assert "Invoking OSX-Notifier failed: Something failed" in caplog.messages
+
+
+def test_osxnotify_json_success(desktop_notifier_mock, srv, caplog):
+
+    module = load_module_by_name("mqttwarn.services.osxnotify")
+
+    json_message = json.dumps(
+        dict(
+            title="⚽ Notification title ⚽",
+            message="⚽ Notification message ⚽",
+        )
+    )
+
+    item = Item(
+        message=json_message,
+    )
+
+    # Plugin needs a real `Struct`.
+    item = Struct(**item.asdict())
+
+    with caplog.at_level(logging.DEBUG):
+
+        outcome = module.plugin(srv, item)
+
+        assert desktop_notifier_mock.mock_calls == [
+            call(),
+            call().send_sync(
+                message="⚽ Notification message ⚽", title="⚽ Notification title ⚽", sound=True
+            ),
+        ]
+
+        assert outcome is True
+        assert "Sending desktop notification" in caplog.messages
+
+
+def test_osxnotify_no_sound_success(desktop_notifier_mock, srv, caplog):
+
+    module = load_module_by_name("mqttwarn.services.osxnotify")
+
+    item = Item(
+        title="⚽ Notification title ⚽",
+        message="⚽ Notification message ⚽",
+        config={"sound": False},
+    )
+
+    # Plugin needs a real `Struct`.
+    item = Struct(**item.asdict())
+
+    with caplog.at_level(logging.DEBUG):
+
+        outcome = module.plugin(srv, item)
+
+        assert desktop_notifier_mock.mock_calls == [
+            call(),
+            call().send_sync(
+                message="⚽ Notification message ⚽", title="⚽ Notification title ⚽", sound=False
+            ),
+        ]
+
+        assert outcome is True
+        assert "Sending desktop notification" in caplog.messages


### PR DESCRIPTION
This patch adds a few test cases to exercise the `osxnotify` plugin after the rewrite #581 by @portalzine. While being at it, it fixes an evaluation glitch with the `sound` configuration setting. `config == dict` would never evaluate to `True`.