### PR TITLE
Tests: Remove use of `surrogate` within Apprise tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Setup project
       run: |
         # Install package in editable mode.
+        pip install wheel
         pip install --editable=.[test,develop]
 
     - name: Check code style

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN chown -R mqttwarn:mqttwarn /etc/mqttwarn
 
 # Install mqttwarn
 COPY . /src
+RUN pip install wheel
 RUN pip install /src
 
 # Make process run as "mqttwarn" user

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -21,6 +21,7 @@ RUN chown -R mqttwarn:mqttwarn /etc/mqttwarn
 
 # Install mqttwarn
 COPY . /src
+RUN pip install wheel
 RUN pip install /src[all]
 
 # Make process run as "mqttwarn" user

--- a/Dockerfile.mqttwarn-slack
+++ b/Dockerfile.mqttwarn-slack
@@ -13,6 +13,7 @@ FROM ghcr.io/jpmens/mqttwarn-standard:latest
 USER root
 
 # Install Slack SDK.
+RUN pip install wheel
 RUN pip install mqttwarn[slack]
 
 # Make process run as "mqttwarn" user

--- a/tests/services/test_apprise_multi.py
+++ b/tests/services/test_apprise_multi.py
@@ -3,13 +3,10 @@
 from unittest import mock
 from unittest.mock import call
 
-from surrogate import surrogate
-
 from mqttwarn.model import ProcessorItem as Item
 from mqttwarn.util import load_module_by_name
 
 
-@surrogate("apprise")
 @mock.patch("apprise.Apprise", create=True)
 @mock.patch("apprise.AppriseAsset", create=True)
 def test_apprise_multi_basic_success(apprise_asset, apprise_mock, srv, caplog):
@@ -44,7 +41,6 @@ def test_apprise_multi_basic_success(apprise_asset, apprise_mock, srv, caplog):
     assert "Successfully sent message using Apprise" in caplog.messages
 
 
-@surrogate("apprise")
 @mock.patch("apprise.Apprise", create=True)
 @mock.patch("apprise.AppriseAsset", create=True)
 def test_apprise_multi_mailto_success(apprise_asset, apprise_mock, srv, caplog):
@@ -87,7 +83,6 @@ def test_apprise_multi_mailto_success(apprise_asset, apprise_mock, srv, caplog):
     assert "Successfully sent message using Apprise" in caplog.messages
 
 
-@surrogate("apprise")
 def test_apprise_multi_failure_notify(srv, caplog):
 
     mock_connection = mock.MagicMock()
@@ -125,7 +120,6 @@ def test_apprise_multi_failure_notify(srv, caplog):
             assert "Sending message using Apprise failed" in caplog.messages
 
 
-@surrogate("apprise")
 def test_apprise_multi_error(srv, caplog):
 
     mock_connection = mock.MagicMock()

--- a/tests/services/test_apprise_single.py
+++ b/tests/services/test_apprise_single.py
@@ -3,8 +3,6 @@
 from unittest import mock
 from unittest.mock import Mock, call
 
-from surrogate import surrogate
-
 from mqttwarn.model import ProcessorItem as Item
 from mqttwarn.util import load_module_from_file
 
@@ -44,7 +42,6 @@ def test_apprise_success(srv, mocker, caplog):
     assert "Successfully sent message using Apprise" in caplog.messages
 
 
-@surrogate("apprise")
 @mock.patch("apprise.Apprise", create=True)
 @mock.patch("apprise.AppriseAsset", create=True)
 def test_apprise_success_no_addresses(apprise_asset, apprise_mock, srv, caplog):
@@ -76,7 +73,6 @@ def test_apprise_success_no_addresses(apprise_asset, apprise_mock, srv, caplog):
     assert "Successfully sent message using Apprise" in caplog.messages
 
 
-@surrogate("apprise")
 def test_apprise_failure_notify(srv, caplog):
 
     mock_connection = mock.MagicMock()
@@ -118,7 +114,6 @@ def test_apprise_failure_notify(srv, caplog):
             assert "Sending message using Apprise failed" in caplog.messages
 
 
-@surrogate("apprise")
 def test_apprise_error(srv, caplog):
 
     mock_connection = mock.MagicMock()
@@ -160,7 +155,6 @@ def test_apprise_error(srv, caplog):
             assert "Sending message using Apprise failed. target=test, error=something failed" in caplog.messages
 
 
-@surrogate("apprise")
 @mock.patch("apprise.Apprise", create=True)
 @mock.patch("apprise.AppriseAsset", create=True)
 def test_apprise_success_with_sender(apprise_asset, apprise_mock, srv, caplog):
@@ -194,7 +188,6 @@ def test_apprise_success_with_sender(apprise_asset, apprise_mock, srv, caplog):
     assert "Successfully sent message using Apprise" in caplog.messages
 
 
-@surrogate("apprise")
 @mock.patch("apprise.Apprise", create=True)
 @mock.patch("apprise.AppriseAsset", create=True)
 def test_apprise_success_backward_compat(apprise_asset, apprise_mock, srv, caplog):


### PR DESCRIPTION
Aiming to repair CI run on #613.

- Tests: Remove use of `surrogate` within Apprise tests
- Sandbox: Install package `wheel` before installing the project