### PR TITLE
Add more test cases for `mqttwarn/core.py`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ mqttwarn changelog
 in progress
 ===========
 
+- Fix job sorting by priority after migration to Python 3
+
 
 2022-08-22 0.29.1
 =================

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -281,26 +281,6 @@ When a message is received at a topic with more than one matching section it wil
 directed to the targets in all matching sections.  For consistency, it's a good practice
 to explicitly provide `topic` options to all such sections.
 
-Targets can be also defined as a dictionary containing the pairs of topic and targets. In that case message matching the section can be dispatched in more flexible ways to selected targets. Consider the following example:
-
-```ini
-[#]
-targets = {
-  '/#': 'file:0',
-  '/test/#': 'file:1',
-  '/test/out/#': 'file:2',
-  '/test/out/+': 'file:3',
-  '/test/out/+/+': 'file:4',
-  '/test/out/+/state': 'file:5',
-  '/test/out/FL_power_consumption/state': [ 'file:6', 'file:7' ],
-  '/test/out/BR_ambient_power_sensor/state': 'file:8',
-}
-```
-
-With the message dispatching configuration the message is dispatched to the targets matching the most specific topic. If the message is received at `/test/out/FL_power_consumption/state` it will be directed to `file:6` and `file:7` targets only. Message received at `/test/out/AR_lamp/state` will be directed to `file:5`, but received at `/test/out/AR_lamp/command` will go to `file:4`.
-The dispatcher mechanism is always trying to find the most specific match.
-It allows to define the wide topic with default targets while some more specific topic can be handled differently. It gives additional flexibility in a message routing.
-
 Each of these sections has a number of optional (`O`) or mandatory (`M`)
 options:
 
@@ -317,6 +297,37 @@ options:
 | `image`       |   O    | used by certain targets (see below). May be func()  |
 | `template`    |   O    | use Jinja2 template instead of `format`        |
 | `qos`         |   O    | MQTT QoS for subscription (dflt: 0)            |
+
+
+##### Targets as dictionary
+
+Targets can be also defined as a dictionary containing the pairs of topic and targets.
+In that case message matching the section can be dispatched in more flexible ways to
+selected targets. Consider the following example:
+
+```ini
+[#]
+targets = {
+  '/#': 'file:0',
+  '/test/#': 'file:1',
+  '/test/out/#': 'file:2',
+  '/test/out/+': 'file:3',
+  '/test/out/+/+': 'file:4',
+  '/test/out/+/state': 'file:5',
+  '/test/out/FL_power_consumption/state': [ 'file:6', 'file:7' ],
+  '/test/out/BR_ambient_power_sensor/state': 'file:8',
+  }
+```
+**Note**: the closing brace `}` of the `targets` dict must be indented; this is an artifact of ConfigParser.
+
+With the message dispatching configuration the message is dispatched to the targets matching
+the most specific topic. If the message is received at `/test/out/FL_power_consumption/state`
+it will be directed to `file:6` and `file:7` targets only. Message received at `/test/out/AR_lamp/state`
+will be directed to `file:5`, but received at `/test/out/AR_lamp/command` will go to `file:4`.
+
+The dispatcher mechanism is always trying to find the most specific match. It allows to define
+the wide topic with default targets while some more specific topic can be handled differently.
+It gives additional flexibility in a message routing.
 
 
 ## Supported Notification Services

--- a/mqttwarn/core.py
+++ b/mqttwarn/core.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # (c) 2014-2022 The mqttwarn developers
 from builtins import object
-from past.builtins import cmp
+from functools import total_ordering
+
 from builtins import chr
 from builtins import str
 import os
@@ -105,6 +106,7 @@ def make_service(mqttc=None, name=None):
     return service
 
 
+@total_ordering
 class Job(object):
 
     def __init__(self, prio, service, section, topic, payload, data, target):
@@ -119,8 +121,17 @@ class Job(object):
         logger.debug("New `%s:%s' job: %s" % (service, target, topic))
         return
 
