### PR TITLE
Apprise: Disable the Apprise rate limiting subsystem

### DIFF
--- a/mqttwarn/services/apprise_multi.py
+++ b/mqttwarn/services/apprise_multi.py
@@ -23,6 +23,13 @@ def plugin(srv, item):
     try:
         srv.logging.debug("Sending notification to Apprise. target=%s, addresses=%s" % (item.target, addresses))
 
+        # Disable the Apprise rate limiting subsystem.
+        try:
+            from apprise.plugins.NotifyBase import NotifyBase
+            NotifyBase.request_rate_per_sec = 0
+        except ImportError:
+            pass
+
         # Create an Apprise instance.
         apobj = apprise.Apprise(asset=apprise.AppriseAsset(async_mode=False))
 

--- a/mqttwarn/services/apprise_single.py
+++ b/mqttwarn/services/apprise_single.py
@@ -27,6 +27,13 @@ def plugin(srv, item):
         srv.logging.debug("Sending notification to Apprise. target=%s, addresses=%s" % (item.target, addresses))
         to = ','.join(addresses)
 
+        # Disable the Apprise rate limiting subsystem.
+        try:
+            from apprise.plugins.NotifyBase import NotifyBase
+            NotifyBase.request_rate_per_sec = 0
+        except ImportError:
+            pass
+
         # Create an Apprise instance.
         apobj = apprise.Apprise(asset=apprise.AppriseAsset(async_mode=False))
 


### PR DESCRIPTION
Apprise applies rate limiting with delays of ~4-5 seconds on subsequent message submissions. This is not desired for `mqttwarn`. Indirectly related: https://github.com/caronc/apprise/issues/735#issuecomment-1301595477.

@caronc: Maybe a future Apprise can be made configurable to only _optionally_ enable rate limiting?
