### PR TITLE
Tests: Add e2e/system test cases to verify egress and ingress MQTT messages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,16 @@ jobs:
     - name: Acquire sources
       uses: actions/checkout@v3
 
+    # https://github.com/docker-practice/actions-setup-docker
+    # - name: Install Docker
+    #   if: runner.os == 'Linux'
+    #   uses: docker-practice/actions-setup-docker@master
+
+    - name: Display Docker version
+      if: runner.os == 'Linux'
+      run: |
+        docker version
+
     - name: Setup Python
       uses: actions/setup-python@v4
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ log_cli_level = "DEBUG"
 testpaths = ["tests"]
 xfail_strict = true
 markers = [
+  "e2e",  # Full end-to-end system tests, needing an MQTT broker.
 ]
 
 [tool.coverage.run]

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ extras["test"] = [
     'pytest<8',
     'pytest-cov<4',
     'pytest-mock<4',
-    'lovely.testlayers<1',
+    'pytest-mqtt<1',
     'tox<4',
     'surrogate==0.1',
     'dataclasses; python_version<"3.7"',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,7 @@
 configfile_full = "tests/etc/full.ini"
 configfile_service_loading = "tests/etc/service-loading.ini"
 configfile_no_functions = "tests/etc/no-functions.ini"
+configfile_status_publish = "tests/etc/status-publish.ini"
 configfile_empty_functions = "tests/etc/empty-functions.ini"
 configfile_unknown_functions = "tests/etc/unknown-functions.ini"
 funcfile_good = "tests/etc/functions_good.py"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
-# Import fixtures
-from mqttwarn.testing.fixtures import mqttwarn_service as srv  # noqa
+# Import custom fixtures.
+from mqttwarn.testing.fixtures import mqttwarn_service as srv  # noqa:F401
 
 
 @pytest.fixture

--- a/tests/etc/status-publish.ini
+++ b/tests/etc/status-publish.ini
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# (c) 2014-2021 The mqttwarn developers
+#
+# mqttwarn configuration file for testing the `status_publish` feature
+#
+
+; ------------------------------------------
+;             Base configuration
+; ------------------------------------------
+
+[defaults]
+
+
+; --------
+; Services
+; --------
+
+; This is *without* a `functions` setting.
+;functions = 'DO NOT SET'
+
+; name the service providers you will be using.
+; launch    = nothing
+
+; Publish mqttwarn status information (retained)
+status_publish = True
+status_topic = mqttwarn-testdrive/$SYS

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -284,36 +284,6 @@ def test_config_bad_functions(caplog):
         assert "not found" in error_message
 
 
-def inactive_test_status_publish(caplog):
-    """
-    Aim to test the `status_publish` feature.
-    Test the core connection method.
-
-    TODO: This is not finished.
-
-    Note:
-        We need figure out how ot mock a connection to a non-existent MQTT server.
-    """
-
-    # from unittest import mock
-
-    # from mqttwarn.core import connect
-
-    with caplog.at_level(logging.DEBUG):
-
-        # Bootstrap the core machinery without MQTT
-        core_bootstrap(configfile=configfile_full)
-
-        # mqtt_publish_mock = mock.MagicMock()
-        # mqttc = mqtt_publish_mock
-
-        # Signal mocked MQTT message to the core machinery for processing
-        # outcome = connect().mqttc = mqtt_publish_mock
-
-        # Proof that the message has been routed to the "log" plugin properly
-        # assert assertion here to verify the connection
-
-
 def test_render_template():
     tplvars = {
         "name": "foo",

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+# (c) 2022 The mqttwarn developers
+"""
+Full system tests verifying mqttwarn end-to-end, using an MQTT broker.
+"""
+import json
+import logging
+import os
+import sys
+
+import pytest
+from mqttwarn.configuration import load_configuration
+from mqttwarn.core import bootstrap, connect
+from mqttwarn.model import StatusInformation
+from pytest_mqtt import MqttMessage
+from tests import configfile_no_functions, configfile_status_publish
+from tests.util import delay, mqtt_process
+
+if os.getenv("GITHUB_ACTIONS") == "true" and sys.platform != "linux":
+    raise pytest.skip(msg="On GHA, Mosquitto via Docker is only available on Linux", allow_module_level=True)
+
+
+# Mark all test case functions within this module with `e2e`.
+pytestmark = pytest.mark.e2e
+
+# Configure `capmqtt` to return `MqttMessage.payload` as `str`, decoded from `utf-8`.
+capmqtt_decode_utf8 = True
+
+
+def test_system_status_publish(mosquitto, caplog, capmqtt):
+    """
+    A full system test verifying the `status_publish` feature.
+    It approves "Does mqttwarn boot and emit system messages to `mqttwarn/$SYS` correctly?".
+    """
+
+    with caplog.at_level(logging.DEBUG):
+
+        # Bootstrap the core machinery without MQTT.
+        config = load_configuration(configfile=configfile_status_publish)
+        bootstrap(config=config)
+
+        # Add MQTT.
+        mqttc = connect()
+
+        # Make mqttwarn run the subscription to the broker.
+        mqtt_process(mqttc)
+
+        # Let mqttwarn emit messages to `mqttwarn/$SYS`.
+        delay()
+
+        # Verify log output.
+        assert "No services defined" in caplog.messages
+        assert "Attempting connection to MQTT broker localhost:1883" in caplog.messages
+        assert "Setting LWT to clients/mqttwarn" in caplog.messages
+        assert "Publishing status information to mqttwarn-testdrive/$SYS" in caplog.messages
+        assert "Starting 1 worker threads" in caplog.messages
+        assert "Job queue has 0 items to process" in caplog.messages
+        assert "Connected to MQTT broker, subscribing to topics" in caplog.messages
+
+        # Verify MQTT messages.
+        si = StatusInformation()
+        assert (
+            MqttMessage(topic="mqttwarn-testdrive/$SYS/version", payload=si.mqttwarn_version, userdata=None)
+            in capmqtt.messages
+        )
+        assert (
+            MqttMessage(topic="mqttwarn-testdrive/$SYS/platform", payload=si.os_platform, userdata=None)
+            in capmqtt.messages
+        )
+        assert (
+            MqttMessage(topic="mqttwarn-testdrive/$SYS/python/version", payload=si.python_version, userdata=None)
+            in capmqtt.messages
+        )
+        # assert MqttMessage(topic="clients/mqttwarn", payload="1", userdata=None) in capmqtt.messages
+
+        mqttc.disconnect()
+
+
+def test_system_dispatch_to_log_service_plaintext(mosquitto, caplog, capmqtt):
+    """
+    A full system test verifying the notification message dispatching feature with a plaintext message.
+    It approves "Does mqttwarn boot and process messages correctly?".
+    Within this test case, it uses the `log` service plugin.
+    """
+
+    with caplog.at_level(logging.DEBUG):
+
+        # Bootstrap the core machinery without MQTT.
+        config = load_configuration(configfile=configfile_no_functions)
+        bootstrap(config=config)
+
+        # Add MQTT.
+        mqttc = connect()
+
+        # Make mqttwarn run the subscription to the broker.
+        mqtt_process(mqttc)
+
+        # Submit a message to the broker.
+        capmqtt.publish(topic="test/log-1", payload="foobar")
+
+        # Make mqttwarn receive and process the message.
+        mqtt_process(mqttc, loops=3)
+
+        # Verify log output.
+        assert 'Successfully loaded service "log"' in caplog.messages
+        assert "Subscribing to test/log-1 (qos=0)" in caplog.messages
+
+        assert "Message received on test/log-1: foobar" in caplog.messages
+        assert "Section [test/log-1] matches message on test/log-1, processing it" in caplog.messages
+        assert "Cannot decode JSON object, payload=foobar: Expecting value: line 1 column 1 (char 0)" in caplog.messages
+        assert "Message on test/log-1 going to log:info" in caplog.messages
+        assert "New `log:info' job: test/log-1" in caplog.messages
+        assert "Processor #0 is handling: `log' for info" in caplog.messages
+        assert "Formatting message with function '{name}: {value}' failed" in caplog.messages
+        assert "Invoking service plugin for `log'" in caplog.messages
+        assert ("mqttwarn.services.log", 20, "foobar") in caplog.record_tuples
+        assert "Job queue has 0 items to process" in caplog.messages
+
+        # Verify MQTT messages.
+        assert MqttMessage(topic="test/log-1", payload="foobar", userdata=None) in capmqtt.messages
+
+        mqttc.disconnect()
+
+
+def test_system_dispatch_to_log_service_json(mosquitto, caplog, capmqtt):
+    """
+    A full system test verifying the notification message dispatching feature with a JSON message.
+    It approves "Does mqttwarn boot and process messages correctly?".
+    Within this test case, it uses the `log` service plugin.
+    """
+
+    with caplog.at_level(logging.DEBUG):
+
+        # Bootstrap the core machinery without MQTT.
+        config = load_configuration(configfile=configfile_no_functions)
+        bootstrap(config=config)
+
+        # Add MQTT.
+        mqttc = connect()
+
+        # Make mqttwarn run the subscription to the broker.
+        mqtt_process(mqttc)
+
+        # Submit a message to the broker.
+        capmqtt.publish(topic="test/log-1", payload=json.dumps({"name": "foo", "value": "bar"}))
+
+        # Make mqttwarn receive and process the message.
+        mqtt_process(mqttc, loops=3)
+
+        # Verify log output.
+        assert 'Successfully loaded service "log"' in caplog.messages
+        assert "Subscribing to test/log-1 (qos=0)" in caplog.messages
+
+        assert 'Message received on test/log-1: {"name": "foo", "value": "bar"}' in caplog.messages
+        assert "Section [test/log-1] matches message on test/log-1, processing it" in caplog.messages
+        assert "Message on test/log-1 going to log:info" in caplog.messages
+        assert "New `log:info' job: test/log-1" in caplog.messages
+        assert "Processor #0 is handling: `log' for info" in caplog.messages
+        assert "Invoking service plugin for `log'" in caplog.messages
+        assert ("mqttwarn.services.log", 20, "foo: bar") in caplog.record_tuples
+        assert "Job queue has 0 items to process" in caplog.messages
+
+        # Verify MQTT messages.
+        assert (
+            MqttMessage(topic="test/log-1", payload='{"name": "foo", "value": "bar"}', userdata=None)
+            in capmqtt.messages
+        )
+
+        mqttc.disconnect()

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # (c) 2018-2021 The mqttwarn developers
-import time
+import threading
 
+import paho
 from mqttwarn.configuration import load_configuration
 from mqttwarn.core import bootstrap, load_services, on_message, start_workers
 from paho.mqtt.client import MQTTMessage
@@ -37,4 +38,21 @@ def send_message(topic=None, payload=None):
     on_message(None, None, message)
 
     # Give the machinery some time to process the message
-    time.sleep(0.10)
+    delay()
+
+
+def delay(seconds=0.05):
+    """
+    Wait for designated number of seconds.
+    """
+    threading.Event().wait(seconds)
+
+
+def mqtt_process(mqttc: paho.mqtt.client.Client, loops=2):
+    """
+    Process network events for Paho MQTT client library. Wait a bit before and after.
+    """
+    delay()
+    for _ in range(loops):
+        mqttc.loop()
+    delay()


### PR DESCRIPTION
## About
This patch sets the stage to further improve the test coverage of the mqttwarn core machinery [`mqttwarn/core.py`](https://github.com/jpmens/mqttwarn/blob/main/mqttwarn/core.py), as outlined within #332. My goal is to reach 85% code coverage mid-term. The patch starts adding full e2e/system test cases, in order to verify basic scenarios while running the full stack, of:

- Mosquitto - MQTT broker
- `mqttwarn` - this program
- `capmqtt` MQTT test client - for receiving and submitting messages from/to the MQTT broker from `pytest` test cases

## Details
1. It starts Mosquitto using Docker, invokes the `mqttwarn` machinery, and verifies if certain status messages have been published by `mqttwarn` during the bootstrapping process, originating from the `status_publish` feature.
2. It submits an MQTT message to the broker and verifies that `mqttwarn` correctly receives and dispatches the message to its `log` service plugin.

## More
While working on the patch, the pytest fixture utilities `capmqtt` and `mosquitto` have been converged into a separate package at [pytest-mqtt](https://pypi.org/project/pytest-mqtt/), ready to be reused by other projects based on MQTT in one way or another. Enjoy.