-    def __cmp__(self, other):
-        return cmp(self.prio, other.prio)
+    # The `__cmp__()` special method is no longer honored in Python 3.
+    # https://portingguide.readthedocs.io/en/latest/comparisons.html#rich-comparisons
+
+    def __eq__(self, other):
+        return self.prio == other.prio
+
+    def __ne__(self, other):
+        return not (self.prio == other.prio)
+
+    def __lt__(self, other):
+        return self.prio < other.prio
 
 
 def render_template(filename, data):

--- a/mqttwarn/core.py
+++ b/mqttwarn/core.py
@@ -179,17 +179,17 @@ def on_connect(mosq, userdata, flags, result_code):
             mqttc.publish(cf.lwt, cf.lwt_alive, qos=0, retain=True)
 
     elif result_code == 1:
-        logger.info("Connection refused - unacceptable protocol version")
+        logger.error("Connection refused - unacceptable protocol version")
     elif result_code == 2:
-        logger.info("Connection refused - identifier rejected")
+        logger.error("Connection refused - identifier rejected")
     elif result_code == 3:
-        logger.info("Connection refused - server unavailable")
+        logger.error("Connection refused - server unavailable")
     elif result_code == 4:
-        logger.info("Connection refused - bad user name or password")
+        logger.error("Connection refused - bad user name or password")
     elif result_code == 5:
-        logger.info("Connection refused - not authorised")
+        logger.error("Connection refused - not authorised")
     else:
-        logger.warning("Connection failed - result code %d" % (result_code))
+        logger.error("Connection failed - result code %d" % (result_code))
 
 
 def on_disconnect(mosq, userdata, result_code):

--- a/mqttwarn/services/log.py
+++ b/mqttwarn/services/log.py
@@ -9,6 +9,8 @@ __license__ = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-
 def plugin(srv, item):
     srv.logging.debug("*** MODULE=%s: service=%s, target=%s", __file__, item.service, item.target)
 
+    assert isinstance(item.addrs, list), "`item.addrs` is not a list"
+
     level = item.addrs[0]
 
     text = item.message
@@ -24,7 +26,7 @@ def plugin(srv, item):
     try:
         levels[level]("%s", text)
     except Exception as e:
-        srv.logging.warn("Cannot invoke service log with level `%s': %s" % (level, e))
+        srv.logging.error("Cannot invoke service log with level `%s': %s" % (level, e))
         return False
 
     return True

