### PR TITLE
Add a bit of type hinting and basic `mypy` checks on `mqttwarn/core.py`

### DIFF
--- a/mqttwarn/core.py
+++ b/mqttwarn/core.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-# (c) 2014-2021 The mqttwarn developers
-import platform
+# (c) 2014-2022 The mqttwarn developers
 from builtins import object
 from past.builtins import cmp
 from builtins import chr
@@ -11,18 +10,17 @@ import time
 import socket
 import logging
 import threading
+import typing as t
+
+import mqttwarn.configuration
 from mqttwarn.model import StatusInformation
-try:
-    from queue import Queue
-except ImportError:
-    # Backward-compatibility for Python 2
-    from Queue import Queue
+
+from queue import Queue
 from datetime import datetime
 from pkg_resources import resource_filename
 
 import paho.mqtt.client as paho
 
-from mqttwarn import __version__
 from mqttwarn.context import RuntimeContext, FunctionInvoker
 from mqttwarn.cron import PeriodicThread
 from mqttwarn.util import \
@@ -32,7 +30,7 @@ from mqttwarn.util import \
 try:
     import json
 except ImportError:
-    import simplejson as json
+    import simplejson as json  # type: ignore
 
 
 
@@ -53,24 +51,24 @@ logger = logging.getLogger(__name__)
 SCRIPTNAME = 'mqttwarn'
 
 # Global runtime context object
-context = None
+context: t.Optional[RuntimeContext] = None
 
 # Global configuration object
-cf = None
+cf: t.Optional[mqttwarn.configuration.Config] = None
 
 # Global handle to MQTT client
-mqttc = None
+mqttc: t.Optional[paho.Client] = None
 
 
 # Initialize processor queue
-q_in = Queue(maxsize=0)
+q_in: Queue = Queue(maxsize=0)
 exit_flag = False
 
 # Instances of PeriodicThread objects
 ptlist = {}
 
 # Instances of loaded service plugins
-service_plugins = {}
+service_plugins: t.Dict[str, t.Dict[str, t.Any]] = dict()
 
 
 # Class with helper functions which is passed to each plugin

--- a/mqttwarn/model.py
+++ b/mqttwarn/model.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-# (c) 2021 The mqttwarn developers
+# (c) 2021-2022 The mqttwarn developers
 import dataclasses
 import platform
 import sys
 from dataclasses import dataclass, field
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Optional
 from mqttwarn import __version__
 
 
@@ -14,15 +14,15 @@ class ProcessorItem:
     A processor item for feeding information into service handlers.
     """
 
-    service: str = None
-    target: str = None
+    service: Optional[str] = None
+    target: Optional[str] = None
     config: Dict = field(default_factory=dict)
     addrs: List[Union[str, Dict[str, str]]] = field(default_factory=list)
-    priority: int = None
-    topic: str = None
-    title: str = None
-    message: Union[str, bytes] = None
-    data: Dict = None
+    priority: Optional[int] = None
+    topic: Optional[str] = None
+    title: Optional[str] = None
+    message: Optional[Union[str, bytes]] = None
+    data: Optional[Dict] = None
 
     def asdict(self):
         return dataclasses.asdict(self)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ extend-exclude = [
   "./tests/etc/functions_bad.py"
 ]
 
+[tool.mypy]
+ignore_missing_imports = true
+
 
 # ==================
 # Test configuration
@@ -59,6 +62,7 @@ check-style = [
   {cmd="ruff tests"},
   {cmd="black --check tests"},
   {cmd="isort --check tests"},
+  {cmd="mypy --install-types --non-interactive mqttwarn/core.py"},
 ]
 test = [
   {cmd="pytest"},

--- a/setup.py
+++ b/setup.py
@@ -164,6 +164,7 @@ extras["develop"] = [
     'isort<6',
     'black<23',
     'build<1',
+    'mypy<1',
     'poethepoet<1',
     'ruff==0.0.40; python_version>="3.7"',
 ]


### PR DESCRIPTION
Adding type hint checks using `mypy` on the most important part of the code base, `mqttwarn/core.py`, was easy. Other than removing a spot for backward-compatibility with Python 2, the patch does not change the code base semantically in any way.