### PR TITLE
Improve documentation and `setup.py` for `osxnotify` service plugin

### DIFF
--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -2004,7 +2004,8 @@ Requires:
 
 ### `osxnotify`
 
-* For Macs only, utilizing desktop-notifier from https://github.com/samschott/desktop-notifier 
+* Despite its name, it is a cross-platform desktop notifier, based on
+  https://github.com/samschott/desktop-notifier.
 
 ```ini
 [config:osxnotify]

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ extras = {
         'pynsca>=1.6',
     ],
     'osxnotify': [
-        'pync>=1.6.1',
+        'desktop-notifier<4',
     ],
     'pastebinpub': [
         'Pastebin>=1.1.2',


### PR DESCRIPTION
A small patch to improve the documentation and setup convenience around the `osxnotify` rework.

/cc @portalzine 