### PR TITLE
Tests: Improve mocking of the `socket` object using `pytest-mock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ exclude = 'tests/etc/functions_bad.py'
 line-length = 120
 # ignore = ["F821"]
 exclude = [
-  "tests/etc/functions_bad.py"
+  "./tests/etc/functions_bad.py"
 ]
 
 

--- a/tests/services/test_carbon.py
+++ b/tests/services/test_carbon.py
@@ -8,7 +8,7 @@ from mqttwarn.model import ProcessorItem as Item
 from mqttwarn.util import load_module_from_file
 
 
-def test_carbon_success_metric_value_timestamp(srv, caplog):
+def test_carbon_success_metric_value_timestamp(mocker, srv, caplog):
 
     item = Item(
         target="test",
@@ -21,8 +21,7 @@ def test_carbon_success_metric_value_timestamp(srv, caplog):
 
         module = load_module_from_file("mqttwarn/services/carbon.py")
 
-        socket_mock = mock.MagicMock()
-        module.socket.socket = socket_mock
+        socket_mock = mocker.patch("socket.socket")
 
         outcome = module.plugin(srv, item)
         assert socket_mock.mock_calls == [
@@ -36,7 +35,7 @@ def test_carbon_success_metric_value_timestamp(srv, caplog):
         assert "Sending to carbon: foo 42.42 1623887596" in caplog.text
 
 
-def test_carbon_success_metric_value(srv, caplog):
+def test_carbon_success_metric_value(mocker, srv, caplog):
 
     item = Item(target="test", addrs=["localhost", 2003], message="foo 42.42", data={})
 
@@ -44,8 +43,7 @@ def test_carbon_success_metric_value(srv, caplog):
 
         module = load_module_from_file("mqttwarn/services/carbon.py")
 
-        socket_mock = mock.MagicMock()
-        module.socket.socket = socket_mock
+        socket_mock = mocker.patch("socket.socket")
 
         outcome = module.plugin(srv, item)
         assert socket_mock.mock_calls == [
@@ -59,7 +57,7 @@ def test_carbon_success_metric_value(srv, caplog):
         assert "Sending to carbon: foo 42.42" in caplog.text
 
 
-def test_carbon_success_value(srv, caplog):
+def test_carbon_success_value(mocker, srv, caplog):
 
     item = Item(target="test", addrs=["localhost", 2003], message="42.42", data={})
 
@@ -67,8 +65,7 @@ def test_carbon_success_value(srv, caplog):
 
         module = load_module_from_file("mqttwarn/services/carbon.py")
 
-        socket_mock = mock.MagicMock()
-        module.socket.socket = socket_mock
+        socket_mock = mocker.patch("socket.socket")
 
         outcome = module.plugin(srv, item)
         assert socket_mock.mock_calls == [
@@ -82,7 +79,7 @@ def test_carbon_success_value(srv, caplog):
         assert "Sending to carbon: ohno 42.42" in caplog.text
 
 
-def test_carbon_success_value_metric_from_topic(srv, caplog):
+def test_carbon_success_value_metric_from_topic(mocker, srv, caplog):
 
     item = Item(
         target="test",
@@ -95,8 +92,7 @@ def test_carbon_success_value_metric_from_topic(srv, caplog):
 
         module = load_module_from_file("mqttwarn/services/carbon.py")
 
-        socket_mock = mock.MagicMock()
-        module.socket.socket = socket_mock
+        socket_mock = mocker.patch("socket.socket")
 
         outcome = module.plugin(srv, item)
         assert socket_mock.mock_calls == [
@@ -110,7 +106,7 @@ def test_carbon_success_value_metric_from_topic(srv, caplog):
         assert "Sending to carbon: foo.bar 42.42" in caplog.text
 
 
-def test_carbon_success_value_metric_from_topic_with_leading_slash(srv, caplog):
+def test_carbon_success_value_metric_from_topic_with_leading_slash(mocker, srv, caplog):
 
     item = Item(
         target="test",
@@ -123,8 +119,7 @@ def test_carbon_success_value_metric_from_topic_with_leading_slash(srv, caplog):
 
         module = load_module_from_file("mqttwarn/services/carbon.py")
 
-        socket_mock = mock.MagicMock()
-        module.socket.socket = socket_mock
+        socket_mock = mocker.patch("socket.socket")
 
         outcome = module.plugin(srv, item)
         assert socket_mock.mock_calls == [
@@ -185,7 +180,7 @@ def test_carbon_failure_invalid_message_format(srv, caplog):
         assert "target `carbon': error decoding message" in caplog.text
 
 
