### PR TITLE
[Pushsafer] Improve configuration to use named parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,13 @@ mqttwarn changelog
 in progress
 ===========
 
+- Pushsafer: Fix to prevent submitting empty parameters to upstream API.
+
+  BREAKING CHANGE: This has an impact on the ``vibration`` parameter:
+  Previously, a Pushsafer notification would always have vibrations turned
+  on, which is considered to be a bug. Now, you will have to explicitly
+  configure ``vibration=0``, in order to use the "device-default" vibration.
+
 
 2023-02-13 0.32.0
 =================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ in progress
 ===========
 
 - Pushsafer: Fix to prevent submitting empty parameters to upstream API.
+- Pushsafer: Modernize configuration layout for target addresses.
 
 
 2023-02-13 0.32.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,11 +8,6 @@ in progress
 
 - Pushsafer: Fix to prevent submitting empty parameters to upstream API.
 
-  BREAKING CHANGE: This has an impact on the ``vibration`` parameter:
-  Previously, a Pushsafer notification would always have vibrations turned
-  on, which is considered to be a bug. Now, you will have to explicitly
-  configure ``vibration=0``, in order to use the "device-default" vibration.
-
 
 2023-02-13 0.32.0
 =================

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -2468,7 +2468,11 @@ notify, say, one or more of your devices as well as one for your spouse.
 For a list of available icons, sounds and other params see the
 [Pushsafer API](https://www.pushsafer.com/en/pushapi).
 
-Please note that `vibration=0` means "device-default" vibration.
+Please note:
+- The default value for the [_Expire_](https://www.pushsafer.com/en/pushapi_ext#API-EX)
+  parameter is `3600`.
+  
+- `vibration=0` means "device-default" vibration.
 
 | Topic option  |  M/O   | Description                            |
 | ------------- | :----: | -------------------------------------- |

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -2457,8 +2457,8 @@ In order to receive pushsafer notifications you need what is called a _private o
 targets = {
     'nagios'     : ['privatekey', 'Device ID', 'Icon', 'Sound', 'Vibration', 'URL', 'Url Title', 'Time2Live', 'Priority', 'Retry', 'Expire', 'Answer'],
     'tracking'   : ['aliaskey1'],
-    'extraphone' : ['aliaskey2', '', '', '', '0', '', '', '60', '2', '60', '600', '0'],
-	'warnme'     : ['aliaskey3', '', '', '', '0', '', '', '60', '1', '', '', '1']
+    'extraphone' : ['aliaskey2', '', '', '', '', '', '', '60', '2', '60', '600', '0'],
+	'warnme'     : ['aliaskey3', '', '', '', '', '', '', '60', '1', '', '', '1']
     }
 ```
 
@@ -2472,9 +2472,6 @@ Please note:
 - [Retry](https://www.pushsafer.com/en/pushapi_ext#API-RE)
   with [Expire](https://www.pushsafer.com/en/pushapi_ext#API-EX): 
   For configuring delivery retries, you must set both parameters.
-- [Vibration](https://www.pushsafer.com/en/pushapi_ext#API-V):
-  `vibration=0` means "device-default" vibration. This is a special value
-  used by mqttwarn, it will be translated to an empty `v=` upstream parameter.
 
 | Topic option  |  M/O   | Description                            |
 | ------------- | :----: | -------------------------------------- |

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -2449,38 +2449,64 @@ Requires:
 
 ### `pushsafer`
 
-This service is for [Pushsafer](https://www.pushsafer.com), an app for iOS, Android and Windows 10.
-In order to receive pushsafer notifications you need what is called a _private or alias key_:
+[Pushsafer](https://www.pushsafer.com) is an app for iOS, Android and Windows 10.
+You can define different notification targets, in turn dispatching to one or 
+multiple Pushsafer devices or groups.
+For a list of available icons, sounds and other parameters, see the
+[Pushsafer API](https://www.pushsafer.com/en/pushapi) documentation.
+
+#### Requirements
+In order to receive Pushsafer notifications, you need what is called a _private 
+or alias key_. To receive such a key, you will need to sign up for an account.
+
+#### Configuration example
 
 ```ini
 [config:pushsafer]
+; https://www.pushsafer.com/en/pushapi
+; https://www.pushsafer.com/en/pushapi_ext
 targets = {
-    'nagios'     : ['privatekey', 'Device ID', 'Icon', 'Sound', 'Vibration', 'URL', 'Url Title', 'Time2Live', 'Priority', 'Retry', 'Expire', 'Answer'],
-    'tracking'   : ['aliaskey1'],
-    'extraphone' : ['aliaskey2', '', '', '', '', '', '', '60', '2', '60', '600', '0'],
-	'warnme'     : ['aliaskey3', '', '', '', '', '', '', '60', '1', '', '', '1']
+    'basic': { 'private_key': '3SAz1a2iTYsh19eXIMiO' },
+    'nagios': {
+        'private_key': '3SAz1a2iTYsh19eXIMiO',
+        'device': '52|65|78',
+        'icon': 64,
+        'sound': 2,
+        'vibration': 1,
+        'url': 'http://example.org',
+        'url_title': 'Example Org',
+        'time_to_live': 60,
+        'priority': 2,
+        'retry': 60,
+        'expire': 600,
+        'answer': 1,
+        },
+    'tracking': {
+        'private_key': '3SAz1a2iTYsh19eXIMiO',
+        'device': 'gs23',
+        'icon': 18,
+        },
+    'extraphone': { 'private_key': 'aliaskey2', 'time_to_live': 60, 'priority': 2, 'retry': 60, 'expire': 600, 'answer': 0 },
+    'warnme': { 'private_key': 'aliaskey3', 'time_to_live': 60, 'priority': 1, 'answer': 1 },
     }
 ```
 
-This defines targets (`nagios`, `alerts`, etc.) which are directed to the
-configured _private or alias key_ combinations. This in turn enables you to
-notify, say, one or more of your devices as well as one for your spouse.
-For a list of available icons, sounds and other params see the
-[Pushsafer API](https://www.pushsafer.com/en/pushapi).
-
-Please note:
-- [Retry](https://www.pushsafer.com/en/pushapi_ext#API-RE)
-  with [Expire](https://www.pushsafer.com/en/pushapi_ext#API-EX): 
-  For configuring delivery retries, you must set both parameters.
+#### MQTT topic options
 
 | Topic option  |  M/O   | Description                            |
 | ------------- | :----: | -------------------------------------- |
 | `title`       |   O    | application title (dflt: pushsafer dflt) |
 
+#### Notes
+- [Retry](https://www.pushsafer.com/en/pushapi_ext#API-RE)
+  with [Expire](https://www.pushsafer.com/en/pushapi_ext#API-EX):
+  For configuring delivery retries, you must set both parameters.
+- The legacy configuration layout, based on a list for the `addrs` slot,
+  is still supported.
+
+#### Screenshot
 ![pushsafer on iOS](assets/pushsafer.jpg)
 
-Requires:
-* An account at [pushsafer.com](https://www.pushsafer.com/).
 
 ### `redispub`
 

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -2457,8 +2457,8 @@ In order to receive pushsafer notifications you need what is called a _private o
 targets = {
     'nagios'     : ['privatekey', 'Device ID', 'Icon', 'Sound', 'Vibration', 'URL', 'Url Title', 'Time2Live', 'Priority', 'Retry', 'Expire', 'Answer'],
     'tracking'   : ['aliaskey1'],
-    'extraphone' : ['aliaskey2', '', '', '', '', '', '', '60', '2', '60', '600', '0'],
-	'warnme'     : ['aliaskey3', '', '', '', '', '', '', '60', '1', '', '', '1']
+    'extraphone' : ['aliaskey2', '', '', '', '0', '', '', '60', '2', '60', '600', '0'],
+	'warnme'     : ['aliaskey3', '', '', '', '0', '', '', '60', '1', '', '', '1']
     }
 ```
 
@@ -2467,6 +2467,8 @@ configured _private or alias key_ combinations. This in turn enables you to
 notify, say, one or more of your devices as well as one for your spouse.
 For a list of available icons, sounds and other params see the
 [Pushsafer API](https://www.pushsafer.com/en/pushapi).
+
+Please note that `vibration=0` means "device-default" vibration.
 
 | Topic option  |  M/O   | Description                            |
 | ------------- | :----: | -------------------------------------- |

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -2469,10 +2469,12 @@ For a list of available icons, sounds and other params see the
 [Pushsafer API](https://www.pushsafer.com/en/pushapi).
 
 Please note:
-- The default value for the [_Expire_](https://www.pushsafer.com/en/pushapi_ext#API-EX)
-  parameter is `3600`.
-  
-- `vibration=0` means "device-default" vibration.
+- [Retry](https://www.pushsafer.com/en/pushapi_ext#API-RE)
+  with [Expire](https://www.pushsafer.com/en/pushapi_ext#API-EX): 
+  For configuring delivery retries, you must set both parameters.
+- [Vibration](https://www.pushsafer.com/en/pushapi_ext#API-V):
+  `vibration=0` means "device-default" vibration. This is a special value
+  used by mqttwarn, it will be translated to an empty `v=` upstream parameter.
 
 | Topic option  |  M/O   | Description                            |
 | ------------- | :----: | -------------------------------------- |

--- a/mqttwarn/model.py
+++ b/mqttwarn/model.py
@@ -37,6 +37,12 @@ class Struct:
         return item
 
 
+# Covering old- and new-style configuration layouts. `addrs` has
+# originally been a list of strings, has been expanded to be a
+# list of dictionaries (Apprise), and to be a dictionary (Pushsafer).
+addrs_type = Union[List[Union[str, Dict[str, str]]], Dict[str, str]]
+
+
 @dataclass
 class ProcessorItem:
     """
@@ -46,7 +52,7 @@ class ProcessorItem:
     service: Optional[str] = None
     target: Optional[str] = None
     config: Dict = field(default_factory=dict)
-    addrs: List[Union[str, Dict[str, str]]] = field(default_factory=list)
+    addrs: addrs_type = field(default_factory=list)  # type: ignore[assignment]
     priority: Optional[int] = None
     topic: Optional[str] = None
     title: Optional[str] = None

--- a/mqttwarn/services/pushsafer.py
+++ b/mqttwarn/services/pushsafer.py
@@ -131,9 +131,7 @@ class PushsaferParameterEncoder:
         except IndexError:
             raise PushsaferConfigurationError(f"Pushsafer private or alias key not configured")
 
-        params = {
-            'expire': 3600,
-        }
+        params = OrderedDict()
 
         if len(addrs) > 1:
             params['d'] = addrs[1]
@@ -192,13 +190,9 @@ class PushsaferParameterEncoder:
         except KeyError:
             raise PushsaferConfigurationError(f"Pushsafer private or alias key not configured")
 
-        params = {
-            'expire': 3600,
-        }
-
         # Decode and serialize all other parameters.
         pp = PushsaferParameters(**addrs)
-        params.update(pp.translated())
+        params = pp.translated()
 
         # Propagate `title` separately.
         if title is not None:

--- a/mqttwarn/services/pushsafer.py
+++ b/mqttwarn/services/pushsafer.py
@@ -13,13 +13,21 @@ import urllib.request, urllib.parse, urllib.error
 import urllib.request, urllib.error, urllib.parse
 import urllib.parse
 
+import typing as t
+
+from mqttwarn.model import ProcessorItem
+
 PUSHSAFER_API = "https://www.pushsafer.com/"
 
 
 class PushsaferError(Exception): pass
+class PushsaferConfigurationError(Exception): pass
 
 
 def pushsafer(**kwargs):
+    """
+    Submit notification to Pushsafer.
+    """
     assert 'm' in kwargs
 
     if not kwargs['k']:
@@ -38,80 +46,113 @@ def pushsafer(**kwargs):
 
 def plugin(srv, item):
 
-    message  = item.message
-    addrs    = item.addrs
-    title    = item.title
-
-
     srv.logging.debug("*** MODULE=%s: service=%s, target=%s", __file__, item.service, item.target)
-    
-    # based on the Pushsafer API (https://www.pushsafer.com/en/pushapi)
-    # addrs is an array with two or three elements:
-    # 0 is the private or alias key
-    # 1 (if present) is the Pushsafer device or device group id where the message is to be sent
-    # 2 (if present) is the Pushsafer icon to display in the message
-    # 3 (if present) is the Pushsafer sound to play for the message
-    # 4 (if present) is the Pushsafer vibration for the message
-    # 5 (if present) is the Pushsafer URL or URL Scheme
-    # 6 (if present) is the Pushsafer Title of URL
-    # 7 (if present) is the Pushsafer Time in minutes, after which message automatically gets purged
-    # 8 (if present) is the Pushsafer priority, integer -2, -1, 0, 1, 2
-    # 9 (if present) is the Pushsafer retry after which time (in secomds 60-10800) a message should resend
-    # 10 (if present) is the Pushsafer expire after which time (in secomds 60-10800) the retry should stopped
-    # 11 (if present) is the Pushsafer answer, 1 = Answer, 0 = no possibilty to answer
 
+    # Compute Pushsafer parameters from `ProcessorItem`.
+    pe = PushsaferParameterEncoder(item=item)
     try:
-        appkey  = addrs[0]
-    except:
-        srv.logging.warn("No pushsafer private or alias key configured for target `%s'" % (item.target))
+        pe.encode()
+    except PushsaferConfigurationError as ex:
+        srv.logging.error(f"{ex}. target={item.target}")
         return False
 
-    params = {
-            'expire' : 3600,
-        }
-
-    if len(addrs) > 1:
-        params['d'] = addrs[1]
-
-    if len(addrs) > 2:
-        params['i'] = addrs[2]
-
-    if len(addrs) > 3:
-        params['s'] = addrs[3]
-
-    if len(addrs) > 4:
-        params['v'] = addrs[4]
-
-    if len(addrs) > 5:
-        params['u'] = addrs[5]
-
-    if len(addrs) > 6:
-        params['ut'] = addrs[6]
-
-    if len(addrs) > 7:
-        params['l'] = addrs[7]
-
-    if len(addrs) > 8:
-        params['pr'] = addrs[8]
-
-    if len(addrs) > 9:
-        params['re'] = addrs[9]
-
-    if len(addrs) > 10:
-        params['ex'] = addrs[10]
-
-    if len(addrs) > 11:
-        params['a'] = addrs[11]
-
-    if title is not None:
-        params['t'] = title
-
+    # Submit notification.
+    params = pe.params
     try:
         srv.logging.debug("Sending pushsafer notification to %s [%s]..." % (item.target, params))
-        pushsafer(m=message, k=appkey, **params)
+        pushsafer(m=item.message, k=pe.private_key, **params)
         srv.logging.debug("Successfully sent pushsafer notification")
     except Exception as e:
-        srv.logging.warn("Error sending pushsafer notification to %s [%s]: %s" % (item.target, params, e))
+        srv.logging.warning("Error sending pushsafer notification to %s [%s]: %s" % (item.target, params, e))
         return False
 
     return True
+
+
+class PushsaferParameterEncoder:
+    """
+    Encode Pushsafer parameters from mqttwarn configuration layout.
+    """
+    def __init__(self, item: ProcessorItem):
+        self.item = item
+        self.private_key: t.Optional[str] = None
+        self.params: t.Dict[str, str] = {}
+
+    def encode(self):
+        addrs = self.item.addrs
+        if isinstance(addrs, t.List):
+            self.encode_v1()
+        elif isinstance(addrs, t.Dict):
+            raise NotImplementedError("Pushsafer configuration layout v2 not implemented yet")
+        else:
+            raise ValueError(f"Unable to decode Pushsafer configuration layout. type={type(addrs)}")
+
+    def encode_v1(self):
+        """
+        Based on the Pushsafer API (https://www.pushsafer.com/en/pushapi).
+        `addrs` is a list with two or three elements.
+
+        0 is the private or alias key
+        1 (if present) is the Pushsafer device or device group id where the message is to be sent
+        2 (if present) is the Pushsafer icon to display in the message
+        3 (if present) is the Pushsafer sound to play for the message
+        4 (if present) is the Pushsafer vibration for the message
+        5 (if present) is the Pushsafer URL or URL Scheme
+        6 (if present) is the Pushsafer Title of URL
+        7 (if present) is the Pushsafer Time in minutes, after which message automatically gets purged
+        8 (if present) is the Pushsafer priority, integer -2, -1, 0, 1, 2
+        9 (if present) is the Pushsafer retry after which time (in seconds 60-10800) a message should resend
+        10 (if present) is the Pushsafer expire after which time (in seconds 60-10800) the retry should stopped
+        11 (if present) is the Pushsafer answer, 1 = Answer, 0 = no possibility to answer
+        """
+
+        addrs = self.item.addrs
+        title = self.item.title
+
+        # Decode Private or Alias Key.
+        try:
+            self.private_key = addrs[0]
+        except IndexError:
+            raise PushsaferConfigurationError(f"Pushsafer private or alias key not configured")
+
+        params = {
+            'expire': 3600,
+        }
+
+        if len(addrs) > 1:
+            params['d'] = addrs[1]
+
+        if len(addrs) > 2:
+            params['i'] = addrs[2]
+
+        if len(addrs) > 3:
+            params['s'] = addrs[3]
+
+        if len(addrs) > 4:
+            params['v'] = addrs[4]
+
+        if len(addrs) > 5:
+            params['u'] = addrs[5]
+
+        if len(addrs) > 6:
+            params['ut'] = addrs[6]
+
+        if len(addrs) > 7:
+            params['l'] = addrs[7]
+
+        if len(addrs) > 8:
+            params['pr'] = addrs[8]
+
+        if len(addrs) > 9:
+            params['re'] = addrs[9]
+
+        if len(addrs) > 10:
+            params['ex'] = addrs[10]
+
+        if len(addrs) > 11:
+            params['a'] = addrs[11]
+
+        if title is not None:
+            params['t'] = title
+
+        self.params = params

--- a/mqttwarn/services/pushsafer.py
+++ b/mqttwarn/services/pushsafer.py
@@ -101,7 +101,7 @@ class PushsaferParameterEncoder:
         elif isinstance(addrs, t.Dict):
             self.encode_v2()
         else:
-            raise ValueError(f"Unable to decode Pushsafer configuration layout. type={type(addrs)}")
+            raise ValueError(f"Pushsafer configuration layout empty or invalid. type={type(addrs).__name__}")
 
     def encode_v1(self):
         """

--- a/mqttwarn/services/pushsafer.py
+++ b/mqttwarn/services/pushsafer.py
@@ -143,12 +143,7 @@ class PushsaferParameterEncoder:
             params['s'] = addrs[3]
 
         if len(addrs) > 4:
-            # Special handling for `vibration`.
-            # With the v1 configuration layout, it should not always trigger a vibration when left empty.
-            # Therefore, a synthetic value `0` can be used to configure "device-default" vibration.
-            value = str(addrs[4])
-            if value != "":
-                params['v'] = value
+            params['v'] = addrs[4]
 
         if len(addrs) > 5:
             params['u'] = addrs[5]

--- a/tests/etc/better-addresses.ini
+++ b/tests/etc/better-addresses.ini
@@ -67,6 +67,33 @@ targets = {
    }
 
 
+[config:pushsafer]
+; https://www.pushsafer.com/en/pushapi
+; https://www.pushsafer.com/en/pushapi_ext
+targets = {
+    'nagios': {
+        'private_key': '3SAz1a2iTYsh19eXIMiO',
+        'device': '52|65|78',
+        'icon': 64,
+        'sound': 2,
+        'vibration': 'blank',  # ?
+        'url': 'http://example.org',
+        'url_title': 'Example Org',
+        'time_to_live': 60,
+        'priority': 2,
+        'retry': 60,
+        'expire': 600,
+        'answer': 1,
+        },
+    'tracking': {
+        'private_key': '3SAz1a2iTYsh19eXIMiO',
+        'device': 'gs23',
+        'icon': 18,
+        },
+    }
+
+
+
 ; -------
 ; Targets
 ; -------

--- a/tests/etc/better-addresses.ini
+++ b/tests/etc/better-addresses.ini
@@ -77,8 +77,7 @@ targets = {
         'device': '52|65|78',
         'icon': 64,
         'sound': 2,
-        # Zero means "vibrate with device-default".
-        'vibration': '0',
+        'vibration': 1,
         'url': 'http://example.org',
         'url_title': 'Example Org',
         'time_to_live': 60,

--- a/tests/etc/better-addresses.ini
+++ b/tests/etc/better-addresses.ini
@@ -71,6 +71,7 @@ targets = {
 ; https://www.pushsafer.com/en/pushapi
 ; https://www.pushsafer.com/en/pushapi_ext
 targets = {
+    'basic': { 'private_key': '3SAz1a2iTYsh19eXIMiO' },
     'nagios': {
         'private_key': '3SAz1a2iTYsh19eXIMiO',
         'device': '52|65|78',
@@ -90,6 +91,7 @@ targets = {
         'device': 'gs23',
         'icon': 18,
         },
+    'bogus': { 'foo': 'bar' },
     }
 
 

--- a/tests/etc/better-addresses.ini
+++ b/tests/etc/better-addresses.ini
@@ -77,7 +77,8 @@ targets = {
         'device': '52|65|78',
         'icon': 64,
         'sound': 2,
-        'vibration': 'blank',  # ?
+        # Zero means "vibrate with device-default".
+        'vibration': '0',
         'url': 'http://example.org',
         'url_title': 'Example Org',
         'time_to_live': 60,

--- a/tests/services/pushsafer/conftest.py
+++ b/tests/services/pushsafer/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+from tests.util import FakeResponse
+
+
+@pytest.fixture
+def mock_urlopen_success(mocker):
+    return mocker.patch("urllib.request.urlopen", return_value=FakeResponse(data=b'{"status": 1}'))
+
+
+@pytest.fixture
+def mock_urlopen_failure(mocker):
+    return mocker.patch("urllib.request.urlopen", return_value=FakeResponse(data=b'{"status": 6}'))

--- a/tests/services/pushsafer/test_pushsafer_common.py
+++ b/tests/services/pushsafer/test_pushsafer_common.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# (c) 2023 The mqttwarn developers
+"""
+This file contains common cases for the Pushsafer plugin, independently
+of the used configuration layout variant (v1 vs. v2) within the `addrs` slot.
+"""
+import pytest
+
+from mqttwarn.model import ProcessorItem as Item
+from mqttwarn.services.pushsafer import PushsaferParameters
+from mqttwarn.util import load_module_from_file
+
+
+def test_pushsafer_configuration_empty_failure(srv, caplog, mock_urlopen_success):
+    """
+    Test Pushsafer service fails when providing an empty `addrs` configuration slot.
+    """
+
+    module = load_module_from_file("mqttwarn/services/pushsafer.py")
+    item = Item(addrs=None, message="⚽ Notification message ⚽")
+    with pytest.raises(ValueError) as ex:
+        module.plugin(srv, item)
+    assert ex.match("Pushsafer configuration layout empty or invalid. type=NoneType")
+
+
+def test_pushsafer_configuration_invalid_failure(srv, caplog, mock_urlopen_success):
+    """
+    Test Pushsafer service fails when providing an invalid `addrs` configuration slot.
+    """
+
+    module = load_module_from_file("mqttwarn/services/pushsafer.py")
+    item = Item(addrs=42, message="⚽ Notification message ⚽")
+    with pytest.raises(ValueError) as ex:
+        module.plugin(srv, item)
+    assert ex.match("Pushsafer configuration layout empty or invalid. type=int")
+
+
+def test_pushsafer_parameters_to_dict():
+    pp = PushsaferParameters(private_key="foo", device="bar")
+    result = pp.to_dict()
+    assert isinstance(result, dict)
+    assert "private_key" in result
+    assert "device" in result

--- a/tests/services/pushsafer/test_pushsafer_v1.py
+++ b/tests/services/pushsafer/test_pushsafer_v1.py
@@ -106,7 +106,8 @@ variants = [
     IoTestItem(id="device-id", in_addrs=[TEST_TOKEN, "52|65|78"], out_data={"d": "52|65|78"}),
     IoTestItem(id="icon", in_addrs=[TEST_TOKEN, "", "test.ico"], out_data={"i": "test.ico"}),
     IoTestItem(id="sound", in_addrs=[TEST_TOKEN, "", "", "test.mp3"], out_data={"s": "test.mp3"}),
-    IoTestItem(id="vibration", in_addrs=[TEST_TOKEN, "", "", "", "1"], out_data={"v": "1"}),
+    IoTestItem(id="vibration-default", in_addrs=[TEST_TOKEN, "", "", "", "0"], out_data={"v": ""}),
+    IoTestItem(id="vibration-two", in_addrs=[TEST_TOKEN, "", "", "", "2"], out_data={"v": "2"}),
     IoTestItem(
         id="url", in_addrs=[TEST_TOKEN, "", "", "", "", "http://example.org"], out_data={"u": "http://example.org"}
     ),

--- a/tests/services/pushsafer/test_pushsafer_v1.py
+++ b/tests/services/pushsafer/test_pushsafer_v1.py
@@ -106,8 +106,7 @@ variants = [
     IoTestItem(id="device-id", in_addrs=[TEST_TOKEN, "52|65|78"], out_data={"d": "52|65|78"}),
     IoTestItem(id="icon", in_addrs=[TEST_TOKEN, "", "test.ico"], out_data={"i": "test.ico"}),
     IoTestItem(id="sound", in_addrs=[TEST_TOKEN, "", "", "test.mp3"], out_data={"s": "test.mp3"}),
-    IoTestItem(id="vibration-default", in_addrs=[TEST_TOKEN, "", "", "", "0"], out_data={"v": ""}),
-    IoTestItem(id="vibration-two", in_addrs=[TEST_TOKEN, "", "", "", "2"], out_data={"v": "2"}),
+    IoTestItem(id="vibration", in_addrs=[TEST_TOKEN, "", "", "", "2"], out_data={"v": "2"}),
     IoTestItem(
         id="url", in_addrs=[TEST_TOKEN, "", "", "", "", "http://example.org"], out_data={"u": "http://example.org"}
     ),

--- a/tests/services/pushsafer/test_pushsafer_v1.py
+++ b/tests/services/pushsafer/test_pushsafer_v1.py
@@ -46,6 +46,20 @@ def test_pushsafer_basic_success(srv, caplog, mock_urlopen_success):
     assert "Successfully sent pushsafer notification" in caplog.text
 
 
+def test_pushsafer_basic_failure(srv, caplog, mock_urlopen_failure):
+    """
+    Test Pushsafer service with a response indicating an error.
+    """
+
+    module = load_module_from_file("mqttwarn/services/pushsafer.py")
+    item = Item(addrs=[TEST_TOKEN], message="⚽ Notification message ⚽")
+    outcome = module.plugin(srv, item)
+
+    assert outcome is False
+    assert "Sending pushsafer notification" in caplog.text
+    assert re.match('.*Error sending pushsafer notification.*{"status": 6}.*', caplog.text, re.DOTALL)
+
+
 def test_pushsafer_title_success(srv, caplog, mock_urlopen_success):
     """
     Test Pushsafer service with title.
@@ -61,20 +75,6 @@ def test_pushsafer_title_success(srv, caplog, mock_urlopen_success):
     assert outcome is True
     assert "Sending pushsafer notification" in caplog.text
     assert "Successfully sent pushsafer notification" in caplog.text
-
-
-def test_pushsafer_basic_failure(srv, caplog, mock_urlopen_failure):
-    """
-    Test Pushsafer service with a response indicating an error.
-    """
-
-    module = load_module_from_file("mqttwarn/services/pushsafer.py")
-    item = Item(addrs=[TEST_TOKEN], message="⚽ Notification message ⚽")
-    outcome = module.plugin(srv, item)
-
-    assert outcome is False
-    assert "Sending pushsafer notification" in caplog.text
-    assert re.match('.*Error sending pushsafer notification.*{"status": 6}.*', caplog.text, re.DOTALL)
 
 
 def test_pushsafer_token_environment_success(srv, caplog, mocker, mock_urlopen_success):
@@ -106,7 +106,7 @@ variants = [
     IoTestItem(id="device-id", in_addrs=[TEST_TOKEN, "52|65|78"], out_data={"d": "52|65|78"}),
     IoTestItem(id="icon", in_addrs=[TEST_TOKEN, "", "test.ico"], out_data={"i": "test.ico"}),
     IoTestItem(id="sound", in_addrs=[TEST_TOKEN, "", "", "test.mp3"], out_data={"s": "test.mp3"}),
-    IoTestItem(id="vibration", in_addrs=[TEST_TOKEN, "", "", "", "true"], out_data={"v": "true"}),
+    IoTestItem(id="vibration", in_addrs=[TEST_TOKEN, "", "", "", "1"], out_data={"v": "1"}),
     IoTestItem(
         id="url", in_addrs=[TEST_TOKEN, "", "", "", "", "http://example.org"], out_data={"u": "http://example.org"}
     ),

--- a/tests/services/pushsafer/test_pushsafer_v1.py
+++ b/tests/services/pushsafer/test_pushsafer_v1.py
@@ -1,44 +1,19 @@
 # -*- coding: utf-8 -*-
 # (c) 2023 The mqttwarn developers
+"""
+This file contains test cases for the v1 configuration layout variant,
+where `addrs` is a list.
+"""
 import dataclasses
 import re
 import typing as t
-import urllib.request
 from operator import attrgetter
-from urllib.parse import parse_qsl
 
 import pytest
 
 from mqttwarn.model import ProcessorItem as Item
 from mqttwarn.util import load_module_from_file
-from tests.util import FakeResponse
-
-TEST_TOKEN = "myToken"
-
-
-def get_reference_data(**more_data):
-    data = {
-        "m": "⚽ Notification message ⚽",
-        "k": "myToken",
-        "expire": "3600",
-    }
-    data.update(more_data)
-    return data
-
-
-def assert_request(request: urllib.request.Request, data: t.Dict[str, str]):
-    assert request.full_url == "https://www.pushsafer.com/api"
-    assert dict(parse_qsl(request.data.decode("utf-8"))) == data
-
-
-@pytest.fixture
-def mock_urlopen_success(mocker):
-    return mocker.patch("urllib.request.urlopen", return_value=FakeResponse(data=b'{"status": 1}'))
-
-
-@pytest.fixture
-def mock_urlopen_failure(mocker):
-    return mocker.patch("urllib.request.urlopen", return_value=FakeResponse(data=b'{"status": 6}'))
+from tests.services.pushsafer.util import TEST_TOKEN, assert_request, get_reference_data
 
 
 def test_pushsafer_parameter_failure(srv, caplog, mock_urlopen_success):

--- a/tests/services/pushsafer/test_pushsafer_v2.py
+++ b/tests/services/pushsafer/test_pushsafer_v2.py
@@ -106,7 +106,8 @@ variants = [
     IoTestItem(id="device-id", in_addrs={"private_key": TEST_TOKEN, "device": "52|65|78"}, out_data={"d": "52|65|78"}),
     IoTestItem(id="icon", in_addrs={"private_key": TEST_TOKEN, "icon": "test.ico"}, out_data={"i": "test.ico"}),
     IoTestItem(id="sound", in_addrs={"private_key": TEST_TOKEN, "sound": "test.mp3"}, out_data={"s": "test.mp3"}),
-    IoTestItem(id="vibration", in_addrs={"private_key": TEST_TOKEN, "vibration": 1}, out_data={"v": "1"}),
+    IoTestItem(id="vibration-default", in_addrs={"private_key": TEST_TOKEN, "vibration": 0}, out_data={"v": ""}),
+    IoTestItem(id="vibration-two", in_addrs={"private_key": TEST_TOKEN, "vibration": 2}, out_data={"v": "2"}),
     IoTestItem(
         id="url",
         in_addrs={"private_key": TEST_TOKEN, "url": "http://example.org"},

--- a/tests/services/pushsafer/test_pushsafer_v2.py
+++ b/tests/services/pushsafer/test_pushsafer_v2.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+# (c) 2023 The mqttwarn developers
+"""
+This file contains test cases for the v2 configuration layout variant,
+where `addrs` is a dictionary.
+"""
+import dataclasses
+import re
+import typing as t
+from operator import attrgetter
+
+import pytest
+
+from mqttwarn.model import ProcessorItem as Item
+from mqttwarn.util import load_module_from_file
+from tests.services.pushsafer.util import TEST_TOKEN, assert_request, get_reference_data
+
+
+def test_pushsafer_parameter_failure(srv, caplog, mock_urlopen_success):
+    """
+    Test Pushsafer service with missing `private_key` parameter. It should fail.
+    """
+
+    module = load_module_from_file("mqttwarn/services/pushsafer.py")
+    item = Item(addrs={}, message="⚽ Notification message ⚽")
+    outcome = module.plugin(srv, item)
+
+    assert outcome is False
+    assert "Pushsafer private or alias key not configured. target=None" in caplog.messages
+
+
+def test_pushsafer_basic_success(srv, caplog, mock_urlopen_success):
+    """
+    Test Pushsafer service with only `private_key` parameter.
+    """
+
+    module = load_module_from_file("mqttwarn/services/pushsafer.py")
+    item = Item(addrs={"private_key": TEST_TOKEN}, message="⚽ Notification message ⚽")
+    outcome = module.plugin(srv, item)
+
+    request = mock_urlopen_success.call_args[0][0]
+    assert_request(request, get_reference_data())
+
+    assert outcome is True
+    assert "Sending pushsafer notification" in caplog.text
+    assert "Successfully sent pushsafer notification" in caplog.text
+
+
+def test_pushsafer_basic_failure(srv, caplog, mock_urlopen_failure):
+    """
+    Test Pushsafer service with a response indicating an error.
+    """
+
+    module = load_module_from_file("mqttwarn/services/pushsafer.py")
+    item = Item(addrs={"private_key": TEST_TOKEN}, message="⚽ Notification message ⚽")
+    outcome = module.plugin(srv, item)
+
+    assert outcome is False
+    assert "Sending pushsafer notification" in caplog.text
+    assert re.match('.*Error sending pushsafer notification.*{"status": 6}.*', caplog.text, re.DOTALL)
+
+
+def test_pushsafer_title_success(srv, caplog, mock_urlopen_success):
+    """
+    Test Pushsafer service with title.
+    """
+
+    module = load_module_from_file("mqttwarn/services/pushsafer.py")
+    item = Item(addrs={"private_key": TEST_TOKEN}, message="⚽ Notification message ⚽", title="⚽ Message title ⚽")
+    outcome = module.plugin(srv, item)
+
+    request = mock_urlopen_success.call_args[0][0]
+    assert_request(request, get_reference_data(t="⚽ Message title ⚽"))
+
+    assert outcome is True
+    assert "Sending pushsafer notification" in caplog.text
+    assert "Successfully sent pushsafer notification" in caplog.text
+
+
+def test_pushsafer_token_environment_success(srv, caplog, mocker, mock_urlopen_success):
+    """
+    Test Pushsafer service with token from `PUSHSAFER_TOKEN` environment variable.
+    """
+    mocker.patch.dict("os.environ", {"PUSHSAFER_TOKEN": TEST_TOKEN})
+
+    module = load_module_from_file("mqttwarn/services/pushsafer.py")
+    item = Item(addrs={"private_key": ""}, message="⚽ Notification message ⚽")
+    outcome = module.plugin(srv, item)
+
+    request = mock_urlopen_success.call_args[0][0]
+    assert_request(request, get_reference_data())
+
+    assert outcome is True
+    assert "Sending pushsafer notification" in caplog.text
+    assert "Successfully sent pushsafer notification" in caplog.text
+
+
+@dataclasses.dataclass
+class IoTestItem:
+    id: str  # noqa: A003
+    in_addrs: t.Dict[str, str]
+    out_data: t.Dict[str, str]
+
+
+variants = [
+    IoTestItem(id="device-id", in_addrs={"private_key": TEST_TOKEN, "device": "52|65|78"}, out_data={"d": "52|65|78"}),
+    IoTestItem(id="icon", in_addrs={"private_key": TEST_TOKEN, "icon": "test.ico"}, out_data={"i": "test.ico"}),
+    IoTestItem(id="sound", in_addrs={"private_key": TEST_TOKEN, "sound": "test.mp3"}, out_data={"s": "test.mp3"}),
+    IoTestItem(id="vibration", in_addrs={"private_key": TEST_TOKEN, "vibration": 1}, out_data={"v": "1"}),
+    IoTestItem(
+        id="url",
+        in_addrs={"private_key": TEST_TOKEN, "url": "http://example.org"},
+        out_data={"u": "http://example.org"},
+    ),
+    IoTestItem(
+        id="url-title", in_addrs={"private_key": TEST_TOKEN, "url_title": "Example Org"}, out_data={"ut": "Example Org"}
+    ),
+    IoTestItem(id="time-to-live", in_addrs={"private_key": TEST_TOKEN, "time_to_live": 60}, out_data={"l": "60"}),
+    IoTestItem(id="priority", in_addrs={"private_key": TEST_TOKEN, "priority": 2}, out_data={"pr": "2"}),
+    IoTestItem(id="retry", in_addrs={"private_key": TEST_TOKEN, "retry": 60}, out_data={"re": "60"}),
+    IoTestItem(id="expire", in_addrs={"private_key": TEST_TOKEN, "expire": 600}, out_data={"ex": "600"}),
+    IoTestItem(id="answer", in_addrs={"private_key": TEST_TOKEN, "answer": 1}, out_data={"a": "1"}),
+]
+
+
+@pytest.mark.parametrize("variant", variants, ids=attrgetter("id"))
+def test_pushsafer_variant(srv, caplog, mock_urlopen_success, variant: IoTestItem):
+    module = load_module_from_file("mqttwarn/services/pushsafer.py")
+    item = Item(addrs=variant.in_addrs, message="⚽ Notification message ⚽")
+    outcome = module.plugin(srv, item)
+
+    request = mock_urlopen_success.call_args[0][0]
+    assert_request(request, get_reference_data(**variant.out_data))
+
+    assert outcome is True
+    assert "Sending pushsafer notification" in caplog.text
+    assert "Successfully sent pushsafer notification" in caplog.text

--- a/tests/services/pushsafer/test_pushsafer_v2.py
+++ b/tests/services/pushsafer/test_pushsafer_v2.py
@@ -106,8 +106,7 @@ variants = [
     IoTestItem(id="device-id", in_addrs={"private_key": TEST_TOKEN, "device": "52|65|78"}, out_data={"d": "52|65|78"}),
     IoTestItem(id="icon", in_addrs={"private_key": TEST_TOKEN, "icon": "test.ico"}, out_data={"i": "test.ico"}),
     IoTestItem(id="sound", in_addrs={"private_key": TEST_TOKEN, "sound": "test.mp3"}, out_data={"s": "test.mp3"}),
-    IoTestItem(id="vibration-default", in_addrs={"private_key": TEST_TOKEN, "vibration": 0}, out_data={"v": ""}),
-    IoTestItem(id="vibration-two", in_addrs={"private_key": TEST_TOKEN, "vibration": 2}, out_data={"v": "2"}),
+    IoTestItem(id="vibration", in_addrs={"private_key": TEST_TOKEN, "vibration": 2}, out_data={"v": "2"}),
     IoTestItem(
         id="url",
         in_addrs={"private_key": TEST_TOKEN, "url": "http://example.org"},

--- a/tests/services/pushsafer/util.py
+++ b/tests/services/pushsafer/util.py
@@ -15,6 +15,8 @@ def get_reference_data(**more_data):
     return data
 
 
-def assert_request(request: urllib.request.Request, data: t.Dict[str, str]):
+def assert_request(request: urllib.request.Request, reference_data: t.Dict[str, str]):
     assert request.full_url == "https://www.pushsafer.com/api"
-    assert dict(parse_qsl(request.data.decode("utf-8"))) == data
+    actual_data = dict(parse_qsl(request.data.decode("utf-8")))
+    msg = f"\nGot:      {actual_data}\nExpected: {reference_data}"
+    assert actual_data == reference_data, msg

--- a/tests/services/pushsafer/util.py
+++ b/tests/services/pushsafer/util.py
@@ -17,6 +17,6 @@ def get_reference_data(**more_data):
 
 def assert_request(request: urllib.request.Request, reference_data: t.Dict[str, str]):
     assert request.full_url == "https://www.pushsafer.com/api"
-    actual_data = dict(parse_qsl(request.data.decode("utf-8")))
+    actual_data = dict(parse_qsl(request.data.decode("utf-8"), keep_blank_values=True))
     msg = f"\nGot:      {actual_data}\nExpected: {reference_data}"
     assert actual_data == reference_data, msg

--- a/tests/services/pushsafer/util.py
+++ b/tests/services/pushsafer/util.py
@@ -9,7 +9,6 @@ def get_reference_data(**more_data):
     data = {
         "m": "⚽ Notification message ⚽",
         "k": "myToken",
-        "expire": "3600",
     }
     data.update(more_data)
     return data

--- a/tests/services/pushsafer/util.py
+++ b/tests/services/pushsafer/util.py
@@ -1,0 +1,20 @@
+import typing as t
+import urllib.request
+from urllib.parse import parse_qsl
+
+TEST_TOKEN = "myToken"
+
+
+def get_reference_data(**more_data):
+    data = {
+        "m": "⚽ Notification message ⚽",
+        "k": "myToken",
+        "expire": "3600",
+    }
+    data.update(more_data)
+    return data
+
+
+def assert_request(request: urllib.request.Request, data: t.Dict[str, str]):
+    assert request.full_url == "https://www.pushsafer.com/api"
+    assert dict(parse_qsl(request.data.decode("utf-8"))) == data

--- a/tests/services/test_pushsafer.py
+++ b/tests/services/test_pushsafer.py
@@ -51,7 +51,7 @@ def test_pushsafer_parameter_failure(srv, caplog, mock_urlopen_success):
     outcome = module.plugin(srv, item)
 
     assert outcome is False
-    assert "No pushsafer private or alias key configured" in caplog.text
+    assert "Pushsafer private or alias key not configured. target=None" in caplog.messages
 
 
 def test_pushsafer_basic_success(srv, caplog, mock_urlopen_success):

--- a/tests/services/test_pushsafer.py
+++ b/tests/services/test_pushsafer.py
@@ -121,31 +121,33 @@ def test_pushsafer_token_environment_success(srv, caplog, mocker, mock_urlopen_s
 
 
 @dataclasses.dataclass
-class TestItem:
+class IoTestItem:
     id: str  # noqa: A003
     in_addrs: t.List[str]
     out_data: t.Dict[str, str]
 
 
 variants = [
-    TestItem(id="device-id", in_addrs=[TEST_TOKEN, "52|65|78"], out_data={"d": "52|65|78"}),
-    TestItem(id="icon", in_addrs=[TEST_TOKEN, "", "test.ico"], out_data={"i": "test.ico"}),
-    TestItem(id="sound", in_addrs=[TEST_TOKEN, "", "", "test.mp3"], out_data={"s": "test.mp3"}),
-    TestItem(id="vibration", in_addrs=[TEST_TOKEN, "", "", "", "true"], out_data={"v": "true"}),
-    TestItem(
+    IoTestItem(id="device-id", in_addrs=[TEST_TOKEN, "52|65|78"], out_data={"d": "52|65|78"}),
+    IoTestItem(id="icon", in_addrs=[TEST_TOKEN, "", "test.ico"], out_data={"i": "test.ico"}),
+    IoTestItem(id="sound", in_addrs=[TEST_TOKEN, "", "", "test.mp3"], out_data={"s": "test.mp3"}),
+    IoTestItem(id="vibration", in_addrs=[TEST_TOKEN, "", "", "", "true"], out_data={"v": "true"}),
+    IoTestItem(
         id="url", in_addrs=[TEST_TOKEN, "", "", "", "", "http://example.org"], out_data={"u": "http://example.org"}
     ),
-    TestItem(id="url-title", in_addrs=[TEST_TOKEN, "", "", "", "", "", "Example Org"], out_data={"ut": "Example Org"}),
-    TestItem(id="time-to-live", in_addrs=[TEST_TOKEN, "", "", "", "", "", "", "60"], out_data={"l": "60"}),
-    TestItem(id="priority", in_addrs=[TEST_TOKEN, "", "", "", "", "", "", "", "2"], out_data={"pr": "2"}),
-    TestItem(id="retry", in_addrs=[TEST_TOKEN, "", "", "", "", "", "", "", "", "60"], out_data={"re": "60"}),
-    TestItem(id="expire", in_addrs=[TEST_TOKEN, "", "", "", "", "", "", "", "", "", "600"], out_data={"ex": "600"}),
-    TestItem(id="answer", in_addrs=[TEST_TOKEN, "", "", "", "", "", "", "", "", "", "", "0"], out_data={"a": "0"}),
+    IoTestItem(
+        id="url-title", in_addrs=[TEST_TOKEN, "", "", "", "", "", "Example Org"], out_data={"ut": "Example Org"}
+    ),
+    IoTestItem(id="time-to-live", in_addrs=[TEST_TOKEN, "", "", "", "", "", "", "60"], out_data={"l": "60"}),
+    IoTestItem(id="priority", in_addrs=[TEST_TOKEN, "", "", "", "", "", "", "", "2"], out_data={"pr": "2"}),
+    IoTestItem(id="retry", in_addrs=[TEST_TOKEN, "", "", "", "", "", "", "", "", "60"], out_data={"re": "60"}),
+    IoTestItem(id="expire", in_addrs=[TEST_TOKEN, "", "", "", "", "", "", "", "", "", "600"], out_data={"ex": "600"}),
+    IoTestItem(id="answer", in_addrs=[TEST_TOKEN, "", "", "", "", "", "", "", "", "", "", "0"], out_data={"a": "0"}),
 ]
 
 
 @pytest.mark.parametrize("variant", variants, ids=attrgetter("id"))
-def test_pushsafer_variant(srv, caplog, mock_urlopen_success, variant: TestItem):
+def test_pushsafer_variant(srv, caplog, mock_urlopen_success, variant: IoTestItem):
     module = load_module_from_file("mqttwarn/services/pushsafer.py")
     item = Item(addrs=variant.in_addrs, message="⚽ Notification message ⚽")
     outcome = module.plugin(srv, item)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -77,6 +77,7 @@ def test_config_better_addresses_pushsafer():
     """
     config = load_configuration(configfile_better_addresses)
     apprise_service_targets = config.getdict("config:pushsafer", "targets")
+    assert apprise_service_targets["basic"]["private_key"] == "3SAz1a2iTYsh19eXIMiO"
     assert apprise_service_targets["nagios"]["private_key"] == "3SAz1a2iTYsh19eXIMiO"
     assert apprise_service_targets["nagios"]["device"] == "52|65|78"
     assert apprise_service_targets["nagios"]["priority"] == 2

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -69,3 +69,15 @@ def test_config_better_addresses_apprise():
     config = load_configuration(configfile_better_addresses)
     apprise_service_targets = config.getdict("config:apprise", "targets")
     assert apprise_service_targets["demo-mailto"][0]["recipients"] == ["foo@example.org", "bar@example.org"]
+
+
+def test_config_better_addresses_pushsafer():
+    """
+    Verify reading configuration files with nested dictionaries.
+    """
+    config = load_configuration(configfile_better_addresses)
+    apprise_service_targets = config.getdict("config:pushsafer", "targets")
+    assert apprise_service_targets["nagios"]["private_key"] == "3SAz1a2iTYsh19eXIMiO"
+    assert apprise_service_targets["nagios"]["device"] == "52|65|78"
+    assert apprise_service_targets["nagios"]["priority"] == 2
+    assert apprise_service_targets["tracking"]["device"] == "gs23"


### PR DESCRIPTION
Hi,

following the rationale provided at GH-628, this would be my proposal to improve the Pushsafer configuration snippet to use named parameters instead of a list, which is confusing, and barely maintainable and extendable.

### Documentation
Visit the rendered version of the reworked [mqttwarn » Pushsafer service](https://github.com/jpmens/mqttwarn/blob/d9c9efb32df75e31dea3c10fd68c6de1122143b0/HANDBOOK.md#pushsafer).

### Configuration snippet
A valid configuration for Pushsafer in the v2 layout would be:
```ini
[config:pushsafer]
; https://www.pushsafer.com/en/pushapi
; https://www.pushsafer.com/en/pushapi_ext
targets = {
    'basic': { 'private_key': '3SAz1a2iTYsh19eXIMiO' },
    'nagios': {
        'private_key': '3SAz1a2iTYsh19eXIMiO',
        'device': '52|65|78',
        'icon': 64,
        'sound': 2,
        'vibration': 1,
        'url': 'http://example.org',
        'url_title': 'Example Org',
        'time_to_live': 60,
        'priority': 2,
        'retry': 60,
        'expire': 600,
        'answer': 1,
        },
    'tracking': {
        'private_key': '3SAz1a2iTYsh19eXIMiO',
        'device': 'gs23',
        'icon': 18,
        },
    'bogus': { 'foo': 'bar' },
    }
```

With kind regards,
Andreas.

/cc @appzer