### PR TITLE
Tests: Trim and improve test cases for service plugins

### DIFF
--- a/mqttwarn/services/alexa-notify-me.py
+++ b/mqttwarn/services/alexa-notify-me.py
@@ -23,7 +23,7 @@ def plugin(srv, item):
     srv.logging.debug("*** MODULE=%s: service=%s, target=%s", __file__, item.service, item.target)
 
     try:
-        srv.logging.debug("Sending to NotifyMe service.")
+        srv.logging.debug("Sending to NotifyMe service")
         body = json.dumps({
             "notification": item.message,
             "accessCode": item.addrs[0]
@@ -32,7 +32,7 @@ def plugin(srv, item):
         response = requests.post(url="https://api.notifymyecho.com/v1/NotifyMe", data=body)
         response.raise_for_status()
 
-        srv.logging.debug("Successfully sent to NotifyMe service.")
+        srv.logging.debug("Successfully sent to NotifyMe service")
 
     except Exception as e:
         srv.logging.warning("Failed to send message to NotifyMe service: %s" % e)

--- a/mqttwarn/services/amqp.py
+++ b/mqttwarn/services/amqp.py
@@ -16,7 +16,7 @@ def plugin(srv, item):
     exchange, routing_key = item.addrs
 
     try:
-        srv.logging.debug("AMQP publish to %s [%s/%s]..." % (item.target, exchange, routing_key))
+        srv.logging.debug("AMQP publish to %s [%s/%s]" % (item.target, exchange, routing_key))
 
         client = puka.Client(uri)
         promise = client.connect()

--- a/mqttwarn/services/azure_iot.py
+++ b/mqttwarn/services/azure_iot.py
@@ -21,7 +21,7 @@ def plugin(srv, item):
     iothubname = item.config['iothubname']
     qos = int(item.config.get('qos', 0))
     if qos < 0 or qos > 1:
-        srv.logging.error("Only QoS 0 or 1 allowed for Azure IoT Hub, not '%s'." % str(qos))
+        srv.logging.error("Only QoS 0 or 1 allowed for Azure IoT Hub, not '%s'" % str(qos))
         return False
 
     # connection info...

--- a/mqttwarn/services/pushover.py
+++ b/mqttwarn/services/pushover.py
@@ -132,7 +132,7 @@ def plugin(srv, item):
         image = base64.decodebytes(imagebase64)
 
     try:
-        srv.logging.debug("Sending pushover notification to %s [%s]...." % (item.target, params))
+        srv.logging.debug("Sending pushover notification to %s [%s]" % (item.target, params))
         pushover(image=image, user=userkey, token=token, **params)
         srv.logging.debug("Successfully sent pushover notification")
     except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,6 @@
 
 [tool.isort]
 profile = "black"
-#src_paths = ["mqttwarn", "examples", "tests"]
-src_paths = ["test"]
 
 [tool.black]
 line-length = 120

--- a/tests/services/test_alexa.py
+++ b/tests/services/test_alexa.py
@@ -1,30 +1,26 @@
 # -*- coding: utf-8 -*-
-# (c) 2021 The mqttwarn developers
-import logging
-from unittest import mock
-
+# (c) 2021-2022 The mqttwarn developers
 from mqttwarn.model import ProcessorItem as Item
 from mqttwarn.util import load_module_from_file
 
 
-def test_alexa_notify_me_success(srv, caplog):
+def test_alexa_notify_me_success(srv, mocker, caplog):
 
     module = load_module_from_file("mqttwarn/services/alexa-notify-me.py")
 
     accessCode = "myToken"
     item = Item(addrs=[accessCode], message="⚽ Notification message ⚽")
 
-    with caplog.at_level(logging.DEBUG):
-        with mock.patch("requests.post") as requests_mock:
-            outcome = module.plugin(srv, item)
-            requests_mock.assert_called_once_with(
-                url="https://api.notifymyecho.com/v1/NotifyMe",
-                data='{"notification": "\\u26bd Notification message \\u26bd", "accessCode": "myToken"}',
-            )
+    requests_mock = mocker.patch("requests.post")
+    outcome = module.plugin(srv, item)
+    requests_mock.assert_called_once_with(
+        url="https://api.notifymyecho.com/v1/NotifyMe",
+        data='{"notification": "\\u26bd Notification message \\u26bd", "accessCode": "myToken"}',
+    )
 
-        assert outcome is True
-        assert "Sending to NotifyMe service" in caplog.text
-        assert "Successfully sent to NotifyMe service" in caplog.text
+    assert outcome is True
+    assert "Sending to NotifyMe service" in caplog.messages
+    assert "Successfully sent to NotifyMe service" in caplog.messages
 
 
 def test_alexa_notify_me_real_auth_failure(srv, caplog):
@@ -33,9 +29,8 @@ def test_alexa_notify_me_real_auth_failure(srv, caplog):
     accessCode = "myToken"
     item = Item(addrs=[accessCode], message="⚽ Notification message ⚽")
 
-    with caplog.at_level(logging.DEBUG):
-        outcome = module.plugin(srv, item)
+    outcome = module.plugin(srv, item)
 
-        assert outcome is False
-        assert "Sending to NotifyMe service" in caplog.text
-        assert "Failed to send message to NotifyMe service" in caplog.text
+    assert outcome is False
+    assert "Sending to NotifyMe service" in caplog.messages
+    assert "Failed to send message to NotifyMe service" in caplog.text

--- a/tests/services/test_apns.py
+++ b/tests/services/test_apns.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# (c) 2021 The mqttwarn developers
-import logging
+# (c) 2021-2022 The mqttwarn developers
 from unittest import mock
 from unittest.mock import call
 
+from surrogate import surrogate
+
 from mqttwarn.model import ProcessorItem as Item
 from mqttwarn.util import load_module_from_file
-from surrogate import surrogate
 
 
 @surrogate("apns")
@@ -14,35 +14,33 @@ from surrogate import surrogate
 @mock.patch("apns.Payload", create=True)
 def test_apns_success(mock_apns_payload, mock_apns, srv, caplog):
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/apns.py")
 
-        module = load_module_from_file("mqttwarn/services/apns.py")
+    cert_file, key_file = ["cert_file", "key_file"]
+    item = Item(
+        target="test",
+        addrs=[cert_file, key_file],
+        message="⚽ Notification message ⚽",
+        data={"apns_token": "foobar", "payload": "{}"},
+    )
 
-        cert_file, key_file = ["cert_file", "key_file"]
-        item = Item(
-            target="test",
-            addrs=[cert_file, key_file],
-            message="⚽ Notification message ⚽",
-            data={"apns_token": "foobar", "payload": "{}"},
-        )
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
+    assert mock_apns.mock_calls == [
+        mock.call(use_sandbox=False, cert_file="cert_file", key_file="key_file"),
+        call().gateway_server.send_notification("foobar", mock.ANY),
+    ]
+    assert mock_apns_payload.mock_calls == [
+        call(
+            alert="⚽ Notification message ⚽",
+            custom={},
+            sound="default",
+            badge=1,
+        ),
+    ]
 
-        assert mock_apns_payload.mock_calls == [
-            call(
-                alert="⚽ Notification message ⚽",
-                custom={},
-                sound="default",
-                badge=1,
-            ),
-        ]
-        assert mock_apns.mock_calls == [
-            mock.call(use_sandbox=False, cert_file="cert_file", key_file="key_file"),
-            call().gateway_server.send_notification("foobar", mock.ANY),
-        ]
-
-        assert outcome is True
-        assert "Successfully published APNS notification to foobar" in caplog.text
+    assert outcome is True
+    assert "Successfully published APNS notification to foobar" in caplog.messages
 
 
 @surrogate("apns")
@@ -50,35 +48,23 @@ def test_apns_success(mock_apns_payload, mock_apns, srv, caplog):
 @mock.patch("apns.Payload", create=True)
 def test_apns_success_no_payload(mock_apns_payload, mock_apns, srv, caplog):
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/apns.py")
 
-        module = load_module_from_file("mqttwarn/services/apns.py")
+    cert_file, key_file = ["cert_file", "key_file"]
+    item = Item(
+        target="test",
+        addrs=[cert_file, key_file],
+        message="⚽ Notification message ⚽",
+        data={"apns_token": "foobar"},
+    )
 
-        cert_file, key_file = ["cert_file", "key_file"]
-        item = Item(
-            target="test",
-            addrs=[cert_file, key_file],
-            message="⚽ Notification message ⚽",
-            data={"apns_token": "foobar"},
-        )
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
+    mock_apns.assert_called_once()
+    mock_apns_payload.assert_called_once()
 
-        assert mock_apns_payload.mock_calls == [
-            call(
-                alert="⚽ Notification message ⚽",
-                custom={},
-                sound="default",
-                badge=1,
-            ),
-        ]
-        assert mock_apns.mock_calls == [
-            mock.call(use_sandbox=False, cert_file="cert_file", key_file="key_file"),
-            call().gateway_server.send_notification("foobar", mock.ANY),
-        ]
-
-        assert outcome is True
-        assert "Successfully published APNS notification to foobar" in caplog.text
+    assert outcome is True
+    assert "Successfully published APNS notification to foobar" in caplog.messages
 
 
 @surrogate("apns")
@@ -86,38 +72,33 @@ def test_apns_success_no_payload(mock_apns_payload, mock_apns, srv, caplog):
 @mock.patch("apns.Payload", create=True)
 def test_apns_success_custom_payload(mock_apns_payload, mock_apns, srv, caplog):
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/apns.py")
 
-        module = load_module_from_file("mqttwarn/services/apns.py")
+    cert_file, key_file = ["cert_file", "key_file"]
+    item = Item(
+        target="test",
+        addrs=[cert_file, key_file],
+        message="⚽ Notification message ⚽",
+        data={
+            "apns_token": "foobar",
+            "payload": '{"custom": {"baz": "qux"}}',
+        },
+    )
 
-        cert_file, key_file = ["cert_file", "key_file"]
-        item = Item(
-            target="test",
-            addrs=[cert_file, key_file],
-            message="⚽ Notification message ⚽",
-            data={
-                "apns_token": "foobar",
-                "payload": '{"custom": {"baz": "qux"}}',
-            },
-        )
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
+    mock_apns.assert_called_once()
+    assert mock_apns_payload.mock_calls == [
+        call(
+            alert="⚽ Notification message ⚽",
+            custom={"baz": "qux"},
+            sound="default",
+            badge=1,
+        ),
+    ]
 
-        assert mock_apns_payload.mock_calls == [
-            call(
-                alert="⚽ Notification message ⚽",
-                custom={"baz": "qux"},
-                sound="default",
-                badge=1,
-            ),
-        ]
-        assert mock_apns.mock_calls == [
-            mock.call(use_sandbox=False, cert_file="cert_file", key_file="key_file"),
-            call().gateway_server.send_notification("foobar", mock.ANY),
-        ]
-
-        assert outcome is True
-        assert "Successfully published APNS notification to foobar" in caplog.text
+    assert outcome is True
+    assert "Successfully published APNS notification to foobar" in caplog.messages
 
 
 @surrogate("apns")
@@ -125,21 +106,19 @@ def test_apns_success_custom_payload(mock_apns_payload, mock_apns, srv, caplog):
 @mock.patch("apns.Payload", create=True)
 def test_apns_failure_invalid_config(mock_apns_payload, mock_apns, srv, caplog):
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/apns.py")
 
-        module = load_module_from_file("mqttwarn/services/apns.py")
+    item = Item(
+        target="test",
+        addrs=[None],
+        message="⚽ Notification message ⚽",
+        data={"apns_token": "foobar", "payload": "{}"},
+    )
 
-        item = Item(
-            target="test",
-            addrs=[None],
-            message="⚽ Notification message ⚽",
-            data={"apns_token": "foobar", "payload": "{}"},
-        )
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
-
-        assert outcome is False
-        assert "Incorrect service configuration" in caplog.text
+    assert outcome is False
+    assert "Incorrect service configuration" in caplog.messages
 
 
 @surrogate("apns")
@@ -147,19 +126,17 @@ def test_apns_failure_invalid_config(mock_apns_payload, mock_apns, srv, caplog):
 @mock.patch("apns.Payload", create=True)
 def test_apns_failure_apns_token_missing(mock_apns_payload, mock_apns, srv, caplog):
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/apns.py")
 
-        module = load_module_from_file("mqttwarn/services/apns.py")
+    cert_file, key_file = ["cert_file", "key_file"]
+    item = Item(
+        target="test",
+        addrs=[cert_file, key_file],
+        message="⚽ Notification message ⚽",
+        data={},
+    )
 
-        cert_file, key_file = ["cert_file", "key_file"]
-        item = Item(
-            target="test",
-            addrs=[cert_file, key_file],
-            message="⚽ Notification message ⚽",
-            data={},
-        )
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
-
-        assert outcome is False
-        assert "Cannot notify via APNS: apns_token is missing" in caplog.text
+    assert outcome is False
+    assert "Cannot notify via APNS: apns_token is missing" in caplog.messages

--- a/tests/services/test_apprise_multi.py
+++ b/tests/services/test_apprise_multi.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# (c) 2021 The mqttwarn developers
-import logging
+# (c) 2021-2022 The mqttwarn developers
 from unittest import mock
 from unittest.mock import call
 
+from surrogate import surrogate
+
 from mqttwarn.model import ProcessorItem as Item
 from mqttwarn.util import load_module_by_name
-from surrogate import surrogate
 
 
 @surrogate("apprise")
@@ -14,36 +14,34 @@ from surrogate import surrogate
 @mock.patch("apprise.AppriseAsset", create=True)
 def test_apprise_multi_basic_success(apprise_asset, apprise_mock, srv, caplog):
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_by_name("mqttwarn.services.apprise_multi")
 
-        module = load_module_by_name("mqttwarn.services.apprise_multi")
+    item = Item(
+        addrs=[
+            {"baseuri": "json://localhost:1234/mqtthook"},
+            {"baseuri": "json://daq.example.org:5555/foobar"},
+        ],
+        title="⚽ Message title ⚽",
+        message="⚽ Notification message ⚽",
+    )
 
-        item = Item(
-            addrs=[
-                {"baseuri": "json://localhost:1234/mqtthook"},
-                {"baseuri": "json://daq.example.org:5555/foobar"},
-            ],
-            title="⚽ Message title ⚽",
-            message="⚽ Notification message ⚽",
-        )
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
+    assert apprise_mock.mock_calls == [
+        call(asset=mock.ANY),
+        call().add("json://localhost:1234/mqtthook"),
+        call().add("json://daq.example.org:5555/foobar"),
+        call().notify(body="⚽ Notification message ⚽", title="⚽ Message title ⚽"),
+        call().notify().__bool__(),
+    ]
 
-        assert apprise_mock.mock_calls == [
-            call(asset=mock.ANY),
-            call().add("json://localhost:1234/mqtthook"),
-            call().add("json://daq.example.org:5555/foobar"),
-            call().notify(body="⚽ Notification message ⚽", title="⚽ Message title ⚽"),
-            call().notify().__bool__(),
-        ]
-
-        assert outcome is True
-        assert (
-            "Sending notification to Apprise. target=None, addresses=["
-            "{'baseuri': 'json://localhost:1234/mqtthook'}, {'baseuri': 'json://daq.example.org:5555/foobar'}]"
-            in caplog.messages
-        )
-        assert "Successfully sent message using Apprise" in caplog.messages
+    assert outcome is True
+    assert (
+        "Sending notification to Apprise. target=None, addresses=["
+        "{'baseuri': 'json://localhost:1234/mqtthook'}, {'baseuri': 'json://daq.example.org:5555/foobar'}]"
+        in caplog.messages
+    )
+    assert "Successfully sent message using Apprise" in caplog.messages
 
 
 @surrogate("apprise")
@@ -51,121 +49,115 @@ def test_apprise_multi_basic_success(apprise_asset, apprise_mock, srv, caplog):
 @mock.patch("apprise.AppriseAsset", create=True)
 def test_apprise_multi_mailto_success(apprise_asset, apprise_mock, srv, caplog):
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_by_name("mqttwarn.services.apprise_multi")
 
-        module = load_module_by_name("mqttwarn.services.apprise_multi")
+    item = Item(
+        addrs=[
+            {
+                "baseuri": "mailtos://smtp_username:smtp_password@mail.example.org",
+                "recipients": ["foo@example.org", "bar@example.org"],
+                "sender": "monitoring@example.org",
+                "sender_name": "Example Monitoring",
+            }
+        ],
+        title="⚽ Message title ⚽",
+        message="⚽ Notification message ⚽",
+    )
 
-        item = Item(
-            addrs=[
-                {
-                    "baseuri": "mailtos://smtp_username:smtp_password@mail.example.org",
-                    "recipients": ["foo@example.org", "bar@example.org"],
-                    "sender": "monitoring@example.org",
-                    "sender_name": "Example Monitoring",
-                }
-            ],
-            title="⚽ Message title ⚽",
-            message="⚽ Notification message ⚽",
-        )
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
+    assert apprise_mock.mock_calls == [
+        call(asset=mock.ANY),
+        call().add(
+            "mailtos://smtp_username:smtp_password@mail.example.org"
+            "?to=foo%40example.org%2Cbar%40example.org&from=monitoring%40example.org&name=Example+Monitoring"
+        ),
+        call().notify(body="⚽ Notification message ⚽", title="⚽ Message title ⚽"),
+        call().notify().__bool__(),
+    ]
 
-        assert apprise_mock.mock_calls == [
-            call(asset=mock.ANY),
-            call().add(
-                "mailtos://smtp_username:smtp_password@mail.example.org"
-                "?to=foo%40example.org%2Cbar%40example.org&from=monitoring%40example.org&name=Example+Monitoring"
-            ),
-            call().notify(body="⚽ Notification message ⚽", title="⚽ Message title ⚽"),
-            call().notify().__bool__(),
-        ]
-
-        assert outcome is True
-        assert (
-            "Sending notification to Apprise. target=None, addresses=["
-            "{"
-            "'baseuri': 'mailtos://smtp_username:smtp_password@mail.example.org', "
-            "'recipients': ['foo@example.org', 'bar@example.org'], "
-            "'sender': 'monitoring@example.org', 'sender_name': 'Example Monitoring'}]" in caplog.messages
-        )
-        assert "Successfully sent message using Apprise" in caplog.messages
+    assert outcome is True
+    assert (
+        "Sending notification to Apprise. target=None, addresses=["
+        "{"
+        "'baseuri': 'mailtos://smtp_username:smtp_password@mail.example.org', "
+        "'recipients': ['foo@example.org', 'bar@example.org'], "
+        "'sender': 'monitoring@example.org', 'sender_name': 'Example Monitoring'}]" in caplog.messages
+    )
+    assert "Successfully sent message using Apprise" in caplog.messages
 
 
 @surrogate("apprise")
 def test_apprise_multi_failure_notify(srv, caplog):
 
-    with caplog.at_level(logging.DEBUG):
+    mock_connection = mock.MagicMock()
 
-        mock_connection = mock.MagicMock()
+    # Make the call to `notify` signal failure.
+    def error(*args, **kwargs):
+        return False
 
-        # Make the call to `notify` signal failure.
-        def error(*args, **kwargs):
-            return False
+    mock_connection.notify = error
 
-        mock_connection.notify = error
+    with mock.patch("apprise.Apprise", side_effect=[mock_connection], create=True) as mock_client:
+        with mock.patch("apprise.AppriseAsset", create=True):
+            module = load_module_by_name("mqttwarn.services.apprise_multi")
 
-        with mock.patch("apprise.Apprise", side_effect=[mock_connection], create=True) as mock_client:
-            with mock.patch("apprise.AppriseAsset", create=True):
-                module = load_module_by_name("mqttwarn.services.apprise_multi")
+            item = Item(
+                addrs=[{"baseuri": "json://localhost:1234/mqtthook"}],
+                title="⚽ Message title ⚽",
+                message="⚽ Notification message ⚽",
+            )
 
-                item = Item(
-                    addrs=[{"baseuri": "json://localhost:1234/mqtthook"}],
-                    title="⚽ Message title ⚽",
-                    message="⚽ Notification message ⚽",
-                )
+            outcome = module.plugin(srv, item)
 
-                outcome = module.plugin(srv, item)
+            assert mock_client.mock_calls == [
+                mock.call(asset=mock.ANY),
+            ]
+            assert mock_connection.mock_calls == [
+                call.add("json://localhost:1234/mqtthook"),
+            ]
 
-                assert mock_client.mock_calls == [
-                    mock.call(asset=mock.ANY),
-                ]
-                assert mock_connection.mock_calls == [
-                    call.add("json://localhost:1234/mqtthook"),
-                ]
-
-                assert outcome is False
-                assert (
-                    "Sending notification to Apprise. target=None, "
-                    "addresses=[{'baseuri': 'json://localhost:1234/mqtthook'}]" in caplog.messages
-                )
-                assert "Sending message using Apprise failed" in caplog.messages
+            assert outcome is False
+            assert (
+                "Sending notification to Apprise. target=None, "
+                "addresses=[{'baseuri': 'json://localhost:1234/mqtthook'}]" in caplog.messages
+            )
+            assert "Sending message using Apprise failed" in caplog.messages
 
 
 @surrogate("apprise")
 def test_apprise_multi_error(srv, caplog):
 
-    with caplog.at_level(logging.DEBUG):
+    mock_connection = mock.MagicMock()
 
-        mock_connection = mock.MagicMock()
+    # Make the call to `notify` raise an exception.
+    def error(*args, **kwargs):
+        raise Exception("something failed")
 
-        # Make the call to `notify` raise an exception.
-        def error(*args, **kwargs):
-            raise Exception("something failed")
+    mock_connection.notify = error
 
-        mock_connection.notify = error
+    with mock.patch("apprise.Apprise", side_effect=[mock_connection], create=True) as mock_client:
+        with mock.patch("apprise.AppriseAsset", create=True):
+            module = load_module_by_name("mqttwarn.services.apprise_multi")
 
-        with mock.patch("apprise.Apprise", side_effect=[mock_connection], create=True) as mock_client:
-            with mock.patch("apprise.AppriseAsset", create=True):
-                module = load_module_by_name("mqttwarn.services.apprise_multi")
+            item = Item(
+                addrs=[{"baseuri": "json://localhost:1234/mqtthook"}],
+                title="⚽ Message title ⚽",
+                message="⚽ Notification message ⚽",
+            )
 
-                item = Item(
-                    addrs=[{"baseuri": "json://localhost:1234/mqtthook"}],
-                    title="⚽ Message title ⚽",
-                    message="⚽ Notification message ⚽",
-                )
+            outcome = module.plugin(srv, item)
 
-                outcome = module.plugin(srv, item)
+            assert mock_client.mock_calls == [
+                mock.call(asset=mock.ANY),
+            ]
+            assert mock_connection.mock_calls == [
+                call.add("json://localhost:1234/mqtthook"),
+            ]
 
-                assert mock_client.mock_calls == [
-                    mock.call(asset=mock.ANY),
-                ]
-                assert mock_connection.mock_calls == [
-                    call.add("json://localhost:1234/mqtthook"),
-                ]
-
-                assert outcome is False
-                assert (
-                    "Sending notification to Apprise. target=None, "
-                    "addresses=[{'baseuri': 'json://localhost:1234/mqtthook'}]" in caplog.messages
-                )
-                assert "Sending message using Apprise failed. target=None, error=something failed" in caplog.messages
+            assert outcome is False
+            assert (
+                "Sending notification to Apprise. target=None, "
+                "addresses=[{'baseuri': 'json://localhost:1234/mqtthook'}]" in caplog.messages
+            )
+            assert "Sending message using Apprise failed. target=None, error=something failed" in caplog.messages

--- a/tests/services/test_apprise_single.py
+++ b/tests/services/test_apprise_single.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# (c) 2021 The mqttwarn developers
-import logging
+# (c) 2021-2022 The mqttwarn developers
 from unittest import mock
 from unittest.mock import call
 
+from surrogate import surrogate
+
 from mqttwarn.model import ProcessorItem as Item
 from mqttwarn.util import load_module_from_file
-from surrogate import surrogate
 
 
 @surrogate("apprise")
@@ -14,35 +14,31 @@ from surrogate import surrogate
 @mock.patch("apprise.AppriseAsset", create=True)
 def test_apprise_success(apprise_asset, apprise_mock, srv, caplog):
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/apprise_single.py")
 
-        module = load_module_from_file("mqttwarn/services/apprise_single.py")
+    item = Item(
+        config={"baseuri": "mailtos://smtp_username:smtp_password@mail.example.org"},
+        target="test",
+        addrs=["foo@example.org", "bar@example.org"],
+        title="⚽ Message title ⚽",
+        message="⚽ Notification message ⚽",
+    )
 
-        item = Item(
-            config={"baseuri": "mailtos://smtp_username:smtp_password@mail.example.org"},
-            target="test",
-            addrs=["foo@example.org", "bar@example.org"],
-            title="⚽ Message title ⚽",
-            message="⚽ Notification message ⚽",
-        )
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
+    assert apprise_mock.mock_calls == [
+        call(asset=mock.ANY),
+        call().add("mailtos://smtp_username:smtp_password@mail.example.org?to=foo%40example.org%2Cbar%40example.org"),
+        call().notify(body="⚽ Notification message ⚽", title="⚽ Message title ⚽"),
+        call().notify().__bool__(),
+    ]
 
-        assert apprise_mock.mock_calls == [
-            call(asset=mock.ANY),
-            call().add(
-                "mailtos://smtp_username:smtp_password@mail.example.org?to=foo%40example.org%2Cbar%40example.org"
-            ),
-            call().notify(body="⚽ Notification message ⚽", title="⚽ Message title ⚽"),
-            call().notify().__bool__(),
-        ]
-
-        assert outcome is True
-        assert (
-            "Sending notification to Apprise. target=test, addresses=['foo@example.org', 'bar@example.org']"
-            in caplog.text
-        )
-        assert "Successfully sent message using Apprise" in caplog.text
+    assert outcome is True
+    assert (
+        "Sending notification to Apprise. target=test, addresses=['foo@example.org', 'bar@example.org']"
+        in caplog.messages
+    )
+    assert "Successfully sent message using Apprise" in caplog.messages
 
 
 @surrogate("apprise")
@@ -55,116 +51,110 @@ def test_apprise_success_no_addresses(apprise_asset, apprise_mock, srv, caplog):
     and `addrs` attributes supplied.
     """
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/apprise_single.py")
 
-        module = load_module_from_file("mqttwarn/services/apprise_single.py")
+    item = Item(
+        config={"baseuri": "json://localhost:1234/mqtthook"},
+        title="⚽ Message title ⚽",
+        message="⚽ Notification message ⚽",
+    )
 
-        item = Item(
-            config={"baseuri": "json://localhost:1234/mqtthook"},
-            title="⚽ Message title ⚽",
-            message="⚽ Notification message ⚽",
-        )
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
+    assert apprise_mock.mock_calls == [
+        call(asset=mock.ANY),
+        call().add("json://localhost:1234/mqtthook"),
+        call().notify(body="⚽ Notification message ⚽", title="⚽ Message title ⚽"),
+        call().notify().__bool__(),
+    ]
 
-        assert apprise_mock.mock_calls == [
-            call(asset=mock.ANY),
-            call().add("json://localhost:1234/mqtthook"),
-            call().notify(body="⚽ Notification message ⚽", title="⚽ Message title ⚽"),
-            call().notify().__bool__(),
-        ]
-
-        assert outcome is True
-        assert "Sending notification to Apprise. target=None, addresses=[]" in caplog.messages
-        assert "Successfully sent message using Apprise" in caplog.messages
+    assert outcome is True
+    assert "Sending notification to Apprise. target=None, addresses=[]" in caplog.messages
+    assert "Successfully sent message using Apprise" in caplog.messages
 
 
 @surrogate("apprise")
 def test_apprise_failure_notify(srv, caplog):
 
-    with caplog.at_level(logging.DEBUG):
+    mock_connection = mock.MagicMock()
 
-        mock_connection = mock.MagicMock()
+    # Make the call to `notify` signal failure.
+    def error(*args, **kwargs):
+        return False
 
-        # Make the call to `notify` signal failure.
-        def error(*args, **kwargs):
-            return False
+    mock_connection.notify = error
 
-        mock_connection.notify = error
+    with mock.patch("apprise.Apprise", side_effect=[mock_connection], create=True) as mock_client:
+        with mock.patch("apprise.AppriseAsset", create=True):
+            module = load_module_from_file("mqttwarn/services/apprise_single.py")
 
-        with mock.patch("apprise.Apprise", side_effect=[mock_connection], create=True) as mock_client:
-            with mock.patch("apprise.AppriseAsset", create=True):
-                module = load_module_from_file("mqttwarn/services/apprise_single.py")
+            item = Item(
+                config={"baseuri": "mailtos://smtp_username:smtp_password@mail.example.org"},
+                target="test",
+                addrs=["foo@example.org", "bar@example.org"],
+                title="⚽ Message title ⚽",
+                message="⚽ Notification message ⚽",
+            )
 
-                item = Item(
-                    config={"baseuri": "mailtos://smtp_username:smtp_password@mail.example.org"},
-                    target="test",
-                    addrs=["foo@example.org", "bar@example.org"],
-                    title="⚽ Message title ⚽",
-                    message="⚽ Notification message ⚽",
-                )
+            outcome = module.plugin(srv, item)
 
-                outcome = module.plugin(srv, item)
+            assert mock_client.mock_calls == [
+                mock.call(asset=mock.ANY),
+            ]
+            assert mock_connection.mock_calls == [
+                call.add(
+                    "mailtos://smtp_username:smtp_password@mail.example.org?to=foo%40example.org%2Cbar%40example.org"
+                ),
+            ]
 
-                assert mock_client.mock_calls == [
-                    mock.call(asset=mock.ANY),
-                ]
-                assert mock_connection.mock_calls == [
-                    call.add(
-                        "mailtos://smtp_username:smtp_password@mail.example.org?to=foo%40example.org%2Cbar%40example.org"
-                    ),
-                ]
-
-                assert outcome is False
-                assert (
-                    "Sending notification to Apprise. target=test, addresses=['foo@example.org', 'bar@example.org']"
-                    in caplog.text
-                )
-                assert "Sending message using Apprise failed" in caplog.text
+            assert outcome is False
+            assert (
+                "Sending notification to Apprise. target=test, addresses=['foo@example.org', 'bar@example.org']"
+                in caplog.messages
+            )
+            assert "Sending message using Apprise failed" in caplog.messages
 
 
 @surrogate("apprise")
 def test_apprise_error(srv, caplog):
 
-    with caplog.at_level(logging.DEBUG):
+    mock_connection = mock.MagicMock()
 
-        mock_connection = mock.MagicMock()
+    # Make the call to `notify` raise an exception.
+    def error(*args, **kwargs):
+        raise Exception("something failed")
 
-        # Make the call to `notify` raise an exception.
-        def error(*args, **kwargs):
-            raise Exception("something failed")
+    mock_connection.notify = error
 
-        mock_connection.notify = error
+    with mock.patch("apprise.Apprise", side_effect=[mock_connection], create=True) as mock_client:
+        with mock.patch("apprise.AppriseAsset", create=True):
+            module = load_module_from_file("mqttwarn/services/apprise_single.py")
 
-        with mock.patch("apprise.Apprise", side_effect=[mock_connection], create=True) as mock_client:
-            with mock.patch("apprise.AppriseAsset", create=True):
-                module = load_module_from_file("mqttwarn/services/apprise_single.py")
+            item = Item(
+                config={"baseuri": "mailtos://smtp_username:smtp_password@mail.example.org"},
+                target="test",
+                addrs=["foo@example.org", "bar@example.org"],
+                title="⚽ Message title ⚽",
+                message="⚽ Notification message ⚽",
+            )
 
-                item = Item(
-                    config={"baseuri": "mailtos://smtp_username:smtp_password@mail.example.org"},
-                    target="test",
-                    addrs=["foo@example.org", "bar@example.org"],
-                    title="⚽ Message title ⚽",
-                    message="⚽ Notification message ⚽",
-                )
+            outcome = module.plugin(srv, item)
 
-                outcome = module.plugin(srv, item)
+            assert mock_client.mock_calls == [
+                mock.call(asset=mock.ANY),
+            ]
+            assert mock_connection.mock_calls == [
+                call.add(
+                    "mailtos://smtp_username:smtp_password@mail.example.org?to=foo%40example.org%2Cbar%40example.org"
+                ),
+            ]
 
-                assert mock_client.mock_calls == [
-                    mock.call(asset=mock.ANY),
-                ]
-                assert mock_connection.mock_calls == [
-                    call.add(
-                        "mailtos://smtp_username:smtp_password@mail.example.org?to=foo%40example.org%2Cbar%40example.org"
-                    ),
-                ]
-
-                assert outcome is False
-                assert (
-                    "Sending notification to Apprise. target=test, addresses=['foo@example.org', 'bar@example.org']"
-                    in caplog.messages
-                )
-                assert "Sending message using Apprise failed. target=test, error=something failed" in caplog.messages
+            assert outcome is False
+            assert (
+                "Sending notification to Apprise. target=test, addresses=['foo@example.org', 'bar@example.org']"
+                in caplog.messages
+            )
+            assert "Sending message using Apprise failed. target=test, error=something failed" in caplog.messages
 
 
 @surrogate("apprise")
@@ -172,35 +162,33 @@ def test_apprise_error(srv, caplog):
 @mock.patch("apprise.AppriseAsset", create=True)
 def test_apprise_success_with_sender(apprise_asset, apprise_mock, srv, caplog):
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/apprise_single.py")
 
-        module = load_module_from_file("mqttwarn/services/apprise_single.py")
+    item = Item(
+        config={
+            "baseuri": "mailtos://smtp_username:smtp_password@mail.example.org",
+            "sender": "example@example.org",
+            "sender_name": "Max Mustermann",
+        },
+        target="test",
+        addrs=["foo@example.org", "bar@example.org"],
+        title="⚽ Message title ⚽",
+        message="⚽ Notification message ⚽",
+    )
 
-        item = Item(
-            config={
-                "baseuri": "mailtos://smtp_username:smtp_password@mail.example.org",
-                "sender": "example@example.org",
-                "sender_name": "Max Mustermann",
-            },
-            target="test",
-            addrs=["foo@example.org", "bar@example.org"],
-            title="⚽ Message title ⚽",
-            message="⚽ Notification message ⚽",
-        )
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
+    assert apprise_mock.mock_calls == [
+        call(asset=mock.ANY),
+        call().add(
+            "mailtos://smtp_username:smtp_password@mail.example.org?from=example%40example.org&to=foo%40example.org%2Cbar%40example.org&name=Max+Mustermann"
+        ),
+        call().notify(body="⚽ Notification message ⚽", title="⚽ Message title ⚽"),
+        call().notify().__bool__(),
+    ]
 
-        assert apprise_mock.mock_calls == [
-            call(asset=mock.ANY),
-            call().add(
-                "mailtos://smtp_username:smtp_password@mail.example.org?from=example%40example.org&to=foo%40example.org%2Cbar%40example.org&name=Max+Mustermann"
-            ),
-            call().notify(body="⚽ Notification message ⚽", title="⚽ Message title ⚽"),
-            call().notify().__bool__(),
-        ]
-
-        assert outcome is True
-        assert "Successfully sent message using Apprise" in caplog.text
+    assert outcome is True
+    assert "Successfully sent message using Apprise" in caplog.messages
 
 
 @surrogate("apprise")
@@ -208,25 +196,23 @@ def test_apprise_success_with_sender(apprise_asset, apprise_mock, srv, caplog):
 @mock.patch("apprise.AppriseAsset", create=True)
 def test_apprise_success_backward_compat(apprise_asset, apprise_mock, srv, caplog):
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/apprise.py")
 
-        module = load_module_from_file("mqttwarn/services/apprise.py")
+    item = Item(
+        config={"baseuri": "json://localhost:1234/mqtthook"},
+        title="⚽ Message title ⚽",
+        message="⚽ Notification message ⚽",
+    )
 
-        item = Item(
-            config={"baseuri": "json://localhost:1234/mqtthook"},
-            title="⚽ Message title ⚽",
-            message="⚽ Notification message ⚽",
-        )
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
+    assert apprise_mock.mock_calls == [
+        call(asset=mock.ANY),
+        call().add("json://localhost:1234/mqtthook"),
+        call().notify(body="⚽ Notification message ⚽", title="⚽ Message title ⚽"),
+        call().notify().__bool__(),
+    ]
 
-        assert apprise_mock.mock_calls == [
-            call(asset=mock.ANY),
-            call().add("json://localhost:1234/mqtthook"),
-            call().notify(body="⚽ Notification message ⚽", title="⚽ Message title ⚽"),
-            call().notify().__bool__(),
-        ]
-
-        assert outcome is True
-        assert "Sending notification to Apprise. target=None, addresses=[]" in caplog.messages
-        assert "Successfully sent message using Apprise" in caplog.messages
+    assert outcome is True
+    assert "Sending notification to Apprise. target=None, addresses=[]" in caplog.messages
+    assert "Successfully sent message using Apprise" in caplog.messages

--- a/tests/services/test_asterisk.py
+++ b/tests/services/test_asterisk.py
@@ -1,60 +1,57 @@
 # -*- coding: utf-8 -*-
-# (c) 2021 The mqttwarn developers
-import logging
+# (c) 2021-2022 The mqttwarn developers
 from unittest import mock
-from unittest.mock import call
+from unittest.mock import Mock, call
+
+from surrogate import surrogate
 
 from mqttwarn.model import ProcessorItem as Item
 from mqttwarn.util import load_module_from_file
-from surrogate import surrogate
 
 
 @surrogate("asterisk.manager")
 @mock.patch("asterisk.manager.Manager", create=True)
 def test_asterisk_success(asterisk_mock, srv, caplog):
 
-    with caplog.at_level(logging.DEBUG):
+    asterisk_mock.return_value = Mock(**{"login.return_value": 42, "originate.return_value": 42})
 
-        attrs = {"login.return_value": 42, "originate.return_value": 42}
-        asterisk_mock.return_value = mock.MagicMock(**attrs)
+    module = load_module_from_file("mqttwarn/services/asterisk.py")
 
-        module = load_module_from_file("mqttwarn/services/asterisk.py")
+    item = Item(
+        config={
+            "host": "asterisk.example.org",
+            "port": 5038,
+            "username": "foobar",
+            "password": "bazqux",
+            "extension": 2222,
+            "context": "default",
+        },
+        target="test",
+        addrs=["SIP/avaya/", "0123456789"],
+        message="⚽ Notification message ⚽",
+    )
 
-        item = Item(
-            config={
-                "host": "asterisk.example.org",
-                "port": 5038,
-                "username": "foobar",
-                "password": "bazqux",
-                "extension": 2222,
-                "context": "default",
-            },
-            target="test",
-            addrs=["SIP/avaya/", "0123456789"],
-            message="⚽ Notification message ⚽",
-        )
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
+    assert asterisk_mock.mock_calls == [
+        call(),
+        call().connect("asterisk.example.org", 5038),
+        call().login("foobar", "bazqux"),
+        call().originate(
+            "SIP/avaya/0123456789",
+            2222,
+            context="default",
+            priority="1",
+            caller_id=2222,
+            variables={"text": "⚽ Notification message ⚽"},
+        ),
+        call().logoff(),
+        call().close(),
+    ]
 
-        assert asterisk_mock.mock_calls == [
-            call(),
-            call().connect("asterisk.example.org", 5038),
-            call().login("foobar", "bazqux"),
-            call().originate(
-                "SIP/avaya/0123456789",
-                2222,
-                context="default",
-                priority="1",
-                caller_id=2222,
-                variables={"text": "⚽ Notification message ⚽"},
-            ),
-            call().logoff(),
-            call().close(),
-        ]
-
-        assert outcome is True
-        assert "Authentication 42" in caplog.text
-        assert "Call 42" in caplog.text
+    assert outcome is True
+    assert "Authentication 42" in caplog.text
+    assert "Call 42" in caplog.text
 
 
 class ManagerSocketException(Exception):
@@ -74,37 +71,34 @@ class ManagerException(Exception):
 @mock.patch("asterisk.manager.ManagerSocketException", ManagerSocketException, create=True)
 def test_asterisk_failure_no_connection(asterisk_mock, srv, caplog):
 
-    with caplog.at_level(logging.DEBUG):
+    asterisk_mock.return_value = Mock(**{"connect.side_effect": ManagerSocketException("something failed")})
 
-        attrs = {"connect.side_effect": ManagerSocketException("something failed")}
-        asterisk_mock.return_value = mock.MagicMock(**attrs)
+    module = load_module_from_file("mqttwarn/services/asterisk.py")
 
-        module = load_module_from_file("mqttwarn/services/asterisk.py")
+    item = Item(
+        config={
+            "host": "asterisk.example.org",
+            "port": 5038,
+            "username": "foobar",
+            "password": "bazqux",
+            "extension": 2222,
+            "context": "default",
+        },
+        target="test",
+        addrs=["SIP/avaya/", "0123456789"],
+        message="⚽ Notification message ⚽",
+    )
 
-        item = Item(
-            config={
-                "host": "asterisk.example.org",
-                "port": 5038,
-                "username": "foobar",
-                "password": "bazqux",
-                "extension": 2222,
-                "context": "default",
-            },
-            target="test",
-            addrs=["SIP/avaya/", "0123456789"],
-            message="⚽ Notification message ⚽",
-        )
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
+    assert asterisk_mock.mock_calls == [
+        call(),
+        call().connect("asterisk.example.org", 5038),
+        call().close(),
+    ]
 
-        assert asterisk_mock.mock_calls == [
-            call(),
-            call().connect("asterisk.example.org", 5038),
-            call().close(),
-        ]
-
-        assert outcome is False
-        assert "Error connecting to the manager: something failed" in caplog.text
+    assert outcome is False
+    assert "Error connecting to the manager: something failed" in caplog.messages
 
 
 @surrogate("asterisk.manager")
@@ -113,38 +107,35 @@ def test_asterisk_failure_no_connection(asterisk_mock, srv, caplog):
 @mock.patch("asterisk.manager.ManagerAuthException", ManagerAuthException, create=True)
 def test_asterisk_failure_login_invalid(asterisk_mock, srv, caplog):
 
-    with caplog.at_level(logging.DEBUG):
+    asterisk_mock.return_value = Mock(**{"login.side_effect": ManagerAuthException("something failed")})
 
-        attrs = {"login.side_effect": ManagerAuthException("something failed")}
-        asterisk_mock.return_value = mock.MagicMock(**attrs)
+    module = load_module_from_file("mqttwarn/services/asterisk.py")
 
-        module = load_module_from_file("mqttwarn/services/asterisk.py")
+    item = Item(
+        config={
+            "host": "asterisk.example.org",
+            "port": 5038,
+            "username": "foobar",
+            "password": "bazqux",
+            "extension": 2222,
+            "context": "default",
+        },
+        target="test",
+        addrs=["SIP/avaya/", "0123456789"],
+        message="⚽ Notification message ⚽",
+    )
 
-        item = Item(
-            config={
-                "host": "asterisk.example.org",
-                "port": 5038,
-                "username": "foobar",
-                "password": "bazqux",
-                "extension": 2222,
-                "context": "default",
-            },
-            target="test",
-            addrs=["SIP/avaya/", "0123456789"],
-            message="⚽ Notification message ⚽",
-        )
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
+    assert asterisk_mock.mock_calls == [
+        call(),
+        call().connect("asterisk.example.org", 5038),
+        call().login("foobar", "bazqux"),
+        call().close(),
+    ]
 
-        assert asterisk_mock.mock_calls == [
-            call(),
-            call().connect("asterisk.example.org", 5038),
-            call().login("foobar", "bazqux"),
-            call().close(),
-        ]
-
-        assert outcome is False
-        assert "Error logging in to the manager: something failed" in caplog.text
+    assert outcome is False
+    assert "Error logging in to the manager: something failed" in caplog.messages
 
 
 @surrogate("asterisk.manager")
@@ -154,49 +145,47 @@ def test_asterisk_failure_login_invalid(asterisk_mock, srv, caplog):
 @mock.patch("asterisk.manager.ManagerException", ManagerException, create=True)
 def test_asterisk_failure_originate_croaks(asterisk_mock, srv, caplog):
 
-    with caplog.at_level(logging.DEBUG):
+    attrs = {
+        "login.return_value": 42,
+        "originate.side_effect": ManagerException("something failed"),
+    }
+    asterisk_mock.return_value = Mock(**attrs)
 
-        attrs = {
-            "login.return_value": 42,
-            "originate.side_effect": ManagerException("something failed"),
-        }
-        asterisk_mock.return_value = mock.MagicMock(**attrs)
+    module = load_module_from_file("mqttwarn/services/asterisk.py")
 
-        module = load_module_from_file("mqttwarn/services/asterisk.py")
+    item = Item(
+        config={
+            "host": "asterisk.example.org",
+            "port": 5038,
+            "username": "foobar",
+            "password": "bazqux",
+            "extension": 2222,
+            "context": "default",
+        },
+        target="test",
+        addrs=["SIP/avaya/", "0123456789"],
+        message="⚽ Notification message ⚽",
+    )
 
-        item = Item(
-            config={
-                "host": "asterisk.example.org",
-                "port": 5038,
-                "username": "foobar",
-                "password": "bazqux",
-                "extension": 2222,
-                "context": "default",
-            },
-            target="test",
-            addrs=["SIP/avaya/", "0123456789"],
-            message="⚽ Notification message ⚽",
-        )
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
+    assert asterisk_mock.mock_calls == [
+        call(),
+        call().connect("asterisk.example.org", 5038),
+        call().login("foobar", "bazqux"),
+        call().originate(
+            "SIP/avaya/0123456789",
+            2222,
+            context="default",
+            priority="1",
+            caller_id=2222,
+            variables={"text": "⚽ Notification message ⚽"},
+        ),
+        call().close(),
+    ]
 
-        assert asterisk_mock.mock_calls == [
-            call(),
-            call().connect("asterisk.example.org", 5038),
-            call().login("foobar", "bazqux"),
-            call().originate(
-                "SIP/avaya/0123456789",
-                2222,
-                context="default",
-                priority="1",
-                caller_id=2222,
-                variables={"text": "⚽ Notification message ⚽"},
-            ),
-            call().close(),
-        ]
-
-        assert outcome is False
-        assert "Error: something failed" in caplog.text
+    assert outcome is False
+    assert "Error: something failed" in caplog.messages
 
 
 @surrogate("asterisk.manager")
@@ -206,47 +195,45 @@ def test_asterisk_failure_originate_croaks(asterisk_mock, srv, caplog):
 @mock.patch("asterisk.manager.ManagerException", ManagerException, create=True)
 def test_asterisk_success_with_broken_close(asterisk_mock, srv, caplog):
 
-    with caplog.at_level(logging.DEBUG):
+    attrs = {
+        "login.return_value": 42,
+        "originate.return_value": 42,
+        "close.side_effect": ManagerSocketException("something failed"),
+    }
+    asterisk_mock.return_value = Mock(**attrs)
 
-        attrs = {
-            "login.return_value": 42,
-            "originate.return_value": 42,
-            "close.side_effect": ManagerSocketException("something failed"),
-        }
-        asterisk_mock.return_value = mock.MagicMock(**attrs)
+    module = load_module_from_file("mqttwarn/services/asterisk.py")
 
-        module = load_module_from_file("mqttwarn/services/asterisk.py")
+    item = Item(
+        config={
+            "host": "asterisk.example.org",
+            "port": 5038,
+            "username": "foobar",
+            "password": "bazqux",
+            "extension": 2222,
+            "context": "default",
+        },
+        target="test",
+        addrs=["SIP/avaya/", "0123456789"],
+        message="⚽ Notification message ⚽",
+    )
 
-        item = Item(
-            config={
-                "host": "asterisk.example.org",
-                "port": 5038,
-                "username": "foobar",
-                "password": "bazqux",
-                "extension": 2222,
-                "context": "default",
-            },
-            target="test",
-            addrs=["SIP/avaya/", "0123456789"],
-            message="⚽ Notification message ⚽",
-        )
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
+    assert asterisk_mock.mock_calls == [
+        call(),
+        call().connect("asterisk.example.org", 5038),
+        call().login("foobar", "bazqux"),
+        call().originate(
+            "SIP/avaya/0123456789",
+            2222,
+            context="default",
+            priority="1",
+            caller_id=2222,
+            variables={"text": "⚽ Notification message ⚽"},
+        ),
+        call().logoff(),
+        call().close(),
+    ]
 
-        assert asterisk_mock.mock_calls == [
-            call(),
-            call().connect("asterisk.example.org", 5038),
-            call().login("foobar", "bazqux"),
-            call().originate(
-                "SIP/avaya/0123456789",
-                2222,
-                context="default",
-                priority="1",
-                caller_id=2222,
-                variables={"text": "⚽ Notification message ⚽"},
-            ),
-            call().logoff(),
-            call().close(),
-        ]
-
-        assert outcome is True
+    assert outcome is True

--- a/tests/services/test_azure.py
+++ b/tests/services/test_azure.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-# (c) 2021 The mqttwarn developers
-import logging
+# (c) 2021-2022 The mqttwarn developers
 from unittest import mock
 from unittest.mock import PropertyMock
 
@@ -8,7 +7,7 @@ from mqttwarn.model import ProcessorItem as Item
 from mqttwarn.util import load_module_from_file
 
 
-def test_azure_iot_success_string(srv, caplog):
+def test_azure_iot_success_string(srv, mocker, caplog):
 
     item = Item(
         config={"iothubname": "acmehub"},
@@ -17,45 +16,42 @@ def test_azure_iot_success_string(srv, caplog):
         message="⚽ Notification message ⚽",
     )
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/azure_iot.py")
 
-        module = load_module_from_file("mqttwarn/services/azure_iot.py")
+    mqtt_single = mocker.patch.object(module.mqtt, "single")
 
-        mqtt_publish_mock = mock.MagicMock()
-        module.mqtt = mqtt_publish_mock
+    outcome = module.plugin(srv, item)
+    mqtt_single.assert_called_once_with(
+        "devices/device-id/messages/events/",
+        bytearray(b"\xe2\x9a\xbd Notification message \xe2\x9a\xbd"),
+        auth={
+            "username": "acmehub.azure-devices.net/device-id/?api-version=2018-06-30",
+            "password": "SharedAccessSignature sr=...",
+        },
+        tls={
+            "ca_certs": None,
+            "certfile": None,
+            "keyfile": None,
+            "tls_version": mock.ANY,
+            "ciphers": None,
+            "cert_reqs": mock.ANY,
+        },
+        hostname="acmehub.azure-devices.net",
+        port=8883,
+        protocol=4,
+        qos=0,
+        retain=False,
+        client_id="device-id",
+    )
 
-        outcome = module.plugin(srv, item)
-        mqtt_publish_mock.single.assert_called_once_with(
-            "devices/device-id/messages/events/",
-            bytearray(b"\xe2\x9a\xbd Notification message \xe2\x9a\xbd"),
-            auth={
-                "username": "acmehub.azure-devices.net/device-id/?api-version=2018-06-30",
-                "password": "SharedAccessSignature sr=...",
-            },
-            tls={
-                "ca_certs": None,
-                "certfile": None,
-                "keyfile": None,
-                "tls_version": mock.ANY,
-                "ciphers": None,
-                "cert_reqs": mock.ANY,
-            },
-            hostname="acmehub.azure-devices.net",
-            port=8883,
-            protocol=4,
-            qos=0,
-            retain=False,
-            client_id="device-id",
-        )
-
-        assert outcome is True
-        assert (
-            "Publishing to Azure IoT Hub for target=test (device-id): devices/device-id/messages/events/ "
-            "'bytearray(b'\\xe2\\x9a\\xbd Notification message \\xe2\\x9a\\xbd')'" in caplog.text
-        )
+    assert outcome is True
+    assert (
+        "Publishing to Azure IoT Hub for target=test (device-id): devices/device-id/messages/events/ "
+        "'bytearray(b'\\xe2\\x9a\\xbd Notification message \\xe2\\x9a\\xbd')'" in caplog.messages
+    )
 
 
-def test_azure_iot_success_bytes(srv, caplog):
+def test_azure_iot_success_bytes(srv, mocker, caplog):
 
     item = Item(
         config={"iothubname": "acmehub"},
@@ -64,42 +60,39 @@ def test_azure_iot_success_bytes(srv, caplog):
         message=b"### Notification message ###",
     )
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/azure_iot.py")
 
-        module = load_module_from_file("mqttwarn/services/azure_iot.py")
+    mqtt_single = mocker.patch.object(module.mqtt, "single")
 
-        mqtt_publish_mock = mock.MagicMock()
-        module.mqtt = mqtt_publish_mock
+    outcome = module.plugin(srv, item)
+    mqtt_single.assert_called_once_with(
+        "devices/device-id/messages/events/",
+        bytearray(b"### Notification message ###"),
+        auth={
+            "username": "acmehub.azure-devices.net/device-id/?api-version=2018-06-30",
+            "password": "SharedAccessSignature sr=...",
+        },
+        tls={
+            "ca_certs": None,
+            "certfile": None,
+            "keyfile": None,
+            "tls_version": mock.ANY,
+            "ciphers": None,
+            "cert_reqs": mock.ANY,
+        },
+        hostname="acmehub.azure-devices.net",
+        port=8883,
+        protocol=4,
+        qos=0,
+        retain=False,
+        client_id="device-id",
+    )
 
-        outcome = module.plugin(srv, item)
-        mqtt_publish_mock.single.assert_called_once_with(
-            "devices/device-id/messages/events/",
-            bytearray(b"### Notification message ###"),
-            auth={
-                "username": "acmehub.azure-devices.net/device-id/?api-version=2018-06-30",
-                "password": "SharedAccessSignature sr=...",
-            },
-            tls={
-                "ca_certs": None,
-                "certfile": None,
-                "keyfile": None,
-                "tls_version": mock.ANY,
-                "ciphers": None,
-                "cert_reqs": mock.ANY,
-            },
-            hostname="acmehub.azure-devices.net",
-            port=8883,
-            protocol=4,
-            qos=0,
-            retain=False,
-            client_id="device-id",
-        )
-
-        assert outcome is True
-        assert (
-            "Publishing to Azure IoT Hub for target=test (device-id): devices/device-id/messages/events/ "
-            "'b'### Notification message ###''" in caplog.text
-        )
+    assert outcome is True
+    assert (
+        "Publishing to Azure IoT Hub for target=test (device-id): devices/device-id/messages/events/ "
+        "'b'### Notification message ###''" in caplog.messages
+    )
 
 
 def test_azure_iot_failure_wrong_qos(srv, caplog):
@@ -111,17 +104,15 @@ def test_azure_iot_failure_wrong_qos(srv, caplog):
         message="⚽ Notification message ⚽",
     )
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/azure_iot.py")
 
-        module = load_module_from_file("mqttwarn/services/azure_iot.py")
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
-
-        assert outcome is False
-        assert "Only QoS 0 or 1 allowed for Azure IoT Hub, not '999'" in caplog.text
+    assert outcome is False
+    assert "Only QoS 0 or 1 allowed for Azure IoT Hub, not '999'" in caplog.messages
 
 
-def test_azure_iot_failure_invalid_message(srv, caplog):
+def test_azure_iot_failure_invalid_message(srv, mocker, caplog):
 
     item = Item(
         config={"iothubname": "acmehub"},
@@ -129,20 +120,17 @@ def test_azure_iot_failure_invalid_message(srv, caplog):
         addrs=["device-id", "SharedAccessSignature sr=..."],
     )
 
-    with mock.patch.object(Item, "message", new_callable=PropertyMock) as msg_mock:
-        msg_mock.side_effect = Exception("something failed")
+    mocker.patch.object(Item, "message", new_callable=PropertyMock, side_effect=Exception("something failed"))
 
-        with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/azure_iot.py")
 
-            module = load_module_from_file("mqttwarn/services/azure_iot.py")
+    outcome = module.plugin(srv, item)
 
-            outcome = module.plugin(srv, item)
-
-            assert outcome is False
-            assert "Unable to prepare message for target=test: something failed" in caplog.text
+    assert outcome is False
+    assert "Unable to prepare message for target=test: something failed" in caplog.messages
 
 
-def test_azure_iot_failure_mqtt_publish(srv, caplog):
+def test_azure_iot_failure_mqtt_publish(srv, mocker, caplog):
 
     item = Item(
         config={"iothubname": "acmehub"},
@@ -151,14 +139,11 @@ def test_azure_iot_failure_mqtt_publish(srv, caplog):
         message="⚽ Notification message ⚽",
     )
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/azure_iot.py")
 
-        module = load_module_from_file("mqttwarn/services/azure_iot.py")
+    mocker.patch.object(module.mqtt, "single", side_effect=Exception("something failed"))
 
-        mqtt_publish_mock = mock.MagicMock(side_effect=Exception("something failed"))
-        module.mqtt.single = mqtt_publish_mock
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
-
-        assert outcome is False
-        assert "Unable to publish to Azure IoT Hub for target=test (device-id): something failed" in caplog.text
+    assert outcome is False
+    assert "Unable to publish to Azure IoT Hub for target=test (device-id): something failed" in caplog.messages

--- a/tests/services/test_carbon.py
+++ b/tests/services/test_carbon.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-# (c) 2021 The mqttwarn developers
-import logging
+# (c) 2021-2022 The mqttwarn developers
 from unittest import mock
-from unittest.mock import call
+from unittest.mock import Mock, call
 
 from mqttwarn.model import ProcessorItem as Item
 from mqttwarn.util import load_module_from_file
@@ -17,66 +16,60 @@ def test_carbon_success_metric_value_timestamp(mocker, srv, caplog):
         data={},
     )
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/carbon.py")
 
-        module = load_module_from_file("mqttwarn/services/carbon.py")
+    socket_mock = mocker.patch("socket.socket")
 
-        socket_mock = mocker.patch("socket.socket")
+    outcome = module.plugin(srv, item)
+    assert socket_mock.mock_calls == [
+        call(),
+        call().connect(("localhost", 2003)),
+        call().sendall("foo 42.42 1623887596\n"),
+        call().close(),
+    ]
 
-        outcome = module.plugin(srv, item)
-        assert socket_mock.mock_calls == [
-            call(),
-            call().connect(("localhost", 2003)),
-            call().sendall("foo 42.42 1623887596\n"),
-            call().close(),
-        ]
-
-        assert outcome is True
-        assert "Sending to carbon: foo 42.42 1623887596" in caplog.text
+    assert outcome is True
+    assert "Sending to carbon: foo 42.42 1623887596" in caplog.messages
 
 
 def test_carbon_success_metric_value(mocker, srv, caplog):
 
     item = Item(target="test", addrs=["localhost", 2003], message="foo 42.42", data={})
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/carbon.py")
 
-        module = load_module_from_file("mqttwarn/services/carbon.py")
+    socket_mock = mocker.patch("socket.socket")
 
-        socket_mock = mocker.patch("socket.socket")
+    outcome = module.plugin(srv, item)
+    assert socket_mock.mock_calls == [
+        call(),
+        call().connect(("localhost", 2003)),
+        call().sendall(mock.ANY),
+        call().close(),
+    ]
 
-        outcome = module.plugin(srv, item)
-        assert socket_mock.mock_calls == [
-            call(),
-            call().connect(("localhost", 2003)),
-            call().sendall(mock.ANY),
-            call().close(),
-        ]
-
-        assert outcome is True
-        assert "Sending to carbon: foo 42.42" in caplog.text
+    assert outcome is True
+    assert "Sending to carbon: foo 42.42" in caplog.text
 
 
 def test_carbon_success_value(mocker, srv, caplog):
 
     item = Item(target="test", addrs=["localhost", 2003], message="42.42", data={})
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/carbon.py")
 
-        module = load_module_from_file("mqttwarn/services/carbon.py")
+    socket_mock = mocker.patch("socket.socket")
 
-        socket_mock = mocker.patch("socket.socket")
+    outcome = module.plugin(srv, item)
+    assert socket_mock.mock_calls == [
+        call(),
+        call().connect(("localhost", 2003)),
+        call().sendall(mock.ANY),
+        call().close(),
+    ]
 
-        outcome = module.plugin(srv, item)
-        assert socket_mock.mock_calls == [
-            call(),
-            call().connect(("localhost", 2003)),
-            call().sendall(mock.ANY),
-            call().close(),
-        ]
-
-        assert outcome is True
-        assert "Sending to carbon: ohno 42.42" in caplog.text
+    assert outcome is True
+    assert "Sending to carbon: ohno 42.42" in caplog.text
 
 
 def test_carbon_success_value_metric_from_topic(mocker, srv, caplog):
@@ -88,22 +81,20 @@ def test_carbon_success_value_metric_from_topic(mocker, srv, caplog):
         data={"topic": "foo/bar"},
     )
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/carbon.py")
 
-        module = load_module_from_file("mqttwarn/services/carbon.py")
+    socket_mock = mocker.patch("socket.socket")
 
-        socket_mock = mocker.patch("socket.socket")
+    outcome = module.plugin(srv, item)
+    assert socket_mock.mock_calls == [
+        call(),
+        call().connect(("localhost", 2003)),
+        call().sendall(mock.ANY),
+        call().close(),
+    ]
 
-        outcome = module.plugin(srv, item)
-        assert socket_mock.mock_calls == [
-            call(),
-            call().connect(("localhost", 2003)),
-            call().sendall(mock.ANY),
-            call().close(),
-        ]
-
-        assert outcome is True
-        assert "Sending to carbon: foo.bar 42.42" in caplog.text
+    assert outcome is True
+    assert "Sending to carbon: foo.bar 42.42" in caplog.text
 
 
 def test_carbon_success_value_metric_from_topic_with_leading_slash(mocker, srv, caplog):
@@ -115,50 +106,44 @@ def test_carbon_success_value_metric_from_topic_with_leading_slash(mocker, srv, 
         data={"topic": "/foo/bar"},
     )
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/carbon.py")
 
-        module = load_module_from_file("mqttwarn/services/carbon.py")
+    socket_mock = mocker.patch("socket.socket")
 
-        socket_mock = mocker.patch("socket.socket")
+    outcome = module.plugin(srv, item)
+    assert socket_mock.mock_calls == [
+        call(),
+        call().connect(("localhost", 2003)),
+        call().sendall(mock.ANY),
+        call().close(),
+    ]
 
-        outcome = module.plugin(srv, item)
-        assert socket_mock.mock_calls == [
-            call(),
-            call().connect(("localhost", 2003)),
-            call().sendall(mock.ANY),
-            call().close(),
-        ]
-
-        assert outcome is True
-        assert "Sending to carbon: foo.bar 42.42" in caplog.text
+    assert outcome is True
+    assert "Sending to carbon: foo.bar 42.42" in caplog.text
 
 
 def test_carbon_failure_invalid_configuration(srv, caplog):
 
     item = Item(target="test", addrs=["172.16.153.110", "foobar"])
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/carbon.py")
 
-        module = load_module_from_file("mqttwarn/services/carbon.py")
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
-
-        assert outcome is False
-        assert "Configuration for target `carbon' is incorrect" in caplog.text
+    assert outcome is False
+    assert "Configuration for target `carbon' is incorrect" in caplog.messages
 
 
 def test_carbon_failure_empty_message(srv, caplog):
 
     item = Item(target="test", addrs=["172.16.153.110", 2003])
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/carbon.py")
 
-        module = load_module_from_file("mqttwarn/services/carbon.py")
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
-
-        assert outcome is False
-        assert "target `carbon': cannot split string" in caplog.text
+    assert outcome is False
+    assert "target `carbon': cannot split string" in caplog.messages
 
 
 def test_carbon_failure_invalid_message_format(srv, caplog):
@@ -170,14 +155,12 @@ def test_carbon_failure_invalid_message_format(srv, caplog):
         data={},
     )
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/carbon.py")
 
-        module = load_module_from_file("mqttwarn/services/carbon.py")
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
-
-        assert outcome is False
-        assert "target `carbon': error decoding message" in caplog.text
+    assert outcome is False
+    assert "target `carbon': error decoding message" in caplog.messages
 
 
 def test_carbon_failure_connect(mocker, srv, caplog):
@@ -189,19 +172,16 @@ def test_carbon_failure_connect(mocker, srv, caplog):
         data={},
     )
 
-    with caplog.at_level(logging.DEBUG):
+    module = load_module_from_file("mqttwarn/services/carbon.py")
 
-        module = load_module_from_file("mqttwarn/services/carbon.py")
+    socket_mock = mocker.patch("socket.socket")
 
-        socket_mock = mocker.patch("socket.socket")
+    # Inject exception to be raised on `socket.connect`.
+    socket_mock.return_value = Mock(**{"connect.side_effect": Exception("something failed")})
 
-        # Inject exception to be raised on `socket.connect`.
-        attrs = {"connect.side_effect": Exception("something failed")}
-        socket_mock.return_value = mock.MagicMock(**attrs)
+    outcome = module.plugin(srv, item)
+    assert socket_mock.mock_calls == [call(), call().connect(("localhost", 2003))]
 
-        outcome = module.plugin(srv, item)
-        assert socket_mock.mock_calls == [call(), call().connect(("localhost", 2003))]
-
-        assert outcome is False
-        assert "Sending to carbon: foo 42.42 1623887596" in caplog.text
-        assert "Cannot send to carbon service localhost:2003: something failed" in caplog.text
+    assert outcome is False
+    assert "Sending to carbon: foo 42.42 1623887596" in caplog.messages
+    assert "Cannot send to carbon service localhost:2003: something failed" in caplog.messages

--- a/tests/services/test_file.py
+++ b/tests/services/test_file.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
-# (c) 2021 The mqttwarn developers
-import logging
+# (c) 2021-2022 The mqttwarn developers
 import os
-from unittest import mock
+
+import pytest as pytest
 
 import mqttwarn.services.file
-import pytest as pytest
 from mqttwarn.model import ProcessorItem as Item
 
 
@@ -32,19 +31,16 @@ def test_file_success(fake_filesystem, srv, caplog, item):
     Dispatch a single message and prove it is stored in the designated file.
     """
 
-    with caplog.at_level(logging.DEBUG):
+    module = mqttwarn.services.file
+    outcome = module.plugin(srv, item)
+    assert os.path.exists("/tmp/testdrive.log")
 
-        module = mqttwarn.services.file
-        outcome = module.plugin(srv, item)
-        assert os.path.exists("/tmp/testdrive.log")
-
-        assert outcome is True
-        assert "Writing to file `/tmp/testdrive.log'" in caplog.messages
-        assert open("/tmp/testdrive.log", mode="r", encoding="utf-8").read() == "\u26bd Notification message \u26bd"
+    assert outcome is True
+    assert "Writing to file `/tmp/testdrive.log'" in caplog.messages
+    assert open("/tmp/testdrive.log", mode="r", encoding="utf-8").read() == "\u26bd Notification message \u26bd"
 
 
-@mock.patch("io.open", side_effect=Exception("something failed"))
-def test_file_failure(fake_filesystem, srv, caplog):
+def test_file_failure(fake_filesystem, srv, mocker, caplog):
     """
     When `io.open` fails, prove that the corresponding error code path is
     invoked.
@@ -57,15 +53,14 @@ def test_file_failure(fake_filesystem, srv, caplog):
         data={},
     )
 
-    with caplog.at_level(logging.DEBUG):
+    module = mqttwarn.services.file
 
-        module = mqttwarn.services.file
+    mocker.patch("io.open", side_effect=Exception("something failed"))
+    outcome = module.plugin(srv, item)
+    assert not os.path.exists("/tmp/testdrive.log")
 
-        outcome = module.plugin(srv, item)
-        assert not os.path.exists("/tmp/testdrive.log")
-
-        assert outcome is False
-        assert "Cannot write to file `/tmp/testdrive.log': something failed" in caplog.messages
+    assert outcome is False
+    assert "Cannot write to file `/tmp/testdrive.log': something failed" in caplog.messages
 
 
 @pytest.mark.parametrize(
@@ -93,20 +88,18 @@ def test_file_append_newline_success(fake_filesystem, srv, caplog, item):
     designated file, seperated by a newline character.
     """
 
-    with caplog.at_level(logging.DEBUG):
+    module = mqttwarn.services.file
+    outcome1 = module.plugin(srv, item)
+    outcome2 = module.plugin(srv, item)
+    assert os.path.exists("/tmp/testdrive.log")
 
-        module = mqttwarn.services.file
-        outcome1 = module.plugin(srv, item)
-        outcome2 = module.plugin(srv, item)
-        assert os.path.exists("/tmp/testdrive.log")
-
-        assert outcome1 is True
-        assert outcome2 is True
-        assert "Writing to file `/tmp/testdrive.log'" in caplog.messages
-        assert (
-            open("/tmp/testdrive.log", mode="r", encoding="utf-8").read()
-            == "\u26bd Notification message \u26bd\n\u26bd Notification message \u26bd\n"
-        )
+    assert outcome1 is True
+    assert outcome2 is True
+    assert "Writing to file `/tmp/testdrive.log'" in caplog.messages
+    assert (
+        open("/tmp/testdrive.log", mode="r", encoding="utf-8").read()
+        == "\u26bd Notification message \u26bd\n\u26bd Notification message \u26bd\n"
+    )
 
 
 @pytest.mark.parametrize(
@@ -135,14 +128,12 @@ def test_file_overwrite_success(fake_filesystem, srv, caplog, item):
     `overwrite: True`.
     """
 
-    with caplog.at_level(logging.DEBUG):
+    module = mqttwarn.services.file
+    outcome1 = module.plugin(srv, item)
+    outcome2 = module.plugin(srv, item)
+    assert os.path.exists("/tmp/testdrive.log")
 
-        module = mqttwarn.services.file
-        outcome1 = module.plugin(srv, item)
-        outcome2 = module.plugin(srv, item)
-        assert os.path.exists("/tmp/testdrive.log")
-
-        assert outcome1 is True
-        assert outcome2 is True
-        assert "Writing to file `/tmp/testdrive.log'" in caplog.messages
-        assert open("/tmp/testdrive.log", mode="r", encoding="utf-8").read() == "\u26bd Notification message \u26bd"
+    assert outcome1 is True
+    assert outcome2 is True
+    assert "Writing to file `/tmp/testdrive.log'" in caplog.messages
+    assert open("/tmp/testdrive.log", mode="r", encoding="utf-8").read() == "\u26bd Notification message \u26bd"

--- a/tests/services/test_log.py
+++ b/tests/services/test_log.py
@@ -1,5 +1,6 @@
+# -*- coding: utf-8 -*-
+# (c) 2022 The mqttwarn developers
 import json
-import logging
 
 from tests import configfile_full
 from tests.util import core_bootstrap, send_message
@@ -11,27 +12,25 @@ def test_log_invalid_target(caplog):
     topic target interpolating yields an invalid log level.
     """
 
-    with caplog.at_level(logging.DEBUG):
+    # Bootstrap the core machinery without MQTT.
+    core_bootstrap(configfile=configfile_full)
 
-        # Bootstrap the core machinery without MQTT.
-        core_bootstrap(configfile=configfile_full)
+    # Signal mocked MQTT message to the core machinery for processing.
+    payload = json.dumps({"loglevel": "invalid", "message": "Foo bar"})
+    send_message(topic="test/targets-interpolated", payload=payload)
 
-        # Signal mocked MQTT message to the core machinery for processing.
-        payload = json.dumps({"loglevel": "invalid", "message": "Foo bar"})
-        send_message(topic="test/targets-interpolated", payload=payload)
-
-        # Proof that the message has been routed to the "log" plugin properly.
-        assert ("mqttwarn.core", 20, "Invoking service plugin for `log'") in caplog.record_tuples
-        assert (
-            "mqttwarn.services.log",
-            40,
-            "Cannot invoke service log with level `invalid': 'invalid'",
-        ) in caplog.record_tuples
-        assert (
-            "mqttwarn.core",
-            30,
-            "Notification of log for `test/targets-interpolated' FAILED or TIMED OUT",
-        ) in caplog.record_tuples
+    # Proof that the message has been routed to the "log" plugin properly.
+    assert ("mqttwarn.core", 20, "Invoking service plugin for `log'") in caplog.record_tuples
+    assert (
+        "mqttwarn.services.log",
+        40,
+        "Cannot invoke service log with level `invalid': 'invalid'",
+    ) in caplog.record_tuples
+    assert (
+        "mqttwarn.core",
+        30,
+        "Notification of log for `test/targets-interpolated' FAILED or TIMED OUT",
+    ) in caplog.record_tuples
 
 
 def test_log_broken_target(caplog):
@@ -40,24 +39,22 @@ def test_log_broken_target(caplog):
     topic target interpolating does not yield a list.
     """
 
-    with caplog.at_level(logging.DEBUG):
+    # Bootstrap the core machinery without MQTT.
+    core_bootstrap(configfile=configfile_full)
 
-        # Bootstrap the core machinery without MQTT.
-        core_bootstrap(configfile=configfile_full)
+    # Signal mocked MQTT message to the core machinery for processing.
+    payload = json.dumps({"loglevel": "broken", "message": "Foo bar"})
+    send_message(topic="test/targets-interpolated", payload=payload)
 
-        # Signal mocked MQTT message to the core machinery for processing.
-        payload = json.dumps({"loglevel": "broken", "message": "Foo bar"})
-        send_message(topic="test/targets-interpolated", payload=payload)
-
-        # Proof that the message has been routed to the "log" plugin properly.
-        assert ("mqttwarn.core", 20, "Invoking service plugin for `log'") in caplog.record_tuples
-        assert (
-            "mqttwarn.core",
-            40,
-            "Invoking service 'log' failed: `item.addrs` is not a list",
-        ) in caplog.record_tuples
-        assert (
-            "mqttwarn.core",
-            30,
-            "Notification of log for `test/targets-interpolated' FAILED or TIMED OUT",
-        ) in caplog.record_tuples
+    # Proof that the message has been routed to the "log" plugin properly.
+    assert ("mqttwarn.core", 20, "Invoking service plugin for `log'") in caplog.record_tuples
+    assert (
+        "mqttwarn.core",
+        40,
+        "Invoking service 'log' failed: `item.addrs` is not a list",
+    ) in caplog.record_tuples
+    assert (
+        "mqttwarn.core",
+        30,
+        "Notification of log for `test/targets-interpolated' FAILED or TIMED OUT",
+    ) in caplog.record_tuples

--- a/tests/services/test_pushover.py
+++ b/tests/services/test_pushover.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
-# (c) 2021 The mqttwarn developers
+# (c) 2021-2022 The mqttwarn developers
 import base64
-import logging
 import os
-from unittest import mock
+from unittest.mock import Mock
 
 import responses
+from requests_toolbelt import MultipartDecoder
+
 from mqttwarn.model import ProcessorItem as Item
 from mqttwarn.util import load_module_from_file
-from requests_toolbelt import MultipartDecoder
 
 
 def add_successful_mock_response():
@@ -42,30 +42,29 @@ def test_pushover_success(srv, caplog):
         data={},
     )
 
-    with caplog.at_level(logging.DEBUG):
+    add_successful_mock_response()
+    outcome = module.plugin(srv, item)
 
-        add_successful_mock_response()
-        outcome = module.plugin(srv, item)
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == "https://api.pushover.net/1/messages.json"
+    assert (
+        responses.calls[0].request.body
+        == "user=userkey2&token=appkey2&retry=60&expire=3600&message=%E2%9A%BD+Notification+message+%E2%9A%BD"
+    )
+    assert responses.calls[0].request.headers["User-Agent"] == "mqttwarn"
 
-        assert len(responses.calls) == 1
-        assert responses.calls[0].request.url == "https://api.pushover.net/1/messages.json"
-        assert (
-            responses.calls[0].request.body
-            == "user=userkey2&token=appkey2&retry=60&expire=3600&message=%E2%9A%BD+Notification+message+%E2%9A%BD"
-        )
-        assert responses.calls[0].request.headers["User-Agent"] == "mqttwarn"
+    assert responses.calls[0].response.status_code == 200
+    assert responses.calls[0].response.text == '{"status": 1}'
 
-        assert responses.calls[0].response.status_code == 200
-        assert responses.calls[0].response.text == '{"status": 1}'
-
-        assert outcome is True
-        assert "Sending pushover notification to test" in caplog.text
-        assert "Successfully sent pushover notification" in caplog.text
+    assert outcome is True
+    assert "Sending pushover notification to test" in caplog.text
+    assert "Successfully sent pushover notification" in caplog.messages
 
 
 @responses.activate
-@mock.patch.dict(os.environ, {"PUSHOVER_USER": "userkey2", "PUSHOVER_TOKEN": "appkey2"})
-def test_pushover_success_with_credentials_from_environment(srv, caplog):
+def test_pushover_success_with_credentials_from_environment(srv, mocker, caplog):
+
+    mocker.patch.dict(os.environ, {"PUSHOVER_USER": "userkey2", "PUSHOVER_TOKEN": "appkey2"})
 
     module = load_module_from_file("mqttwarn/services/pushover.py")
 
@@ -77,25 +76,23 @@ def test_pushover_success_with_credentials_from_environment(srv, caplog):
         data={},
     )
 
-    with caplog.at_level(logging.DEBUG):
+    add_successful_mock_response()
+    outcome = module.plugin(srv, item)
 
-        add_successful_mock_response()
-        outcome = module.plugin(srv, item)
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == "https://api.pushover.net/1/messages.json"
+    assert (
+        responses.calls[0].request.body
+        == "user=userkey2&token=appkey2&retry=60&expire=3600&message=%E2%9A%BD+Notification+message+%E2%9A%BD"
+    )
+    assert responses.calls[0].request.headers["User-Agent"] == "mqttwarn"
 
-        assert len(responses.calls) == 1
-        assert responses.calls[0].request.url == "https://api.pushover.net/1/messages.json"
-        assert (
-            responses.calls[0].request.body
-            == "user=userkey2&token=appkey2&retry=60&expire=3600&message=%E2%9A%BD+Notification+message+%E2%9A%BD"
-        )
-        assert responses.calls[0].request.headers["User-Agent"] == "mqttwarn"
+    assert responses.calls[0].response.status_code == 200
+    assert responses.calls[0].response.text == '{"status": 1}'
 
-        assert responses.calls[0].response.status_code == 200
-        assert responses.calls[0].response.text == '{"status": 1}'
-
-        assert outcome is True
-        assert "Sending pushover notification to test" in caplog.text
-        assert "Successfully sent pushover notification" in caplog.text
+    assert outcome is True
+    assert "Sending pushover notification to test" in caplog.text
+    assert "Successfully sent pushover notification" in caplog.messages
 
 
 @responses.activate
@@ -111,22 +108,20 @@ def test_pushover_success_with_sound(srv, caplog):
         data={},
     )
 
-    with caplog.at_level(logging.DEBUG):
+    add_successful_mock_response()
+    outcome = module.plugin(srv, item)
 
-        add_successful_mock_response()
-        outcome = module.plugin(srv, item)
+    assert (
+        responses.calls[0].request.body == "user=userkey2&token=appkey2&retry=60&expire=3600&"
+        "sound=sound1&message=%E2%9A%BD+Notification+message+%E2%9A%BD"
+    )
 
-        assert (
-            responses.calls[0].request.body == "user=userkey2&token=appkey2&retry=60&expire=3600&"
-            "sound=sound1&message=%E2%9A%BD+Notification+message+%E2%9A%BD"
-        )
+    assert responses.calls[0].response.status_code == 200
+    assert responses.calls[0].response.text == '{"status": 1}'
 
-        assert responses.calls[0].response.status_code == 200
-        assert responses.calls[0].response.text == '{"status": 1}'
-
-        assert outcome is True
-        assert "Sending pushover notification to test" in caplog.text
-        assert "Successfully sent pushover notification" in caplog.text
+    assert outcome is True
+    assert "Sending pushover notification to test" in caplog.text
+    assert "Successfully sent pushover notification" in caplog.messages
 
 
 @responses.activate
@@ -146,24 +141,22 @@ def test_pushover_success_with_html_and_url_and_url_title(srv, caplog):
         },
     )
 
-    with caplog.at_level(logging.DEBUG):
+    add_successful_mock_response()
+    outcome = module.plugin(srv, item)
 
-        add_successful_mock_response()
-        outcome = module.plugin(srv, item)
+    assert (
+        responses.calls[0].request.body
+        == "user=userkey2&token=appkey2&retry=60&expire=3600&message=%E2%9A%BD+Notification+message+%E2%9A%BD"
+        "&html=%3Cp%3E%E2%9A%BD+Notification+message+%E2%9A%BD%3C%2Fp%3E&url=https%3A%2F%2Fexample.org%2Ffoo"
+        "&url_title=Notification+group+%27foo%27"
+    )
 
-        assert (
-            responses.calls[0].request.body
-            == "user=userkey2&token=appkey2&retry=60&expire=3600&message=%E2%9A%BD+Notification+message+%E2%9A%BD"
-            "&html=%3Cp%3E%E2%9A%BD+Notification+message+%E2%9A%BD%3C%2Fp%3E&url=https%3A%2F%2Fexample.org%2Ffoo"
-            "&url_title=Notification+group+%27foo%27"
-        )
+    assert responses.calls[0].response.status_code == 200
+    assert responses.calls[0].response.text == '{"status": 1}'
 
-        assert responses.calls[0].response.status_code == 200
-        assert responses.calls[0].response.text == '{"status": 1}'
-
-        assert outcome is True
-        assert "Sending pushover notification to test" in caplog.text
-        assert "Successfully sent pushover notification" in caplog.text
+    assert outcome is True
+    assert "Sending pushover notification to test" in caplog.text
+    assert "Successfully sent pushover notification" in caplog.messages
 
 
 @responses.activate
@@ -179,22 +172,20 @@ def test_pushover_success_with_devices(srv, caplog):
         data={},
     )
 
-    with caplog.at_level(logging.DEBUG):
+    add_successful_mock_response()
+    outcome = module.plugin(srv, item)
 
-        add_successful_mock_response()
-        outcome = module.plugin(srv, item)
+    assert (
+        responses.calls[0].request.body == "user=userkey2&token=appkey2&retry=60&expire=3600&"
+        "devices=cellphone1%2Ccellphone2&message=%E2%9A%BD+Notification+message+%E2%9A%BD"
+    )
 
-        assert (
-            responses.calls[0].request.body == "user=userkey2&token=appkey2&retry=60&expire=3600&"
-            "devices=cellphone1%2Ccellphone2&message=%E2%9A%BD+Notification+message+%E2%9A%BD"
-        )
+    assert responses.calls[0].response.status_code == 200
+    assert responses.calls[0].response.text == '{"status": 1}'
 
-        assert responses.calls[0].response.status_code == 200
-        assert responses.calls[0].response.text == '{"status": 1}'
-
-        assert outcome is True
-        assert "Sending pushover notification to test" in caplog.text
-        assert "Successfully sent pushover notification" in caplog.text
+    assert outcome is True
+    assert "Sending pushover notification to test" in caplog.text
+    assert "Successfully sent pushover notification" in caplog.messages
 
 
 @responses.activate
@@ -212,24 +203,22 @@ def test_pushover_success_with_callback_and_title_and_priority_and_alternative_m
         data={"message": "⚽ Alternative notification message ⚽"},
     )
 
-    with caplog.at_level(logging.DEBUG):
+    add_successful_mock_response()
+    outcome = module.plugin(srv, item)
 
-        add_successful_mock_response()
-        outcome = module.plugin(srv, item)
+    assert (
+        responses.calls[0].request.body == "user=userkey2&token=appkey2&retry=60&expire=3600&"
+        "title=%E2%9A%BD+Message+title+%E2%9A%BD&priority=555&"
+        "callback=https%3A%2F%2Fexample.org%2Fpushover-callback&"
+        "message=%E2%9A%BD+Alternative+notification+message+%E2%9A%BD"
+    )
 
-        assert (
-            responses.calls[0].request.body == "user=userkey2&token=appkey2&retry=60&expire=3600&"
-            "title=%E2%9A%BD+Message+title+%E2%9A%BD&priority=555&"
-            "callback=https%3A%2F%2Fexample.org%2Fpushover-callback&"
-            "message=%E2%9A%BD+Alternative+notification+message+%E2%9A%BD"
-        )
+    assert responses.calls[0].response.status_code == 200
+    assert responses.calls[0].response.text == '{"status": 1}'
 
-        assert responses.calls[0].response.status_code == 200
-        assert responses.calls[0].response.text == '{"status": 1}'
-
-        assert outcome is True
-        assert "Sending pushover notification to test" in caplog.text
-        assert "Successfully sent pushover notification" in caplog.text
+    assert outcome is True
+    assert "Sending pushover notification to test" in caplog.text
+    assert "Successfully sent pushover notification" in caplog.messages
 
 
 @responses.activate
@@ -245,62 +234,60 @@ def test_pushover_success_with_imageurl(srv, caplog):
         data={"imageurl": "https://example.org/image"},
     )
 
-    with caplog.at_level(logging.DEBUG):
+    add_successful_mock_response()
 
-        add_successful_mock_response()
+    image = open("./assets/pushover.png", "rb").read()
+    responses.add(
+        responses.GET,
+        "https://example.org/image",
+        body=image,
+        stream=True,
+        status=200,
+    )
 
-        image = open("./assets/pushover.png", "rb").read()
-        responses.add(
-            responses.GET,
-            "https://example.org/image",
-            body=image,
-            stream=True,
-            status=200,
-        )
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
+    # Check response status.
+    assert responses.calls[1].response.status_code == 200
+    assert responses.calls[1].response.text == '{"status": 1}'
 
-        # Check response status.
-        assert responses.calls[1].response.status_code == 200
-        assert responses.calls[1].response.text == '{"status": 1}'
+    # Decode multipart request.
+    request = responses.calls[1].request
+    decoder = MultipartDecoder(request.body, request.headers["Content-Type"])
 
-        # Decode multipart request.
-        request = responses.calls[1].request
-        decoder = MultipartDecoder(request.body, request.headers["Content-Type"])
+    content_disposition_headers = []
+    contents = {}
+    for part in decoder.parts:
+        content_disposition_headers.append(part.headers[b"Content-Disposition"])
 
-        content_disposition_headers = []
-        contents = {}
-        for part in decoder.parts:
-            content_disposition_headers.append(part.headers[b"Content-Disposition"])
+        key = part.headers[b"Content-Disposition"]
+        contents[key] = part.content
 
-            key = part.headers[b"Content-Disposition"]
-            contents[key] = part.content
+    # Proof request has all body parts.
+    assert content_disposition_headers == [
+        b'form-data; name="user"',
+        b'form-data; name="token"',
+        b'form-data; name="retry"',
+        b'form-data; name="expire"',
+        b'form-data; name="message"',
+        b'form-data; name="attachment"; filename="image.jpg"',
+    ]
 
-        # Proof request has all body parts.
-        assert content_disposition_headers == [
-            b'form-data; name="user"',
-            b'form-data; name="token"',
-            b'form-data; name="retry"',
-            b'form-data; name="expire"',
-            b'form-data; name="message"',
-            b'form-data; name="attachment"; filename="image.jpg"',
-        ]
+    # Proof parameter body parts, modulo image content, have correct values.
+    assert list(contents.values())[:-1] == [
+        b"userkey2",
+        b"appkey2",
+        b"60",
+        b"3600",
+        b"\xe2\x9a\xbd Notification message \xe2\x9a\xbd",
+    ]
 
-        # Proof parameter body parts, modulo image content, have correct values.
-        assert list(contents.values())[:-1] == [
-            b"userkey2",
-            b"appkey2",
-            b"60",
-            b"3600",
-            b"\xe2\x9a\xbd Notification message \xe2\x9a\xbd",
-        ]
+    # Proof image has content.
+    assert len(decoder.parts[-1].content) == 45628
 
-        # Proof image has content.
-        assert len(decoder.parts[-1].content) == 45628
-
-        assert outcome is True
-        assert "Sending pushover notification to test" in caplog.text
-        assert "Successfully sent pushover notification" in caplog.text
+    assert outcome is True
+    assert "Sending pushover notification to test" in caplog.text
+    assert "Successfully sent pushover notification" in caplog.messages
 
 
 @responses.activate
@@ -321,31 +308,29 @@ def test_pushover_success_with_imageurl_and_basic_authentication(srv, caplog):
         },
     )
 
-    with caplog.at_level(logging.DEBUG):
+    add_successful_mock_response()
 
-        add_successful_mock_response()
+    image = open("./assets/pushover.png", "rb").read()
+    responses.add(
+        responses.GET,
+        "https://example.org/image",
+        body=image,
+        stream=True,
+        status=200,
+    )
 
-        image = open("./assets/pushover.png", "rb").read()
-        responses.add(
-            responses.GET,
-            "https://example.org/image",
-            body=image,
-            stream=True,
-            status=200,
-        )
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
+    # Proof authentication on image request.
+    assert responses.calls[0].request.headers["Authorization"] == "Basic Zm9vOmJhcg=="
 
-        # Proof authentication on image request.
-        assert responses.calls[0].request.headers["Authorization"] == "Basic Zm9vOmJhcg=="
+    # Check response status.
+    assert responses.calls[1].response.status_code == 200
+    assert responses.calls[1].response.text == '{"status": 1}'
 
-        # Check response status.
-        assert responses.calls[1].response.status_code == 200
-        assert responses.calls[1].response.text == '{"status": 1}'
-
-        assert outcome is True
-        assert "Sending pushover notification to test" in caplog.text
-        assert "Successfully sent pushover notification" in caplog.text
+    assert outcome is True
+    assert "Sending pushover notification to test" in caplog.text
+    assert "Successfully sent pushover notification" in caplog.messages
 
 
 @responses.activate
@@ -366,35 +351,33 @@ def test_pushover_success_with_imageurl_and_digest_authentication(srv, caplog):
         },
     )
 
-    with caplog.at_level(logging.DEBUG):
+    add_successful_mock_response()
 
-        add_successful_mock_response()
+    image = open("./assets/pushover.png", "rb").read()
+    responses.add(
+        responses.GET,
+        "https://example.org/image",
+        body=image,
+        stream=True,
+        status=200,
+    )
 
-        image = open("./assets/pushover.png", "rb").read()
-        responses.add(
-            responses.GET,
-            "https://example.org/image",
-            body=image,
-            stream=True,
-            status=200,
-        )
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
+    # Proof authentication on image request.
+    # FIXME: Currently not possible because Digest auth will only work if
+    #        the server answers with 4xx.
+    # assert (
+    #    responses.calls[0].request.headers["Authorization"] == "Digest something"
+    # )
 
-        # Proof authentication on image request.
-        # FIXME: Currently not possible because Digest auth will only work if
-        #        the server answers with 4xx.
-        # assert (
-        #    responses.calls[0].request.headers["Authorization"] == "Digest something"
-        # )
+    # Check response status.
+    assert responses.calls[1].response.status_code == 200
+    assert responses.calls[1].response.text == '{"status": 1}'
 
-        # Check response status.
-        assert responses.calls[1].response.status_code == 200
-        assert responses.calls[1].response.text == '{"status": 1}'
-
-        assert outcome is True
-        assert "Sending pushover notification to test" in caplog.text
-        assert "Successfully sent pushover notification" in caplog.text
+    assert outcome is True
+    assert "Sending pushover notification to test" in caplog.text
+    assert "Successfully sent pushover notification" in caplog.messages
 
 
 @responses.activate
@@ -411,52 +394,50 @@ def test_pushover_success_with_imagebase64(srv, caplog):
         data={"imagebase64": base64.encodebytes(image)},
     )
 
-    with caplog.at_level(logging.DEBUG):
+    add_successful_mock_response()
+    outcome = module.plugin(srv, item)
 
-        add_successful_mock_response()
-        outcome = module.plugin(srv, item)
+    # Check response status.
+    assert responses.calls[0].response.status_code == 200
+    assert responses.calls[0].response.text == '{"status": 1}'
 
-        # Check response status.
-        assert responses.calls[0].response.status_code == 200
-        assert responses.calls[0].response.text == '{"status": 1}'
+    # Decode multipart request.
+    request = responses.calls[0].request
+    decoder = MultipartDecoder(request.body, request.headers["Content-Type"])
 
-        # Decode multipart request.
-        request = responses.calls[0].request
-        decoder = MultipartDecoder(request.body, request.headers["Content-Type"])
+    content_disposition_headers = []
+    contents = {}
+    for part in decoder.parts:
+        content_disposition_headers.append(part.headers[b"Content-Disposition"])
 
-        content_disposition_headers = []
-        contents = {}
-        for part in decoder.parts:
-            content_disposition_headers.append(part.headers[b"Content-Disposition"])
+        key = part.headers[b"Content-Disposition"]
+        contents[key] = part.content
 
-            key = part.headers[b"Content-Disposition"]
-            contents[key] = part.content
+    # Proof request has all body parts.
+    assert content_disposition_headers == [
+        b'form-data; name="user"',
+        b'form-data; name="token"',
+        b'form-data; name="retry"',
+        b'form-data; name="expire"',
+        b'form-data; name="message"',
+        b'form-data; name="attachment"; filename="image.jpg"',
+    ]
 
-        # Proof request has all body parts.
-        assert content_disposition_headers == [
-            b'form-data; name="user"',
-            b'form-data; name="token"',
-            b'form-data; name="retry"',
-            b'form-data; name="expire"',
-            b'form-data; name="message"',
-            b'form-data; name="attachment"; filename="image.jpg"',
-        ]
+    # Proof parameter body parts, modulo image content, have correct values.
+    assert list(contents.values())[:-1] == [
+        b"userkey2",
+        b"appkey2",
+        b"60",
+        b"3600",
+        b"\xe2\x9a\xbd Notification message \xe2\x9a\xbd",
+    ]
 
-        # Proof parameter body parts, modulo image content, have correct values.
-        assert list(contents.values())[:-1] == [
-            b"userkey2",
-            b"appkey2",
-            b"60",
-            b"3600",
-            b"\xe2\x9a\xbd Notification message \xe2\x9a\xbd",
-        ]
+    # Proof image has content.
+    assert len(decoder.parts[-1].content) == 45628
 
-        # Proof image has content.
-        assert len(decoder.parts[-1].content) == 45628
-
-        assert outcome is True
-        assert "Sending pushover notification to test" in caplog.text
-        assert "Successfully sent pushover notification" in caplog.text
+    assert outcome is True
+    assert "Sending pushover notification to test" in caplog.text
+    assert "Successfully sent pushover notification" in caplog.messages
 
 
 def test_pushover_failure_invalid_configuration(srv, caplog):
@@ -469,11 +450,10 @@ def test_pushover_failure_invalid_configuration(srv, caplog):
         addrs=[None],
     )
 
-    with caplog.at_level(logging.DEBUG):
-        outcome = module.plugin(srv, item)
+    outcome = module.plugin(srv, item)
 
-        assert outcome is False
-        assert "Invalid address configuration for target `test'" in caplog.text
+    assert outcome is False
+    assert "Invalid address configuration for target `test'" in caplog.messages
 
 
 def test_pushover_failure_missing_credentials(srv, caplog):
@@ -487,15 +467,14 @@ def test_pushover_failure_missing_credentials(srv, caplog):
         data={},
     )
 
-    with caplog.at_level(logging.DEBUG):
-        outcome = module.plugin(srv, item)
+    outcome = module.plugin(srv, item)
 
-        assert outcome is False
-        assert "No pushover credentials configured for target `test'" in caplog.text
+    assert outcome is False
+    assert "No pushover credentials configured for target `test'" in caplog.messages
 
 
 @responses.activate
-def test_pushover_failure_request_error(srv, caplog):
+def test_pushover_failure_module_error(srv, mocker, caplog):
 
     module = load_module_from_file("mqttwarn/services/pushover.py")
 
@@ -507,16 +486,14 @@ def test_pushover_failure_request_error(srv, caplog):
         data={},
     )
 
-    with caplog.at_level(logging.DEBUG):
+    # Make remote call bail out.
+    mocker.patch.object(module, "pushover", Mock(side_effect=Exception("something failed")))
 
-        # Make remote call bail out.
-        module.pushover = mock.MagicMock(side_effect=Exception("something failed"))
+    outcome = module.plugin(srv, item)
 
-        outcome = module.plugin(srv, item)
-
-        assert outcome is False
-        assert "Sending pushover notification to test" in caplog.text
-        assert "Error sending pushover notification: something failed" in caplog.text
+    assert outcome is False
+    assert "Sending pushover notification to test" in caplog.text
+    assert "Error sending pushover notification: something failed" in caplog.messages
 
 
 @responses.activate
@@ -532,23 +509,21 @@ def test_pushover_failure_response_error(srv, caplog):
         data={},
     )
 
-    with caplog.at_level(logging.DEBUG):
+    add_failed_mock_response()
+    outcome = module.plugin(srv, item)
 
-        add_failed_mock_response()
-        outcome = module.plugin(srv, item)
+    assert len(responses.calls) == 1
 
-        assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == "https://api.pushover.net/1/messages.json"
+    assert (
+        responses.calls[0].request.body
+        == "user=userkey2&token=appkey2&retry=60&expire=3600&message=%E2%9A%BD+Notification+message+%E2%9A%BD"
+    )
+    assert responses.calls[0].request.headers["User-Agent"] == "mqttwarn"
 
-        assert responses.calls[0].request.url == "https://api.pushover.net/1/messages.json"
-        assert (
-            responses.calls[0].request.body
-            == "user=userkey2&token=appkey2&retry=60&expire=3600&message=%E2%9A%BD+Notification+message+%E2%9A%BD"
-        )
-        assert responses.calls[0].request.headers["User-Agent"] == "mqttwarn"
+    assert responses.calls[0].response.status_code == 400
+    assert responses.calls[0].response.text == '{"status": 999}'
 
-        assert responses.calls[0].response.status_code == 400
-        assert responses.calls[0].response.text == '{"status": 999}'
-
-        assert outcome is False
-        assert "Sending pushover notification to test" in caplog.text
-        assert "Error sending pushover notification: b'{\"status\": 999}'" in caplog.text
+    assert outcome is False
+    assert "Sending pushover notification to test" in caplog.text
+    assert "Error sending pushover notification: b'{\"status\": 999}'" in caplog.messages

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -6,10 +6,11 @@ from unittest import mock
 from unittest.mock import Mock, patch
 
 import docopt
-import mqttwarn.commands
 import pytest
-from mqttwarn.configuration import Config
 from surrogate import surrogate
+
+import mqttwarn.commands
+from mqttwarn.configuration import Config
 from tests.util import invoke_command
 
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -3,8 +3,9 @@
 import ssl
 from unittest.mock import Mock, call
 
-import mqttwarn.configuration
 import pytest
+
+import mqttwarn.configuration
 
 
 def test_config_with_ssl():

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # (c) 2022 The mqttwarn developers
 import pytest
+
 from mqttwarn.configuration import Config
 from mqttwarn.context import FunctionInvoker, RuntimeContext
 

--- a/tests/test_core_infra.py
+++ b/tests/test_core_infra.py
@@ -6,9 +6,10 @@ import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from unittest import mock
-from unittest.mock import MagicMock, Mock, call
+from unittest.mock import Mock, call
 
 import pytest
+
 from mqttwarn.configuration import Config
 from mqttwarn.context import RuntimeContext
 from mqttwarn.core import (
@@ -36,13 +37,13 @@ def test_bootstrap(caplog):
     core_bootstrap(configfile=configfile_full)
 
     # Proof that mqttwarn loaded all services properly
-    assert 'Successfully loaded service "file"' in caplog.text, caplog.text
-    assert 'Successfully loaded service "log"' in caplog.text, caplog.text
+    assert 'Successfully loaded service "file"' in caplog.messages
+    assert 'Successfully loaded service "log"' in caplog.messages
 
-    assert "Starting 1 worker threads" in caplog.text, caplog.text
+    assert "Starting 1 worker threads" in caplog.messages
 
     # Capturing the last message does not work. Why?
-    # assert 'Job queue has 0 items to process' in caplog.text, caplog.text
+    # assert 'Job queue has 0 items to process' in caplog.messages
 
 
 def test_config_no_functions(caplog):
@@ -324,7 +325,7 @@ def test_subscribe_forever_fails_socket_error(caplog, mocker):
 
     # Invoke `subscribe_forever` and terminate right away using `exit_flag`.
     connect = mocker.patch("mqttwarn.core.connect")
-    connect.return_value = MagicMock(**{"loop_forever.side_effect": socket.error("Something failed")})
+    connect.return_value = Mock(**{"loop_forever.side_effect": socket.error("Something failed")})
     t = threading.Thread(target=subscribe_forever)
     t.start()
     mocker.patch("mqttwarn.core.exit_flag", True)
@@ -353,7 +354,7 @@ def test_subscribe_forever_fails_unknown_error(caplog, mocker):
 
     # Invoke `subscribe_forever` and terminate right away using `exit_flag`.
     connect = mocker.patch("mqttwarn.core.connect")
-    connect.return_value = MagicMock(**{"loop_forever.side_effect": ValueError("Something failed")})
+    connect.return_value = Mock(**{"loop_forever.side_effect": ValueError("Something failed")})
 
     # Invoke `subscribe_forever` in a different thread, but get hold of its exception through a `Future`.
     with ThreadPoolExecutor() as executor:

--- a/tests/test_core_main.py
+++ b/tests/test_core_main.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 
 import pytest
+
 from mqttwarn.core import decode_payload
 from tests import configfile_full, configfile_service_loading
 from tests.util import core_bootstrap, send_message

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,6 +8,7 @@ import time
 from builtins import str
 
 import pytest
+
 from mqttwarn.util import (
     Formatter,
     Struct,

--- a/tests/util.py
+++ b/tests/util.py
@@ -4,12 +4,13 @@ import shlex
 import threading
 from unittest.mock import patch
 
-import mqttwarn
 import paho
+from paho.mqtt.client import MQTTMessage
+
+import mqttwarn
 from mqttwarn.commands import run as run_command
 from mqttwarn.configuration import load_configuration
 from mqttwarn.core import bootstrap, load_services, on_message, start_workers
-from paho.mqtt.client import MQTTMessage
 
 
 def core_bootstrap(configfile=None):


### PR DESCRIPTION
By removing the unneeded `with caplog.at_level` context, and using `mocker` more often, this patch reduces indentation levels and makes reading the test cases more pleasant to the eye.

On the contrary, the patch itself is very noisy, but includes no semantic changes other than adjusting a few log messages.