### PR TITLE
This and that

### DIFF
--- a/.github/workflows/release-docker-full.yml
+++ b/.github/workflows/release-docker-full.yml
@@ -5,15 +5,24 @@
 name: Release Docker Full
 
 on:
-  schedule:
-    - cron: '0 10 * * *' # everyday at 10am
   push:
     tags:
       - '*.*.*'
-  workflow_dispatch:
   pull_request:
     branches: [ main ]
 
+  schedule:
+    - cron: '0 10 * * *' # everyday at 10am
+
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+# The name for the produced image at ghcr.io.
 env:
   GHCR_IMAGE_NAME: jpmens/mqttwarn-full
 

--- a/.github/workflows/release-docker-full.yml
+++ b/.github/workflows/release-docker-full.yml
@@ -31,12 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v2
+        name: Acquire sources
+        uses: actions/checkout@v3
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           # List of Docker images to use as base name for tags
           images: |
@@ -52,14 +52,14 @@ jobs:
           echo "Labels:    ${{ steps.meta.outputs.labels }}"
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -76,14 +76,14 @@ jobs:
       -
         name: Login to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
       -
         name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile.full

--- a/.github/workflows/release-docker-standard.yml
+++ b/.github/workflows/release-docker-standard.yml
@@ -31,12 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v2
+        name: Acquire sources
+        uses: actions/checkout@v3
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           # List of Docker images to use as base name for tags
           images: |
@@ -52,14 +52,14 @@ jobs:
           echo "Labels:    ${{ steps.meta.outputs.labels }}"
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -76,14 +76,14 @@ jobs:
       -
         name: Login to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
       -
         name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/release-docker-standard.yml
+++ b/.github/workflows/release-docker-standard.yml
@@ -5,15 +5,24 @@
 name: Release Docker Standard
 
 on:
-  schedule:
-    - cron: '0 10 * * *' # everyday at 10am
   push:
     tags:
       - '*.*.*'
-  workflow_dispatch:
   pull_request:
     branches: [ main ]
 
+  schedule:
+    - cron: '0 10 * * *' # everyday at 10am
+
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+# The name for the produced image at ghcr.io.
 env:
   GHCR_IMAGE_NAME: jpmens/mqttwarn-standard
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         exclude:
           - os: "windows-latest"
             python-version: "3.6"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,19 @@
 name: Tests
+
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         exclude:
+
+          # Breaks on building `winsdk`
           - os: "windows-latest"
             python-version: "3.6"
+
+          # Takes ages on building `winsdk`
+          - os: "windows-latest"
+            python-version: "3.12-dev"
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ mqttwarn changelog
 in progress
 ===========
 
+- Make the PushOver API ``retry`` and ``expire`` options configurable. Thanks, @jlrgraham.
+- Add new configuration setting ``filteredmessagesloglevel``, to optionally set the log
+  level for filtered messages. Thanks, @jlrgraham.
+- CI and tests: Improvements and maintenance
+- Documentation: Improve section about Apprise
 
 2022-10-05 0.30.0
 =================

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -339,6 +339,7 @@ _mqttwarn_ supports a number of services (listed alphabetically below):
 * [alexa-notify-me](#alexa-notify-me)
 * [amqp](#amqp)
 * [apns](#apns)
+* [apprise_about](#apprise_about)
 * [apprise_single](#apprise_single)
 * [apprise_multi](#apprise_multi)
 * [asterisk](#asterisk)
@@ -530,11 +531,25 @@ would thus emit the APNS notification to the specified device.
 Requires [PyAPNs](https://github.com/djacobs/PyAPNs)
 
 
+### `apprise_about`
+
+The `apprise_single` and `apprise_multi` service plugins interact with the [Apprise]
+Python module, which in turn can talk to a plethora of popular notification services.
+
+[Apprise Notification Services] has a complete list of notification services supported
+by Apprise.
+
+Notification services are addressed by URL, see [Apprise URL Basics].
+Please consult the Apprise documentation about more details.
+
+[Apprise]: https://github.com/caronc/apprise
+[Apprise URL Basics]: https://github.com/caronc/apprise/wiki/URLBasics
+[Apprise Notification Services]: https://github.com/caronc/apprise/wiki#notification-services
+
+
 ### `apprise_single`
 
-The `apprise_single` service interacts with the [Apprise] Python module,
-which in turn can talk to a plethora of popular notification services.
-Please read their documentation about more details.
+This variant can publish messages to a single Apprise plugin by URL.
 
 The following configuration snippet example expects a payload like this to be
 published to the MQTT broker:
@@ -589,12 +604,9 @@ channel, which works like `-m "hello @everyone again"`.
 
 ### `apprise_multi`
 
-The `apprise_multi` service interacts with the [Apprise] Python module,
-which in turn can talk to a plethora of popular notification services.
-Please read their documentation about more details.
-
 The idea behind this variant is to publish messages to different Apprise
-plugins within a single configuration snippet, containing multiple recipients.
+plugins within a single configuration snippet, containing multiple recipients
+at different notification services.
 
 The following configuration snippet example expects a payload like this to be
 published to the MQTT broker:
@@ -626,8 +638,6 @@ targets  = apprise-multi:demo-http, apprise-multi:demo-discord, apprise-multi:de
 format   = Alarm from {device}: {payload}
 title    = Alarm from {device}
 ```
-
-[Apprise]: https://github.com/caronc/apprise
 
 
 ### `autoremote`

--- a/setup.py
+++ b/setup.py
@@ -198,6 +198,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Communications",
         "Topic :: Education",
         "Topic :: Internet",


### PR DESCRIPTION
- CI: Python 3.11 has been released on 24 Oct 2022
- CI: Python 3.12 will be released on 2 Oct 2023
- CI: Update GHA action versions for Docker image workflows
- Documentation: Improve section about Apprise
- Chore: Add changelog items