### PR TITLE
Add documentation and test case about notifications via ntfy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ in progress
   level for filtered messages. Thanks, @jlrgraham.
 - CI and tests: Improvements and maintenance
 - Documentation: Improve section about Apprise
+- Documentation: Notifications to ntfy via Apprise. Thanks, @binwiederhier, @particledecay,
+  and @caronc.
 
 2022-10-05 0.30.0
 =================

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -378,6 +378,7 @@ _mqttwarn_ supports a number of services (listed alphabetically below):
 * [mythtv](#mythtv)
 * [nntp](#nntp)
 * [nsca](#nsca)
+* [ntfy](#ntfy)
 * [desktopnotify](#desktopnotify)
 * [osxsay](#osxsay)
 * [pastebinpub](#pastebinpub)
@@ -562,7 +563,7 @@ Apprise to E-Mail, an HTTP endpoint, and a Discord channel.
 
 ```ini
 [defaults]
-launch    = apprise-mail, apprise-json, apprise-discord
+launch    = apprise-mail, apprise-json, apprise-discord, apprise-ntfy
 
 [config:apprise-mail]
 ; Dispatch message as e-mail.
@@ -589,9 +590,16 @@ baseuri  = 'json://localhost:1234/mqtthook'
 module   = 'apprise'
 baseuri  = 'discord://4174216298/JHMHI8qBe7bk2ZwO5U711o3dV_js'
 
+[config:apprise-ntfy]
+; Dispatch message to ntfy.
+; https://github.com/caronc/apprise/wiki/URLBasics
+; https://github.com/caronc/apprise/wiki/Notify_ntfy
+module   = 'apprise_single'
+baseuri  = 'ntfy://user:password/ntfy.example.org/topic1/topic2'
+
 [apprise-single-test]
 topic    = apprise/single/#
-targets  = apprise-mail:demo, apprise-json, apprise-discord
+targets  = apprise-mail:demo, apprise-json, apprise-discord, apprise-ntfy
 format   = Alarm from {device}: {payload}
 title    = Alarm from {device}
 ```
@@ -624,6 +632,7 @@ module   = 'apprise_multi'
 targets = {
    'demo-http'        : [ { 'baseuri':  'json://localhost:1234/mqtthook' }, { 'baseuri':  'json://daq.example.org:5555/foobar' } ],
    'demo-discord'     : [ { 'baseuri':  'discord://4174216298/JHMHI8qBe7bk2ZwO5U711o3dV_js' } ],
+   'demo-ntfy'        : [ { 'baseuri':  'ntfy://user:password/ntfy.example.org/topic1/topic2' } ],
    'demo-mailto'      : [ {
           'baseuri':  'mailtos://smtp_username:smtp_password@mail.example.org',
           'recipients': ['foo@example.org', 'bar@example.org'],
@@ -634,7 +643,7 @@ targets = {
 
 [apprise-multi-test]
 topic    = apprise/multi/#
-targets  = apprise-multi:demo-http, apprise-multi:demo-discord, apprise-multi:demo-mailto
+targets  = apprise-multi:demo-http, apprise-multi:demo-discord, apprise-multi:demo-mailto, apprise-multi:demo-ntfy
 format   = Alarm from {device}: {payload}
 title    = Alarm from {device}
 ```
@@ -2025,6 +2034,15 @@ def check_temperature(data):
 
 Requires:
 * [pynsca](https://github.com/djmitche/pynsca).
+
+
+### `ntfy`
+
+Support for [ntfy] is provided through Apprise, see [apprise_single](#apprise_single)
+and [apprise_multi](#apprise_multi).
+
+[ntfy]: https://ntfy.sh/
+
 
 ### `desktopnotify`
 

--- a/README.rst
+++ b/README.rst
@@ -189,6 +189,11 @@ you an idea how to pass relevant information on the command line using JSON::
     pip install mqttwarn-contrib
     mqttwarn --plugin=mqttwarn_contrib.services.cloudflare_zone --config='{"auth-email": "foo", "auth-key": "bar"}' --options='{"addrs": ["0815", "www.example.org", ""], "message": "192.168.0.1"}'
 
+    # Submit notification to "ntfy", using Apprise service plugin.
+    mqttwarn --plugin=apprise \
+        --config='{"baseuri": "ntfy://user:password@ntfy.example.org/topic1/topic2"}' \
+        --options='{"addrs": [], "title": "Example notification", "message": "Hello world"}'
+
 
 Also, the ``--config-file`` parameter can be used to optionally specify the
 path to a configuration file.

--- a/tests/services/test_apprise_multi.py
+++ b/tests/services/test_apprise_multi.py
@@ -20,6 +20,7 @@ def test_apprise_multi_basic_success(apprise_asset, apprise_mock, srv, caplog):
         addrs=[
             {"baseuri": "json://localhost:1234/mqtthook"},
             {"baseuri": "json://daq.example.org:5555/foobar"},
+            {"baseuri": "ntfy://user:password@ntfy.example.org/topic1/topic2"},
         ],
         title="⚽ Message title ⚽",
         message="⚽ Notification message ⚽",
@@ -31,6 +32,7 @@ def test_apprise_multi_basic_success(apprise_asset, apprise_mock, srv, caplog):
         call(asset=mock.ANY),
         call().add("json://localhost:1234/mqtthook"),
         call().add("json://daq.example.org:5555/foobar"),
+        call().add("ntfy://user:password@ntfy.example.org/topic1/topic2"),
         call().notify(body="⚽ Notification message ⚽", title="⚽ Message title ⚽"),
         call().notify().__bool__(),
     ]
@@ -38,8 +40,10 @@ def test_apprise_multi_basic_success(apprise_asset, apprise_mock, srv, caplog):
     assert outcome is True
     assert (
         "Sending notification to Apprise. target=None, addresses=["
-        "{'baseuri': 'json://localhost:1234/mqtthook'}, {'baseuri': 'json://daq.example.org:5555/foobar'}]"
-        in caplog.messages
+        "{'baseuri': 'json://localhost:1234/mqtthook'}, "
+        "{'baseuri': 'json://daq.example.org:5555/foobar'}, "
+        "{'baseuri': 'ntfy://user:password@ntfy.example.org/topic1/topic2'}"
+        "]" in caplog.messages
     )
     assert "Successfully sent message using Apprise" in caplog.messages
 


### PR DESCRIPTION
A basic shot at #607, implementing notifications to ntfy via Apprise without putting in much efforts. Kudos to @binwiederhier, @particledecay, and @caronc.