--- a/templates/test.jinja
+++ b/templates/test.jinja
@@ -1,0 +1,3 @@
+{# This is a comment in Jinja2. #}
+{% set upname = name | upper %}
+Name: {{ upname }}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,8 +3,12 @@
 
 # Configuration- and function files used by the test harness
 configfile_full = "tests/etc/full.ini"
+configfile_cron_valid = "tests/etc/cron-valid.ini"
+configfile_cron_invalid = "tests/etc/cron-invalid.ini"
+configfile_dict_router = "tests/etc/dict-router.ini"
 configfile_service_loading = "tests/etc/service-loading.ini"
 configfile_no_functions = "tests/etc/no-functions.ini"
+configfile_no_targets = "tests/etc/no-targets.ini"
 configfile_status_publish = "tests/etc/status-publish.ini"
 configfile_empty_functions = "tests/etc/empty-functions.ini"
 configfile_unknown_functions = "tests/etc/unknown-functions.ini"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import importlib
+import sys
+
 import pytest
 
 # Import custom fixtures.
@@ -11,3 +14,19 @@ def fake_filesystem(fs):  # pylint:disable=invalid-name
     except Exception:
         pass
     yield fs
+
+
+@pytest.fixture
+def without_jinja():
+
+    # Emulate removal of `jinja2` package.
+    # https://stackoverflow.com/a/65163627
+    backup = sys.modules["jinja2"]
+    sys.modules["jinja2"] = None
+    importlib.reload(sys.modules["mqttwarn.core"])
+
+    yield
+
+    # Restore `jinja2` package.
+    sys.modules["jinja2"] = backup
+    importlib.reload(sys.modules["mqttwarn.core"])

--- a/tests/etc/cron-invalid.ini
+++ b/tests/etc/cron-invalid.ini
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# (c) 2014-2022 The mqttwarn developers
+#
+# mqttwarn configuration file for testing the "periodic tasks" feature.
+#
+
+[defaults]
+
+[cron]
+cronfunc = 0.5; now=true

--- a/tests/etc/cron-valid.ini
+++ b/tests/etc/cron-valid.ini
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# (c) 2014-2022 The mqttwarn developers
+#
+# mqttwarn configuration file for testing the "periodic tasks" feature.
+#
+
+[defaults]
+functions = 'tests/etc/functions_good.py'
+
+[cron]
+cronfunc = 0.5; now=true

--- a/tests/etc/dict-router.ini
+++ b/tests/etc/dict-router.ini
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# (c) 2014-2022 The mqttwarn developers
+#
+# mqttwarn configuration file for testing the dictionary-based catchall router.
+#
+
+[defaults]
+launch    = log
+
+[config:log]
+targets = {
+    'debug'  : [ 'debug' ],
+    'info'   : [ 'info' ],
+    'warn'   : [ 'warn' ],
+    'crit'   : [ 'crit' ],
+    'error'  : [ 'error' ]
+  }
+
+[#]
+targets = {
+  'test/targets-dict/info': 'log:info',
+  'test/targets-dict/warn': [ 'log:warn' ],
+  }

--- a/tests/etc/full.ini
+++ b/tests/etc/full.ini
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 # (c) 2014-2018 The mqttwarn developers
 #
-# mqttwarn example configuration file "mqttwarn.ini"
-# generate with "mqttwarn make-config"
+# mqttwarn configuration file for testing many details of the machinery.
 #
 
 ; ------------------------------------------
@@ -63,7 +62,9 @@ targets = {
     'info'   : [ 'info' ],
     'warn'   : [ 'warn' ],
     'crit'   : [ 'crit' ],
-    'error'  : [ 'error' ]
+    'error'  : [ 'error' ],
+    'invalid': [ 'invalid' ],
+    'broken':  'broken'
   }
 
 [config:file]
@@ -125,3 +126,20 @@ datamap = datamap_dummy()
 [test/alldata]
 targets = log:info
 datamap = alldata_dummy()
+
+[test/targets-interpolated]
+targets = log:{loglevel}
+format  = Something {loglevel} happened! {message}
+
+[test/targets-function-valid]
+targets = get_targets_valid()
+
+[test/targets-function-invalid]
+targets = get_targets_invalid()
+
+[test/targets-function-broken]
+targets = get_targets_broken()
+
+[test/template-1]
+template = test.jinja
+targets = log:info

--- a/tests/etc/functions_good.py
+++ b/tests/etc/functions_good.py
@@ -1,8 +1,16 @@
 # -*- coding: utf-8 -*-
-# (c) 2018-2019 The mqttwarn developers
+# (c) 2018-2022 The mqttwarn developers
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def foobar():
+    return True
+
+
+def cronfunc(srv):
+    logger.info("`cronfunc` called")
     return True
 
 
@@ -17,3 +25,15 @@ def datamap_dummy(topic):
 
 def alldata_dummy(topic):
     return {"alldata-key": "alldata-value"}
+
+
+def get_targets_valid(srv, topic, data):
+    return ["log:info"]
+
+
+def get_targets_invalid(srv, topic, data):
+    return ["log:invalid"]
+
+
+def get_targets_broken(srv, topic, data):
+    return "broken"

--- a/tests/etc/no-targets.ini
+++ b/tests/etc/no-targets.ini
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# (c) 2014-2022 The mqttwarn developers
+#
+# mqttwarn configuration file for testing a service with no targets.
+#
+
+[defaults]
+launch    = log
+
+[config:log]
+targets = {
+    'debug'  : [ 'debug' ],
+    'info'   : [ 'info' ],
+    'warn'   : [ 'warn' ],
+    'crit'   : [ 'crit' ],
+    'error'  : [ 'error' ]
+  }
+
+[test/no-targets]

--- a/tests/services/test_log.py
+++ b/tests/services/test_log.py
@@ -1,0 +1,63 @@
+import json
+import logging
+
+from tests import configfile_full
+from tests.util import core_bootstrap, send_message
+
+
+def test_log_invalid_target(caplog):
+    """
+    Verify that mqttwarn warns appropriately when evaluating
+    topic target interpolating yields an invalid log level.
+    """
+
+    with caplog.at_level(logging.DEBUG):
+
+        # Bootstrap the core machinery without MQTT.
+        core_bootstrap(configfile=configfile_full)
+
+        # Signal mocked MQTT message to the core machinery for processing.
+        payload = json.dumps({"loglevel": "invalid", "message": "Foo bar"})
+        send_message(topic="test/targets-interpolated", payload=payload)
+
+        # Proof that the message has been routed to the "log" plugin properly.
+        assert ("mqttwarn.core", 20, "Invoking service plugin for `log'") in caplog.record_tuples
+        assert (
+            "mqttwarn.services.log",
+            40,
+            "Cannot invoke service log with level `invalid': 'invalid'",
+        ) in caplog.record_tuples
+        assert (
+            "mqttwarn.core",
+            30,
+            "Notification of log for `test/targets-interpolated' FAILED or TIMED OUT",
+        ) in caplog.record_tuples
+
+
+def test_log_broken_target(caplog):
+    """
+    Verify that mqttwarn warns appropriately when evaluating
+    topic target interpolating does not yield a list.
+    """
+
+    with caplog.at_level(logging.DEBUG):
+
+        # Bootstrap the core machinery without MQTT.
+        core_bootstrap(configfile=configfile_full)
+
+        # Signal mocked MQTT message to the core machinery for processing.
+        payload = json.dumps({"loglevel": "broken", "message": "Foo bar"})
+        send_message(topic="test/targets-interpolated", payload=payload)
+
+        # Proof that the message has been routed to the "log" plugin properly.
+        assert ("mqttwarn.core", 20, "Invoking service plugin for `log'") in caplog.record_tuples
+        assert (
+            "mqttwarn.core",
+            40,
+            "Invoking service 'log' failed: `item.addrs` is not a list",
+        ) in caplog.record_tuples
+        assert (
+            "mqttwarn.core",
+            30,
+            "Notification of log for `test/targets-interpolated' FAILED or TIMED OUT",
+        ) in caplog.record_tuples

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,22 +1,37 @@
 # -*- coding: utf-8 -*-
-# (c) 2018-2020 The mqttwarn developers
+# (c) 2018-2022 The mqttwarn developers
 import io
 import json
 import logging
 import os
+import socket
 import tempfile
+import threading
 from builtins import str
+from unittest import mock
+from unittest.mock import call
 
 import pytest
-from mqttwarn.core import decode_payload, make_service, on_connect, render_template
+from mqttwarn.core import (
+    cleanup,
+    decode_payload,
+    make_service,
+    on_connect,
+    render_template,
+    subscribe_forever,
+)
 from tests import (
+    configfile_cron_invalid,
+    configfile_cron_valid,
+    configfile_dict_router,
     configfile_empty_functions,
     configfile_full,
     configfile_no_functions,
+    configfile_no_targets,
     configfile_service_loading,
     configfile_unknown_functions,
 )
-from tests.util import core_bootstrap, send_message
+from tests.util import core_bootstrap, delay, send_message
 
 
 def test_make_service():
@@ -304,6 +319,26 @@ Original payload.....: {'foo': 'bar'}
     )
 
 
+def test_bootstrap_with_jinja2():
+    """
+    Verify `jinja2` is installed.
+    """
+
+    import mqttwarn
+
+    assert mqttwarn.core.HAVE_JINJA is True
+
+
+def test_bootstrap_without_jinja2(without_jinja):
+    """
+    Approve that mqttwarn can also work without Jinja2.
+    """
+
+    import mqttwarn
+
+    assert mqttwarn.core.HAVE_JINJA is False
+
+
 def test_on_connect(caplog):
     for result_code in range(1, 6):
         on_connect(mosq=None, userdata=None, flags=None, result_code=result_code)
@@ -314,3 +349,340 @@ def test_on_connect(caplog):
         ("mqttwarn.core", 40, "Connection refused - bad user name or password"),
         ("mqttwarn.core", 40, "Connection refused - not authorised"),
     ]
