### PR TITLE
Tests: Improve full-stack testing without mocking whole modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ extras["all"] = extras_all
 # Packages needed for running the tests.
 extras["test"] = [
     "pytest<8",
-    "pytest-cov<4",
+    "pytest-cov<5",
     "pytest-mock<4",
     "pytest-mqtt<1",
     "tox<4",

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,6 @@ extras["test"] = [
     "pytest-mock<4",
     "pytest-mqtt<1",
     "tox<4",
-    "surrogate==0.1",
     'dataclasses; python_version<"3.7"',
     "requests-toolbelt>=0.9.1,<1",
     "responses>=0.13.3,<1",

--- a/tests/services/test_amqp.py
+++ b/tests/services/test_amqp.py
@@ -2,13 +2,10 @@
 # (c) 2021-2022 The mqttwarn developers
 from unittest.mock import ANY, Mock, call
 
-from surrogate import surrogate
-
 from mqttwarn.model import ProcessorItem as Item
 from mqttwarn.util import load_module_by_name
 
 
-@surrogate("puka")
 def test_amqp_success(srv, mocker, caplog):
     module = load_module_by_name("mqttwarn.services.amqp")
 
@@ -47,7 +44,6 @@ def test_amqp_success(srv, mocker, caplog):
     assert "Successfully published AMQP notification" in caplog.messages
 
 
-@surrogate("puka")
 def test_amqp_failure(srv, mocker, caplog):
     module = load_module_by_name("mqttwarn.services.amqp")
 

--- a/tests/services/test_apns.py
+++ b/tests/services/test_apns.py
@@ -3,8 +3,12 @@
 from unittest import mock
 from unittest.mock import call
 
+import pytest
+
 from mqttwarn.model import ProcessorItem as Item
 from mqttwarn.util import load_module_from_file
+
+pytest.skip(reason="The `apns` package is not ready for Python3", allow_module_level=True)
 
 
 @mock.patch("apns.APNs", create=True)

--- a/tests/services/test_apns.py
+++ b/tests/services/test_apns.py
@@ -3,13 +3,10 @@
 from unittest import mock
 from unittest.mock import call
 
-from surrogate import surrogate
-
 from mqttwarn.model import ProcessorItem as Item
 from mqttwarn.util import load_module_from_file
 
 
-@surrogate("apns")
 @mock.patch("apns.APNs", create=True)
 @mock.patch("apns.Payload", create=True)
 def test_apns_success(mock_apns_payload, mock_apns, srv, caplog):
@@ -43,7 +40,6 @@ def test_apns_success(mock_apns_payload, mock_apns, srv, caplog):
     assert "Successfully published APNS notification to foobar" in caplog.messages
 
 
-@surrogate("apns")
 @mock.patch("apns.APNs", create=True)
 @mock.patch("apns.Payload", create=True)
 def test_apns_success_no_payload(mock_apns_payload, mock_apns, srv, caplog):
@@ -67,7 +63,6 @@ def test_apns_success_no_payload(mock_apns_payload, mock_apns, srv, caplog):
     assert "Successfully published APNS notification to foobar" in caplog.messages
 
 
-@surrogate("apns")
 @mock.patch("apns.APNs", create=True)
 @mock.patch("apns.Payload", create=True)
 def test_apns_success_custom_payload(mock_apns_payload, mock_apns, srv, caplog):
@@ -101,7 +96,6 @@ def test_apns_success_custom_payload(mock_apns_payload, mock_apns, srv, caplog):
     assert "Successfully published APNS notification to foobar" in caplog.messages
 
 
-@surrogate("apns")
 @mock.patch("apns.APNs", create=True)
 @mock.patch("apns.Payload", create=True)
 def test_apns_failure_invalid_config(mock_apns_payload, mock_apns, srv, caplog):
@@ -121,7 +115,6 @@ def test_apns_failure_invalid_config(mock_apns_payload, mock_apns, srv, caplog):
     assert "Incorrect service configuration" in caplog.messages
 
 
-@surrogate("apns")
 @mock.patch("apns.APNs", create=True)
 @mock.patch("apns.Payload", create=True)
 def test_apns_failure_apns_token_missing(mock_apns_payload, mock_apns, srv, caplog):

--- a/tests/services/test_asterisk.py
+++ b/tests/services/test_asterisk.py
@@ -3,13 +3,10 @@
 from unittest import mock
 from unittest.mock import Mock, call
 
-from surrogate import surrogate
-
 from mqttwarn.model import ProcessorItem as Item
 from mqttwarn.util import load_module_from_file
 
 
-@surrogate("asterisk.manager")
 @mock.patch("asterisk.manager.Manager", create=True)
 def test_asterisk_success(asterisk_mock, srv, caplog):
 
@@ -66,7 +63,6 @@ class ManagerException(Exception):
     pass
 
 
-@surrogate("asterisk.manager")
 @mock.patch("asterisk.manager.Manager", create=True)
 @mock.patch("asterisk.manager.ManagerSocketException", ManagerSocketException, create=True)
 def test_asterisk_failure_no_connection(asterisk_mock, srv, caplog):
@@ -101,7 +97,6 @@ def test_asterisk_failure_no_connection(asterisk_mock, srv, caplog):
     assert "Error connecting to the manager: something failed" in caplog.messages
 
 
-@surrogate("asterisk.manager")
 @mock.patch("asterisk.manager.Manager", create=True)
 @mock.patch("asterisk.manager.ManagerSocketException", ManagerSocketException, create=True)
 @mock.patch("asterisk.manager.ManagerAuthException", ManagerAuthException, create=True)
@@ -138,7 +133,6 @@ def test_asterisk_failure_login_invalid(asterisk_mock, srv, caplog):
     assert "Error logging in to the manager: something failed" in caplog.messages
 
 
-@surrogate("asterisk.manager")
 @mock.patch("asterisk.manager.Manager", create=True)
 @mock.patch("asterisk.manager.ManagerSocketException", ManagerSocketException, create=True)
 @mock.patch("asterisk.manager.ManagerAuthException", ManagerAuthException, create=True)
@@ -188,7 +182,6 @@ def test_asterisk_failure_originate_croaks(asterisk_mock, srv, caplog):
     assert "Error: something failed" in caplog.messages
 
 
-@surrogate("asterisk.manager")
 @mock.patch("asterisk.manager.Manager", create=True)
 @mock.patch("asterisk.manager.ManagerSocketException", ManagerSocketException, create=True)
 @mock.patch("asterisk.manager.ManagerAuthException", ManagerAuthException, create=True)

--- a/tests/services/test_desktopnotify.py
+++ b/tests/services/test_desktopnotify.py
@@ -4,7 +4,6 @@ import json
 from unittest.mock import Mock, call
 
 import pytest
-from surrogate import surrogate
 
 from mqttwarn.model import ProcessorItem as Item
 from mqttwarn.model import Struct
@@ -13,12 +12,11 @@ from mqttwarn.util import load_module_by_name
 
 @pytest.fixture
 def desktop_notifier_mock(mocker):
-    with surrogate("desktop_notifier"):
-        notifier = mocker.patch("desktop_notifier.DesktopNotifier", create=True)
-        mocker.patch("desktop_notifier.Urgency", create=True)
-        mocker.patch("desktop_notifier.Button", create=True)
-        mocker.patch("desktop_notifier.ReplyField", create=True)
-        yield notifier
+    notifier = mocker.patch("desktop_notifier.DesktopNotifier", create=True)
+    mocker.patch("desktop_notifier.Urgency", create=True)
+    mocker.patch("desktop_notifier.Button", create=True)
+    mocker.patch("desktop_notifier.ReplyField", create=True)
+    yield notifier
 
 
 def test_desktopnotify_vanilla_success(desktop_notifier_mock, srv, caplog):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -7,7 +7,6 @@ from unittest.mock import Mock, patch
 
 import docopt
 import pytest
-from surrogate import surrogate
 
 import mqttwarn.commands
 from mqttwarn.configuration import Config
@@ -162,12 +161,11 @@ def test_setup_logging_default(mocker):
     """
     config = Config()
 
-    with surrogate("logging"):
-        logging_mock: Mock = mocker.patch("logging.basicConfig")
-        mqttwarn.commands.setup_logging(config)
-        logging_mock.assert_called_with(
-            format="%(asctime)-15s %(levelname)-8s [%(name)-26s] %(message)s", level=10, stream=mock.ANY
-        )
+    logging_mock: Mock = mocker.patch("logging.basicConfig")
+    mqttwarn.commands.setup_logging(config)
+    logging_mock.assert_called_with(
+        format="%(asctime)-15s %(levelname)-8s [%(name)-26s] %(message)s", level=10, stream=mock.ANY
+    )
 
 
 def test_setup_logging_no_logfile():
@@ -186,9 +184,8 @@ def test_setup_logging_logfile_without_protocol(mocker):
     config = Config()
     config.logfile = "sys.stderr"
 
-    with surrogate("logging"):
-        logging_mock: Mock = mocker.patch("logging.basicConfig")
-        mqttwarn.commands.setup_logging(config)
-        logging_mock.assert_called_with(
-            filename="sys.stderr", format="%(asctime)-15s %(levelname)-8s [%(name)-26s] %(message)s", level=10
-        )
+    logging_mock: Mock = mocker.patch("logging.basicConfig")
+    mqttwarn.commands.setup_logging(config)
+    logging_mock.assert_called_with(
+        filename="sys.stderr", format="%(asctime)-15s %(levelname)-8s [%(name)-26s] %(message)s", level=10
+    )


### PR DESCRIPTION
Previously, the test suite used the [`surrogate`](https://pypi.org/project/surrogate/) package, because it was not ensured that all third-party packages would have been installed within the testing environment.

Now, with b4c461977, "all" third-party packages will _always_ be installed when installing the "test" extra, in order to enable full-stack testing, and improve the overall quality of the test suite.

702fa768d9d disables testing the `apns` service plugin, because the [`apns`](https://pypi.org/project/apns/) package is not ready for Python3. For upgrading to a successor library, see also #580.
