### PR TITLE
Touch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,7 @@ jobs:
         pip install --editable=.[test,develop]
 
     - name: Check code style
+      # `ruff` is only available for Python>=3.7.
       if: matrix.python-version != '3.6'
       run: |
         poe check-style


### PR DESCRIPTION
Just evaluates if Python 3.6 still works on CI.