+
+
+def test_no_targets(caplog):
+    """
+    Verify behavior of mqttwarn when no targets are specified.
+    """
+
+    with caplog.at_level(logging.DEBUG):
+
+        # Bootstrap the core machinery without MQTT.
+        core_bootstrap(configfile=configfile_no_targets)
+
+        # Signal mocked MQTT messages to the core machinery for processing.
+        send_message(topic="test/template-1", payload="foobar")
+
+        # Proof that the message has been routed to the "log" plugin properly.
+        assert ("mqttwarn.core", 10, "Message received on test/template-1: foobar") in caplog.record_tuples
+        assert ("mqttwarn.context", 30, "Section `test/no-targets' has no targets defined") in caplog.record_tuples
+
+
+def test_targets_interpolated_valid(caplog):
+    """
+    Verify that interpolating values into topic targets works.
+    """
+
+    with caplog.at_level(logging.DEBUG):
+
+        # Bootstrap the core machinery without MQTT.
+        core_bootstrap(configfile=configfile_full)
+
+        # Signal mocked MQTT message to the core machinery for processing.
+        payload = json.dumps({"loglevel": "crit", "message": "Nur Döner macht schöner!"})
+        send_message(topic="test/targets-interpolated", payload=payload)
+
+        # Proof that the message has been routed to the "log" plugin properly.
+        assert ("mqttwarn.core", 20, "Invoking service plugin for `log'") in caplog.record_tuples
+        assert (
+            "mqttwarn.services.log",
+            50,
+            "Something crit happened! Nur Döner macht schöner!",
+        ) in caplog.record_tuples
+
+
+def test_targets_interpolated_unknown(caplog):
+    """
+    Verify that mqttwarn warns appropriately when hitting an unknown target.
+    """
+
+    with caplog.at_level(logging.DEBUG):
+
+        # Bootstrap the core machinery without MQTT.
+        core_bootstrap(configfile=configfile_full)
+
+        # Signal mocked MQTT message to the core machinery for processing.
+        payload = json.dumps({"loglevel": "unknown", "message": "foobar"})
+        send_message(topic="test/targets-interpolated", payload=payload)
+
+        # Proof that the message has been routed to the "log" plugin properly.
+        assert ("mqttwarn.core", 10, "New `log:unknown' job: test/targets-interpolated") in caplog.record_tuples
+        assert ("mqttwarn.core", 40, "Cannot handle service=log, target=unknown") in caplog.record_tuples
+        assert (
+            """KeyError: "Invalid configuration: Topic 'test/targets-interpolated' """
+            '''points to non-existing target 'unknown' in service 'log'"''' in caplog.text
+        )
+
+
+def test_targets_function_valid(caplog):
+    """
+    Verify that resolving the targets using a function works.
+    """
+
+    with caplog.at_level(logging.DEBUG):
+
+        # Bootstrap the core machinery without MQTT.
+        core_bootstrap(configfile=configfile_full)
+
+        # Signal mocked MQTT message to the core machinery for processing.
+        send_message(topic="test/targets-function-valid", payload="foobar")
+
+        # Proof that the message has been routed to the "log" plugin properly.
+        assert (
+            "mqttwarn.configuration",
+            20,
+            "Loading user-defined functions from tests/etc/functions_good.py",
+        ) in caplog.record_tuples
+        assert ("mqttwarn.core", 10, "New `log:info' job: test/targets-function-valid") in caplog.record_tuples
+        assert ("mqttwarn.core", 20, "Invoking service plugin for `log'") in caplog.record_tuples
+        assert ("mqttwarn.services.log", 20, "foobar") in caplog.record_tuples
+
+
+def test_targets_function_invalid(caplog):
+    """
+    Verify that mqttwarn warns correctly when resolving the targets using a function yields invalid results.
+    """
+
+    with caplog.at_level(logging.DEBUG):
+
+        # Bootstrap the core machinery without MQTT.
+        core_bootstrap(configfile=configfile_full)
+
+        # Signal mocked MQTT message to the core machinery for processing.
+        send_message(topic="test/targets-function-invalid", payload="foobar")
+
+        # Proof that the message has been routed to the "log" plugin properly.
+        assert ("mqttwarn.core", 10, "New `log:invalid' job: test/targets-function-invalid") in caplog.record_tuples
+        assert ("mqttwarn.core", 20, "Invoking service plugin for `log'") in caplog.record_tuples
+        assert (
+            "mqttwarn.services.log",
+            40,
+            "Cannot invoke service log with level `invalid': 'invalid'",
+        ) in caplog.record_tuples
+        assert (
+            "mqttwarn.core",
+            30,
+            "Notification of log for `test/targets-function-invalid' FAILED or TIMED OUT",
+        ) in caplog.record_tuples
+
+
+def test_targets_function_broken(caplog):
+    """
+    Verify that mqttwarn warns correctly when resolving the targets using a function yields invalid results.
+    """
+
+    with caplog.at_level(logging.DEBUG):
+
+        # Bootstrap the core machinery without MQTT.
+        core_bootstrap(configfile=configfile_full)
+
+        # Signal mocked MQTT message to the core machinery for processing.
+        send_message(topic="test/targets-function-broken", payload="foobar")
+
+        # Proof that the message has been routed to the "log" plugin properly.
+        assert (
+            "mqttwarn.core",
+            40,
+            'Topic target definition by function "get_targets_broken" in section "test/targets-function-broken" '
+            "is empty or incorrect. Should be a list. targetlist=broken, type=<class 'str'>",
+        ) in caplog.record_tuples
+
+
+def test_targets_dictionary_valid(caplog):
+    """
+    Verify that specifying the targets using a dictionary works.
+    """
+
+    with caplog.at_level(logging.DEBUG):
+
+        # Bootstrap the core machinery without MQTT.
+        core_bootstrap(configfile=configfile_dict_router)
+
+        # Signal mocked MQTT messages to the core machinery for processing.
+        send_message(topic="test/targets-dict/info", payload="foobar")
+        send_message(topic="test/targets-dict/warn", payload="foobar")
+
+        # Proof that the `info` messages have been routed to the "log" plugin properly.
+        assert (
+            "mqttwarn.core",
+            10,
+            "Section [#] matches message on test/targets-dict/info, processing it",
+        ) in caplog.record_tuples
+        assert ("mqttwarn.core", 10, "New `log:info' job: test/targets-dict/info") in caplog.record_tuples
+        assert ("mqttwarn.core", 20, "Invoking service plugin for `log'") in caplog.record_tuples
+        assert ("mqttwarn.services.log", 20, "foobar") in caplog.record_tuples
+
+        # Proof that the `warn` messages have been routed to the "log" plugin properly.
+        assert (
+            "mqttwarn.core",
+            10,
+            "Section [#] matches message on test/targets-dict/warn, processing it",
+        ) in caplog.record_tuples
+        assert ("mqttwarn.core", 10, "New `log:warn' job: test/targets-dict/warn") in caplog.record_tuples
+        assert ("mqttwarn.core", 20, "Invoking service plugin for `log'") in caplog.record_tuples
+        assert ("mqttwarn.services.log", 30, "foobar") in caplog.record_tuples
+
+
+def test_process_template_with_jinja(caplog):
+    """
+    Verify that the Jinja2 templating subsystem works.
+    """
+
+    with caplog.at_level(logging.DEBUG):
+
+        # Bootstrap the core machinery without MQTT.
+        core_bootstrap(configfile=configfile_full)
+
+        # Signal mocked MQTT messages to the core machinery for processing.
+        send_message(topic="test/template-1", payload=json.dumps({"name": "foobar"}))
+
+        # Proof that the message has been routed to the "log" plugin properly.
+        assert ("mqttwarn.core", 10, "New `log:info' job: test/template-1") in caplog.record_tuples
+        assert ("mqttwarn.core", 20, "Invoking service plugin for `log'") in caplog.record_tuples
+        assert ("mqttwarn.services.log", 20, "Name: FOOBAR") in caplog.record_tuples
+
+
+def test_process_template_without_jinja(caplog, without_jinja):
+    """
+    Verify that mqttwarn behaves correctly when using the templating subsystem without having jinja2 installed.
+    """
+
+    with caplog.at_level(logging.DEBUG):
+
+        # Bootstrap the core machinery without MQTT.
+        core_bootstrap(configfile=configfile_full)
+
+        # Signal mocked MQTT messages to the core machinery for processing.
+        send_message(topic="test/template-1", payload=json.dumps({"name": "foobar"}))
+
+        # Proof that the message has been routed to the "log" plugin properly.
+        assert ("mqttwarn.core", 10, "New `log:info' job: test/template-1") in caplog.record_tuples
+        assert ("mqttwarn.core", 30, "Templating not possible because Jinja2 is not installed") in caplog.record_tuples
+        assert ("mqttwarn.core", 20, "Invoking service plugin for `log'") in caplog.record_tuples
+        assert ("mqttwarn.services.log", 20, '{"name": "foobar"}') in caplog.record_tuples
+
+
+def test_subscribe_forever_success(caplog, mocker):
+    """
+    Verify the `core.subscribe_forever` function.
+    """
+
+    # Adjust plumbing to speed up test case.
+    mocker.patch("time.sleep", lambda _: delay(0.05))
+
+    # Invoke `subscribe_forever` and terminate right away using `exit_flag`.
+    connect = mocker.patch("mqttwarn.core.connect")
+    t = threading.Thread(target=subscribe_forever)
+    t.start()
+    mocker.patch("mqttwarn.core.exit_flag", True)
+    t.join()
+
+    assert connect.mock_calls == [call(), call().loop_forever()]
+
+    assert caplog.record_tuples == [
+        ("mqttwarn.core", 30, "MQTT server disconnected, trying to reconnect each 5 seconds"),
+    ]
+
+
+def test_subscribe_forever_fails_socket_error(caplog, mocker):
+    """
+    Verify the `core.subscribe_forever` function correctly reports about errors.
+    """
+
+    # Adjust plumbing to speed up test case.
+    mocker.patch("time.sleep", lambda _: delay(0.05))
+
+    # Invoke `subscribe_forever` and terminate right away using `exit_flag`.
+    connect = mocker.patch("mqttwarn.core.connect")
+    connect.return_value = mock.MagicMock(**{"loop_forever.side_effect": socket.error("Something failed")})
+    t = threading.Thread(target=subscribe_forever)
+    t.start()
+    mocker.patch("mqttwarn.core.exit_flag", True)
+    t.join()
+
+    assert connect.mock_calls == [call(), call().loop_forever()]
+
+    assert caplog.record_tuples == [
+        ("mqttwarn.core", 40, "Connection to MQTT broker lost: OSError(Something failed)"),
+    ] or caplog.record_tuples == [
+        ("mqttwarn.core", 30, "MQTT server disconnected, trying to reconnect each 5 seconds"),
+    ]
+
+
+def test_subscribe_forever_fails_unknown_error(caplog, mocker):
+    """
+    Verify the `core.subscribe_forever` function correctly reports about errors.
+    """
+
+    # Adjust plumbing to speed up test case.
+    mocker.patch("time.sleep", lambda _: delay(0.05))
+
+    # Invoke `subscribe_forever` and terminate right away using `exit_flag`.
+    connect = mocker.patch("mqttwarn.core.connect")
+    connect.return_value = mock.MagicMock(**{"loop_forever.side_effect": ValueError("Something failed")})
+    t = threading.Thread(target=subscribe_forever)
+    t.start()
+    mocker.patch("mqttwarn.core.exit_flag", True)
+    t.join()
+
+    assert connect.mock_calls == [call(), call().loop_forever()]
+
+    assert caplog.record_tuples == [
+        ("mqttwarn.core", 40, "Connection to MQTT broker lost: ValueError(Something failed)"),
+    ]
+
+
+def test_cron_success(caplog, mocker):
+    """
+    Approve the `cron` subsystem.
+    """
+
+    with caplog.at_level(logging.DEBUG):
+
+        mocker.patch("sys.exit")
+        mqttc = mocker.patch("mqttwarn.core.mqttc")
+
+        # Bootstrap the core machinery without MQTT, and shut it down again.
+        core_bootstrap(configfile=configfile_cron_valid)
+        cleanup()
+
+        assert mqttc.mock_calls == [
+            call.publish("clients/mqttwarn", "0", qos=0, retain=True),
+            call.loop_stop(),
+            call.disconnect(),
+        ]
+
+        # Proof that the cron function has been called at least once.
+        assert (
+            "mqttwarn.configuration",
+            20,
+            "Loading user-defined functions from tests/etc/functions_good.py",
+        ) in caplog.record_tuples
+        assert (
+            "mqttwarn.configuration",
+            30,
+            "Expecting a list in section `defaults', key `launch' (No option 'launch' in section: 'defaults')",
+        ) in caplog.record_tuples
+        assert ("mqttwarn.core", 30, "No services defined") in caplog.record_tuples
+        assert (
+            "mqttwarn.core",
+            20,
+            "Scheduling periodic task 'cronfunc' to run each 0.5 seconds via [cron] section",
+        ) in caplog.record_tuples
+        assert ("functions_good", 20, "`cronfunc` called") in caplog.record_tuples
+
+        assert ("mqttwarn.core", 20, "Cancelling periodic task 'cronfunc'") in caplog.record_tuples
+        assert ("mqttwarn.core", 10, "Disconnecting from MQTT broker") in caplog.record_tuples
+        assert ("mqttwarn.core", 20, "Waiting for queue to drain") in caplog.record_tuples
+        assert ("mqttwarn.core", 10, "Exiting on signal None") in caplog.record_tuples
+
+
+def test_cron_without_functions(caplog):
+    """
+    Verify that mqttwarn croaks when configuring a `cron` function, but no function file.
+    """
+
+    with pytest.raises(AssertionError) as ex:
+        core_bootstrap(configfile=configfile_cron_invalid)
+    assert ex.match("Python module must be given")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,7 +8,7 @@ import tempfile
 from builtins import str
 
 import pytest
