### PR TITLE
[Pushsafer] Add configuration options "Confirm", "Answer Options", and "Force Answers"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ in progress
 
 - Pushsafer: Fix to prevent submitting empty parameters to upstream API.
 - Pushsafer: Modernize configuration layout for target addresses.
+- Pushsafer: Add parameters for "Confirm", "Answer Options", and "Force Answer".
 
 
 2023-02-13 0.32.0

--- a/mqttwarn/services/pushsafer.py
+++ b/mqttwarn/services/pushsafer.py
@@ -120,6 +120,9 @@ class PushsaferParameterEncoder:
         9 (if present) is the Pushsafer retry after which time (in seconds 60-10800) a message should resend
         10 (if present) is the Pushsafer expire after which time (in seconds 60-10800) the retry should stopped
         11 (if present) is the Pushsafer answer, 1 = Answer, 0 = no possibility to answer
+        12 (if present) is the Pushsafer answer options seperated by a pipe character e.g. yes|no|maybe
+        13 (if present) is the Pushsafer force answer, 1 = yes, 0 = no
+        14 (if present) is the Pushsafer message will be repeated after specified time delay when not confirmed
         """
 
         addrs = self.item.addrs
@@ -165,6 +168,15 @@ class PushsaferParameterEncoder:
 
         if len(addrs) > 11:
             params['a'] = addrs[11]
+
+        if len(addrs) > 12:
+            params['ao'] = addrs[12]
+
+        if len(addrs) > 13:
+            params['af'] = addrs[13]
+
+        if len(addrs) > 14:
+            params['cr'] = addrs[14]
 
         if title is not None:
             params['t'] = title
@@ -217,6 +229,9 @@ class PushsaferParameters:
     retry: t.Optional[int] = None
     expire: t.Optional[int] = None
     answer: t.Optional[int] = None
+    answer_options: t.Optional[str] = None
+    answer_force: t.Optional[int] = None
+    confirm_repeat: t.Optional[int] = None
 
     PARAMETER_MAP = {
         "device": "d",
@@ -230,6 +245,9 @@ class PushsaferParameters:
         "retry": "re",
         "expire": "ex",
         "answer": "a",
+        "answer_options": "ao",
+        "answer_force": "af",
+        "confirm_repeat": "cr",
     }
 
     def to_dict(self) -> t.Dict[str, t.Union[str, int]]:

--- a/tests/services/pushsafer/test_pushsafer_v1.py
+++ b/tests/services/pushsafer/test_pushsafer_v1.py
@@ -118,6 +118,21 @@ variants = [
     IoTestItem(id="retry", in_addrs=[TEST_TOKEN, "", "", "", "", "", "", "", "", "60"], out_data={"re": "60"}),
     IoTestItem(id="expire", in_addrs=[TEST_TOKEN, "", "", "", "", "", "", "", "", "", "600"], out_data={"ex": "600"}),
     IoTestItem(id="answer", in_addrs=[TEST_TOKEN, "", "", "", "", "", "", "", "", "", "", "0"], out_data={"a": "0"}),
+    IoTestItem(
+        id="answer-options",
+        in_addrs=[TEST_TOKEN, "", "", "", "", "", "", "", "", "", "", "1", "yes|no"],
+        out_data={"a": "1", "ao": "yes|no"},
+    ),
+    IoTestItem(
+        id="answer-force",
+        in_addrs=[TEST_TOKEN, "", "", "", "", "", "", "", "", "", "", "1", "", "1"],
+        out_data={"a": "1", "af": "1"},
+    ),
+    IoTestItem(
+        id="confirm-repeat",
+        in_addrs=[TEST_TOKEN, "", "", "", "", "", "", "", "", "", "", "1", "", "", "45"],
+        out_data={"a": "1", "cr": "45"},
+    ),
 ]
 
 

--- a/tests/services/pushsafer/test_pushsafer_v2.py
+++ b/tests/services/pushsafer/test_pushsafer_v2.py
@@ -120,6 +120,21 @@ variants = [
     IoTestItem(id="retry", in_addrs={"private_key": TEST_TOKEN, "retry": 60}, out_data={"re": "60"}),
     IoTestItem(id="expire", in_addrs={"private_key": TEST_TOKEN, "expire": 600}, out_data={"ex": "600"}),
     IoTestItem(id="answer", in_addrs={"private_key": TEST_TOKEN, "answer": 1}, out_data={"a": "1"}),
+    IoTestItem(
+        id="answer-options",
+        in_addrs={"private_key": TEST_TOKEN, "answer": 1, "answer_options": "yes|no"},
+        out_data={"a": "1", "ao": "yes|no"},
+    ),
+    IoTestItem(
+        id="answer-force",
+        in_addrs={"private_key": TEST_TOKEN, "answer": 1, "answer_force": 1},
+        out_data={"a": "1", "af": "1"},
+    ),
+    IoTestItem(
+        id="confirm-repeat",
+        in_addrs={"private_key": TEST_TOKEN, "answer": 1, "confirm_repeat": 45},
+        out_data={"a": "1", "cr": "45"},
+    ),
 ]
 
 


### PR DESCRIPTION
Adding options to use Pushsafer's [_Confirm_](https://www.pushsafer.com/en/pushapi_ext#API-CR), [_Answer Options_](https://www.pushsafer.com/en/pushapi_ext#API-AO), and [_Force Answer_](https://www.pushsafer.com/en/pushapi_ext#API-AF) features. The corresponding parameter names are `cr`, `ao`, and `af`.

@amotl here the new pull request