### PR TITLE
CI: Fix OCI image builds for mqttwarn-full

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,17 +1,15 @@
-# Running mqttwarn with Docker
+# Running mqttwarn with Podman or Docker
 
-If you would rather use `mqttwarn` without installing Python and the
-required libraries, you can run it as a [Docker container](https://www.docker.com/).
-You need to install only the Docker executable.
+If you would rather use `mqttwarn` without installing Python and the required
+libraries, you can run the OCI image on [Podman] or [Docker].
 
-You can run the image as a service, i.e. in the background, or you can 
-run it interactively, perhaps to help diagnose a problem.
+You can run mqttwarn as a service, i.e. in the background, or you can run it
+interactively, perhaps to help diagnose a problem.
 
 Docker images are automatically published to:
 
 - https://github.com/orgs/jpmens/packages/container/package/mqttwarn-standard
 - https://github.com/orgs/jpmens/packages/container/package/mqttwarn-full
-- ~~https://hub.docker.com/r/jpmens/mqttwarn~~ (not automatically updated)
 
 ## Choosing the Docker image
 
@@ -162,17 +160,25 @@ docker run -it --rm --volume=$PWD:/etc/mqttwarn --link=mosquitto $IMAGE
 
 If you are making any changes to the `mqttwarn` application or to the
 `Dockerfile`, you can build a local image from the files on your drive (not
-from the files on Github).
+from the files on GitHub).
 
 Execute the following from the root of the project :
 ```
-docker build -t mqttwarn-local .
+export DOCKER_BUILDKIT=1
+export COMPOSE_DOCKER_CLI_BUILD=1
+export BUILDKIT_PROGRESS=plain
+
+docker build --tag=local/mqttwarn-standard --file=Dockerfile .
+```
+
+```
+docker build --tag=local/mqttwarn-full --file=Dockerfile.full .
 ```
 
 You can then edit any files and rebuild the image as many times as you need. 
 You don't need to commit any changes.
 
-The name `mqttwarn-local` is not meaningful, other than making it obvious when
+The name `local/mqttwarn-standard` is not meaningful, other than making it obvious when
 you run it that you are using your own personal image. You can use any name you
 like, but avoid `mqttwarn` otherwise it's easily confused with the official
 images.
@@ -199,3 +205,7 @@ image including dependencies for all modules, we have you covered. Alongside
 the standard image, there is also `ghcr.io/jpmens/mqttwarn-full:latest`.
 
 The `standard` image weighs in with about 130 MB, the `full` image has 230 MB.
+
+
+[Docker]: https://docker.com/
+[Podman]: https://podman.io/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ FROM python:3.11-slim-bullseye
 
 # Install build prerequisites.
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt --mount=type=cache,id=apt-lib,target=/var/lib/apt \
+RUN \
+    --mount=type=cache,id=apt,sharing=locked,target=/var/cache/apt \
+    --mount=type=cache,id=apt,sharing=locked,target=/var/lib/apt \
     true \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests --yes git build-essential librrd-dev

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -1,17 +1,22 @@
-# Docker build file for mqttwarn.
-# Based on https://github.com/pfichtner/docker-mqttwarn.
+# Docker build file for `mqttwarn-full`.
 #
 # Invoke like:
 #
-#   docker build --tag=mqttwarn-local-full --file=Dockerfile.full .
+#   docker build --tag=local/mqttwarn-full --file=Dockerfile.full .
 #
 FROM python:3.11-slim-bullseye
 
-# Install additional requirements
-RUN apt-get update && apt-get install --yes git
 
-# FIXME: Skip all packages needing compilation
-#RUN apt-get update && apt-get install --yes librrd-dev
+# =====
+# Build
+# =====
+
+# Install build prerequisites.
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt --mount=type=cache,id=apt-lib,target=/var/lib/apt \
+    true \
+    && apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests --yes git build-essential librrd-dev
 
 # Create /etc/mqttwarn
 RUN mkdir -p /etc/mqttwarn
@@ -21,10 +26,23 @@ WORKDIR /etc/mqttwarn
 RUN groupadd -r mqttwarn && useradd -r -g mqttwarn mqttwarn
 RUN chown -R mqttwarn:mqttwarn /etc/mqttwarn
 
-# Install mqttwarn
+# Install package.
 COPY . /src
-RUN pip install versioningit wheel
-RUN pip install /src[all]
+RUN --mount=type=cache,id=pip,target=/root/.cache/pip \
+    true \
+    && pip install --prefer-binary versioningit wheel \
+    && pip install --use-pep517 --prefer-binary '/src[all]'
+
+# Uninstall build prerequisites again.
+RUN apt-get --yes remove --purge git build-essential && apt-get --yes autoremove
+
+# Purge /src and /tmp directories.
+RUN rm -rf /src /tmp/*
+
+
+# =======
+# Runtime
+# =======
 
 # Make process run as "mqttwarn" user
 USER mqttwarn

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -13,7 +13,9 @@ FROM python:3.11-slim-bullseye
 
 # Install build prerequisites.
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt --mount=type=cache,id=apt-lib,target=/var/lib/apt \
+RUN \
+    --mount=type=cache,id=apt,sharing=locked,target=/var/cache/apt \
+    --mount=type=cache,id=apt,sharing=locked,target=/var/lib/apt \
     true \
     && apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests --yes git build-essential librrd-dev


### PR DESCRIPTION
The job to build nightly `mqttwarn-full` OCI images started failing a few days ago. I think it only happens on armv7 [^1]. This patch intends to fix it.

The gist is to install a compiler toolchain, because, apparently, some dependency packages might no longer be available for armv7 as binary wheels. After using it, the compiler will be uninstalled again. Modulo some apparent leftovers of this process, this will increase the image size only from 428MB to 440MB, which is acceptable.

[^1]: https://github.com/jpmens/mqttwarn/actions/runs/4627768341/jobs/8186074275