-from mqttwarn.core import decode_payload, make_service, render_template
+from mqttwarn.core import decode_payload, make_service, on_connect, render_template
 from tests import (
     configfile_empty_functions,
     configfile_full,
@@ -302,3 +302,15 @@ Timestamp............: 1234567890
 Original payload.....: {'foo': 'bar'}
 """.strip()
     )
+
+
+def test_on_connect(caplog):
+    for result_code in range(1, 6):
+        on_connect(mosq=None, userdata=None, flags=None, result_code=result_code)
+    assert caplog.record_tuples == [
+        ("mqttwarn.core", 40, "Connection refused - unacceptable protocol version"),
+        ("mqttwarn.core", 40, "Connection refused - identifier rejected"),
+        ("mqttwarn.core", 40, "Connection refused - server unavailable"),
+        ("mqttwarn.core", 40, "Connection refused - bad user name or password"),
+        ("mqttwarn.core", 40, "Connection refused - not authorised"),
+    ]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# (c) 2022 The mqttwarn developers
+from mqttwarn.core import Job
+
+
+def test_sort_jobs_by_priority():
+    job1 = Job(
+        prio=1, service="service", section="section", topic="topic", payload="payload", data="data", target="target"
+    )
+    job2 = Job(
+        prio=2, service="service", section="section", topic="topic", payload="payload", data="data", target="target"
+    )
+
+    assert sorted([job2, job1]) == [job1, job2]

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,6 +2,7 @@
 # (c) 2018-2021 The mqttwarn developers
 import threading
 
+import mqttwarn
 import paho
 from mqttwarn.configuration import load_configuration
 from mqttwarn.core import bootstrap, load_services, on_message, start_workers
@@ -10,8 +11,12 @@ from paho.mqtt.client import MQTTMessage
 
 def core_bootstrap(configfile=None):
     """
-    Bootstrap the core machinery without MQTT
+    Bootstrap the core machinery without MQTT.
     """
+
+    # If mqttwarn was already invoked beforehand, reset "exit flag".
+    # TODO: Get rid of global variables.
+    mqttwarn.core.exit_flag = False
 
     # Load configuration file
     config = load_configuration(configfile)


### PR DESCRIPTION
Hi again,

as a followup to #589, this patch exercises more details of `mqttwarn/core.py`, and bumps its coverage to 85%, now covering all of its happy paths. Along the lines, it improves and fixes some very minor issues.

With kind regards,
Andreas.
