### PR TITLE
Docker: Debug why the repository is flagged dirty on CI/GHA

### DIFF
--- a/.github/workflows/release-docker-standard.yml
+++ b/.github/workflows/release-docker-standard.yml
@@ -102,3 +102,7 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      - name: Display git status
+        run: |
+          git status


### PR DESCRIPTION
It looks like not everything is right with GH-620 yet.
```
docker run -it --rm ghcr.io/jpmens/mqttwarn-standard:0.32.0 mqttwarn --version
mqttwarn 0.32.0+d20230213
```
