### PR TITLE
Refactor classes `Struct`, `Service`, and `Job` to `mqttwarn.model`

### DIFF
--- a/mqttwarn/model.py
+++ b/mqttwarn/model.py
@@ -4,15 +4,43 @@ import dataclasses
 import platform
 import sys
 from dataclasses import dataclass, field
+from functools import total_ordering
 from typing import Dict, List, Optional, Union
 
 from mqttwarn import __version__
 
 
+class Struct:
+    """
+    Data container for feeding information into service plugins - V1.
+    """
+
+    # Convert Python dict to object?
+    # http://stackoverflow.com/questions/1305532/
+
+    def __init__(self, **entries):
+        self.__dict__.update(entries)
+
+    def __repr__(self):
+        return "<%s>" % str("\n ".join("%s: %s" % (k, repr(v)) for (k, v) in list(self.__dict__.items())))
+
+    def get(self, key, default=None):
+        if key in self.__dict__ and self.__dict__[key] is not None:
+            return self.__dict__[key]
+        else:
+            return default
+
+    def enum(self):
+        item = {}
+        for (k, v) in list(self.__dict__.items()):
+            item[k] = v
+        return item
+
+
 @dataclass
 class ProcessorItem:
     """
-    A processor item for feeding information into service handlers.
+    Data container for feeding information into service plugins - V2.
     """
 
     service: Optional[str] = None
@@ -38,3 +66,47 @@ class StatusInformation:
     mqttwarn_version: str = __version__
     os_platform: str = sys.platform
     python_version: str = platform.python_version()
+
+
+class Service:
+    """
+    Class with helper functions which is passed to each plugin and its global instantiation.
+    """
+
+    def __init__(self, mqttc, logger, mwcore, program):
+
+        # Reference to MQTT client object.
+        self.mqttc = mqttc
+
+        # Reference to all mqttwarn globals, for using its machinery from plugins.
+        self.mwcore = mwcore
+
+        # Reference to logging object.
+        self.logging = logger
+
+        # Name of self ("mqttwarn", mostly).
+        self.SCRIPTNAME = program
+
+
+@total_ordering
+class Job:
+    def __init__(self, prio, service, section, topic, payload, data, target):
+        self.prio = prio
+        self.service = service
+        self.section = section
+        self.topic = topic
+        self.payload = payload  # raw payload
+        self.data = data  # decoded payload
+        self.target = target
+
+    # The `__cmp__()` special method is no longer honored in Python 3.
+    # https://portingguide.readthedocs.io/en/latest/comparisons.html#rich-comparisons
+
+    def __eq__(self, other):
+        return self.prio == other.prio
+
+    def __ne__(self, other):
+        return not (self.prio == other.prio)
+
+    def __lt__(self, other):
+        return self.prio < other.prio

--- a/mqttwarn/testing/fixtures.py
+++ b/mqttwarn/testing/fixtures.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from mqttwarn.core import Service
+from mqttwarn.model import Service
 
 
 @pytest.fixture
@@ -11,4 +11,5 @@ def mqttwarn_service():
     A service instance for propagating to the plugin.
     """
     logger = logging.getLogger(__name__)
-    return Service(mqttc=None, logger=logger)
+    # FIXME: Should propagate `mqttwarn.core.globals()` to `mwcore`.
+    return Service(mqttc=None, logger=logger, mwcore={}, program="mqttwarn-testdrive")

--- a/mqttwarn/util.py
+++ b/mqttwarn/util.py
@@ -6,35 +6,9 @@ import json
 import os
 import re
 import string
-from builtins import str
 
 import pkg_resources
 from six import string_types
-
-
-class Struct:
-    """
-    Convert Python dict to object?
-    http://stackoverflow.com/questions/1305532/
-    """
-
-    def __init__(self, **entries):
-        self.__dict__.update(entries)
-
-    def __repr__(self):
-        return "<%s>" % str("\n ".join("%s: %s" % (k, repr(v)) for (k, v) in list(self.__dict__.items())))
-
-    def get(self, key, default=None):
-        if key in self.__dict__ and self.__dict__[key] is not None:
-            return self.__dict__[key]
-        else:
-            return default
-
-    def enum(self):
-        item = {}
-        for (k, v) in list(self.__dict__.items()):
-            item[k] = v
-        return item
 
 
 class Formatter(string.Formatter):

--- a/tests/services/test_desktopnotify.py
+++ b/tests/services/test_desktopnotify.py
@@ -7,7 +7,8 @@ import pytest
 from surrogate import surrogate
 
 from mqttwarn.model import ProcessorItem as Item
-from mqttwarn.util import Struct, load_module_by_name
+from mqttwarn.model import Struct
+from mqttwarn.util import load_module_by_name
 
 
 @pytest.fixture

--- a/tests/services/test_smtp.py
+++ b/tests/services/test_smtp.py
@@ -7,7 +7,8 @@ from unittest.mock import call
 import pytest
 
 from mqttwarn.model import ProcessorItem as Item
-from mqttwarn.util import Struct, load_module_from_file
+from mqttwarn.model import Struct
+from mqttwarn.util import load_module_from_file
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="This test only works on Python >= 3.8")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-# (c) 2022 The mqttwarn developers
+# (c) 2018-2022 The mqttwarn developers
 from copy import deepcopy
 
-from mqttwarn.core import Job, make_service
+from mqttwarn.core import make_service
+from mqttwarn.model import Job, Struct
 
 JOB_PRIO1 = dict(
     prio=1, service="service", section="section", topic="topic", payload="payload", data="data", target="target"
@@ -18,7 +19,7 @@ def test_make_service():
     Verify creation of `Service` instance.
     """
     service = make_service(name="foo")
-    assert "<mqttwarn.core.Service object at" in str(service)
+    assert "<mqttwarn.model.Service object at" in str(service)
 
 
 def test_job_equality():
@@ -49,3 +50,13 @@ def test_job_ordering_by_priority():
     job2 = Job(**JOB_PRIO2)
 
     assert sorted([job2, job1]) == [job1, job2]
+
+
+def test_struct():
+    data = {"hello": "world"}
+    struct = Struct(**data)
+    assert struct.hello == "world"
+    assert struct.get("hello") == "world"
+    assert struct.get("unknown", default=42) == 42
+    assert repr(struct) == "<hello: 'world'>"
+    assert struct.enum() == data

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -11,7 +11,6 @@ import pytest
 
 from mqttwarn.util import (
     Formatter,
-    Struct,
     asbool,
     get_resource_content,
     import_module,
@@ -24,16 +23,6 @@ from mqttwarn.util import (
     timeout,
 )
 from tests import configfile_full, funcfile_bad, funcfile_good
-
-
-def test_struct():
-    data = {"hello": "world"}
-    struct = Struct(**data)
-    assert struct.hello == "world"
-    assert struct.get("hello") == "world"
-    assert struct.get("unknown", default=42) == 42
-    assert repr(struct) == "<hello: 'world'>"
-    assert struct.enum() == data
 
 
 def test_formatter_basic():


### PR DESCRIPTION
This patch aims to further shorten `mqttwarn.core` by another 100 lines [^1], by separating all data container classes to `mqttwarn.model`.

[^1]: Now down to ~800 lines of code.