### PR TITLE
Tests: Improve test cases for Apprise service plugin

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        exclude:
+          - os: "windows-latest"
+            python-version: "3.6"
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ extras = {
         "apns>=2.0.1",
     ],
     "apprise": [
-        "apprise>=0.8.9",
+        "apprise<2",
     ],
     "asterisk": [
         "pyst2>=0.5.0",
@@ -157,7 +157,7 @@ extras["test"] = [
     "requests-toolbelt>=0.9.1,<1",
     "responses>=0.13.3,<1",
     "pyfakefs>=4.5,<5",
-]
+] + extras["all"]
 
 # Packages needed for development and running CI.
 extras["develop"] = [

--- a/tests/services/test_smtp.py
+++ b/tests/services/test_smtp.py
@@ -97,8 +97,10 @@ def test_smtp_utf8(srv, mocker, caplog):
     # Specifically examine the email body.
     body = smtplib_mock.mock_calls[5].args[2]
     assert body.startswith('Content-Type: text/plain; charset="utf-8"')
-    assert "Content-Transfer-Encoding: base64" in body
-    assert "4pq9IE5vdGlmaWNhdGlvbiBtZXNzYWdlIOKavQ==" in body
+    if "Content-Transfer-Encoding: base64" in body:
+        assert "4pq9IE5vdGlmaWNhdGlvbiBtZXNzYWdlIOKavQ==" in body
+    elif "Content-Transfer-Encoding: quoted-printable" in body:
+        assert "=E2=9A=BD Notification message =E2=9A=BD" in body
 
     assert outcome is True
 
@@ -136,8 +138,11 @@ def test_smtp_html(srv, mocker, caplog):
     body = smtplib_mock.mock_calls[5].args[2]
     assert body.startswith("Content-Type: multipart/alternative")
     assert 'Content-Type: text/plain; charset="utf-8"' in body
-    assert "Content-Transfer-Encoding: base64" in body
-    assert "4pq9IE5vdGlmaWNhdGlvbiBtZXNzYWdlIOKavQ==" in body
+
+    if "Content-Transfer-Encoding: base64" in body:
+        assert "4pq9IE5vdGlmaWNhdGlvbiBtZXNzYWdlIOKavQ==" in body
+    elif "Content-Transfer-Encoding: quoted-printable" in body:
+        assert "=E2=9A=BD Notification message =E2=9A=BD" in body
 
     assert outcome is True
 


### PR DESCRIPTION
Many test cases still use [`surrogate`](https://pypi.org/project/surrogate/) for mocking whole modules. Let's get rid of it in order to expand testing to the downstream library level, in order to be able to detect corresponding regressions.