-def test_carbon_failure_connect(srv, caplog):
+def test_carbon_failure_connect(mocker, srv, caplog):
 
     item = Item(
         target="test",
@@ -198,10 +193,11 @@ def test_carbon_failure_connect(srv, caplog):
 
         module = load_module_from_file("mqttwarn/services/carbon.py")
 
+        socket_mock = mocker.patch("socket.socket")
+
+        # Inject exception to be raised on `socket.connect`.
         attrs = {"connect.side_effect": Exception("something failed")}
-        socket_mock = mock.MagicMock()
         socket_mock.return_value = mock.MagicMock(**attrs)
-        module.socket.socket = socket_mock
 
         outcome = module.plugin(srv, item)
         assert socket_mock.mock_calls == [call(), call().connect(("localhost", 2003))]

--- a/tests/services/test_irccat.py
+++ b/tests/services/test_irccat.py
@@ -8,7 +8,7 @@ from mqttwarn.model import ProcessorItem as Item
 from mqttwarn.util import load_module_from_file
 
 
-def test_irccat_normal_success(srv, caplog):
+def test_irccat_normal_success(mocker, srv, caplog):
     import socket
 
     item = Item(
@@ -22,8 +22,7 @@ def test_irccat_normal_success(srv, caplog):
 
         module = load_module_from_file("mqttwarn/services/irccat.py")
 
-        socket_mock = mock.MagicMock()
-        module.socket.socket = socket_mock
+        socket_mock = mocker.patch("socket.socket")
 
         outcome = module.plugin(srv, item)
         assert socket_mock.mock_calls == [
@@ -37,7 +36,7 @@ def test_irccat_normal_success(srv, caplog):
         assert "Sending to IRCcat: ⚽ Notification message ⚽" in caplog.messages
 
 
-def test_irccat_green_success(srv, caplog):
+def test_irccat_green_success(mocker, srv, caplog):
     import socket
 
     item = Item(
@@ -52,8 +51,7 @@ def test_irccat_green_success(srv, caplog):
 
         module = load_module_from_file("mqttwarn/services/irccat.py")
 
-        socket_mock = mock.MagicMock()
-        module.socket.socket = socket_mock
+        socket_mock = mocker.patch("socket.socket")
 
         outcome = module.plugin(srv, item)
         assert socket_mock.mock_calls == [
@@ -67,7 +65,7 @@ def test_irccat_green_success(srv, caplog):
         assert "Sending to IRCcat: %GREEN⚽ Notification message ⚽" in caplog.messages
 
 
-def test_irccat_red_success(srv, caplog):
+def test_irccat_red_success(mocker, srv, caplog):
     import socket
 
     item = Item(
@@ -82,8 +80,7 @@ def test_irccat_red_success(srv, caplog):
 
         module = load_module_from_file("mqttwarn/services/irccat.py")
 
-        socket_mock = mock.MagicMock()
-        module.socket.socket = socket_mock
+        socket_mock = mocker.patch("socket.socket")
 
         outcome = module.plugin(srv, item)
         assert socket_mock.mock_calls == [
@@ -97,7 +94,7 @@ def test_irccat_red_success(srv, caplog):
         assert "Sending to IRCcat: %RED⚽ Notification message ⚽" in caplog.messages
 
 
-def test_irccat_config_invalid(srv, caplog):
+def test_irccat_config_invalid(mocker, srv, caplog):
 
     item = Item(
         target="test",
@@ -110,8 +107,7 @@ def test_irccat_config_invalid(srv, caplog):
 
         module = load_module_from_file("mqttwarn/services/irccat.py")
 
-        socket_mock = mock.MagicMock()
-        module.socket.socket = socket_mock
+        socket_mock = mocker.patch("socket.socket")
 
         outcome = module.plugin(srv, item)
         assert socket_mock.mock_calls == []


### PR DESCRIPTION
Hi there,

at https://github.com/jpmens/mqttwarn/pull/589#issuecomment-1249720003, we reported about a flaw regarding a resource leak within two test case modules, for the service plugins `carbon` and `irccat`.

By improving the style of mocking of the `socket` object using `pytest-mock`, it is made sure that all mocks are cleared up after the exit of the test case function.

The flaw was revealed when the `carbon` and `irccat` test cases, which apparently left some mocks on the `socket` object behind, were combined with the new `e2e` test cases, which in turn use the HTTP protocol to communicate with the Docker daemon, and failed on it.

With kind regards,
Andreas.
