### PR TITLE
Adjustments to packaging (OCI) and CI configurations

### DIFF
--- a/.github/workflows/release-docker-full.yml
+++ b/.github/workflows/release-docker-full.yml
@@ -65,7 +65,7 @@ jobs:
         name: Cache Docker layers
         uses: actions/cache@v3
         with:
-          path: /tmp/.buildx-cache
+          path: /tmp/.buildx-cache-full
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
@@ -94,11 +94,11 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          cache-from: type=local,src=/tmp/.buildx-cache-full
+          cache-to: type=local,dest=/tmp/.buildx-cache-full-new
 
       -
         name: Move cache
         run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          rm -rf /tmp/.buildx-cache-full
+          mv /tmp/.buildx-cache-full-new /tmp/.buildx-cache-full

--- a/.github/workflows/release-docker-standard.yml
+++ b/.github/workflows/release-docker-standard.yml
@@ -65,7 +65,7 @@ jobs:
         name: Cache Docker layers
         uses: actions/cache@v3
         with:
-          path: /tmp/.buildx-cache
+          path: /tmp/.buildx-cache-standard
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
@@ -94,14 +94,14 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          cache-from: type=local,src=/tmp/.buildx-cache-standard
+          cache-to: type=local,dest=/tmp/.buildx-cache-standard-new
 
       -
         name: Move cache
         run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          rm -rf /tmp/.buildx-cache-standard
+          mv /tmp/.buildx-cache-standard-new /tmp/.buildx-cache-standard
 
       - name: Display git status
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN chown -R mqttwarn:mqttwarn /etc/mqttwarn
 COPY . /src
 RUN --mount=type=cache,id=pip,target=/root/.cache/pip \
     true \
+    && pip install --upgrade pip \
     && pip install --prefer-binary versioningit wheel \
     && pip install --use-pep517 --prefer-binary '/src'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN \
     --mount=type=cache,id=apt,sharing=locked,target=/var/lib/apt \
     true \
     && apt-get update \
-    && apt-get install --no-install-recommends --no-install-suggests --yes git build-essential librrd-dev
+    && apt-get install --no-install-recommends --no-install-suggests --yes git
 
 # Create /etc/mqttwarn
 RUN mkdir -p /etc/mqttwarn

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -18,7 +18,7 @@ RUN \
     --mount=type=cache,id=apt,sharing=locked,target=/var/lib/apt \
     true \
     && apt-get update \
-    && apt-get install --no-install-recommends --no-install-suggests --yes git build-essential librrd-dev
+    && apt-get install --no-install-recommends --no-install-suggests --yes git
 
 # Create /etc/mqttwarn
 RUN mkdir -p /etc/mqttwarn
@@ -36,7 +36,7 @@ RUN --mount=type=cache,id=pip,target=/root/.cache/pip \
     && pip install --use-pep517 --prefer-binary '/src[all]'
 
 # Uninstall build prerequisites again.
-RUN apt-get --yes remove --purge git build-essential && apt-get --yes autoremove
+RUN apt-get --yes remove --purge git && apt-get --yes autoremove
 
 # Purge /src and /tmp directories.
 RUN rm -rf /src /tmp/*

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -32,6 +32,7 @@ RUN chown -R mqttwarn:mqttwarn /etc/mqttwarn
 COPY . /src
 RUN --mount=type=cache,id=pip,target=/root/.cache/pip \
     true \
+    && pip install --upgrade pip \
     && pip install --prefer-binary versioningit wheel \
     && pip install --use-pep517 --prefer-binary '/src[all]'
 

--- a/docs/usage/oci.md
+++ b/docs/usage/oci.md
@@ -205,8 +205,21 @@ If you prefer not to fiddle with those details, but instead want to run a full
 image including dependencies for all modules, we have you covered. Alongside
 the standard image, there is also `ghcr.io/jpmens/mqttwarn-full:latest`.
 
-The `standard` image weighs in with about 130 MB, the `full` image has 230 MB.
+## Image sizes
+
+We determined the **compressed** image sizes using [dockersize]::
+
+    $ dockersize ghcr.io/jpmens/mqttwarn-standard:latest
+    linux/amd64   172.89M
+    linux/arm64   167.12M
+    linux/arm/v7  143.39M
+
+    $ dockersize ghcr.io/jpmens/mqttwarn-full:latest
+    linux/amd64   205.96M
+    linux/arm64   186.81M
+    linux/arm/v7  160.47M
 
 
+[dockersize]: https://gist.github.com/MichaelSimons/fb588539dcefd9b5fdf45ba04c302db6?permalink_comment_id=4243739#gistcomment-4243739
 [Docker]: https://docker.com/
 [Podman]: https://podman.io/

--- a/setup.py
+++ b/setup.py
@@ -135,8 +135,10 @@ for extra, packages in extras.items():
     if machine in ["armv7l", "aarch64"] and extra in ["postgres", "slixmpp", "ssh"]:
         continue
 
-    # FIXME: The `cryptography` package is not available as binary wheel on arm32v7.
-    if machine in ["armv7l"] and extra in ["apprise"]:
+    # FIXME: A few packages are not available as wheels on arm32v7, and take quite an amount
+    #        of time to build, so let's mask them to improve build times significantly.
+    #        Examples: `cryptography`, `aiohttp`, `frozenlist`, `multidict`, `yarl`.
+    if machine in ["armv7l"] and extra in ["apprise", "twilio"]:
         continue
 
     for package in packages:


### PR DESCRIPTION
### About
Build times of OCI image `mqttwarn-full` increased, probably due to some changes in dependencies. Currently, it needs 10 minutes to build images of that variant for `amd64`, `arm64`, and `armv7` platforms.

### Analysis
I think that the `armv7` builds are mostly responsible for the speed bump, because some of them lack armv7 wheel packages on PyPI.

### Improvement
This patch aims to improve OCI image build times. The outcome is promising.

- Release Docker Standard: 3m 3s
- Release Docker Full: 5m 8s

### Details

#### Packaging/OCI
- Skip installing `twilio` on `armv7`, it's too heavy.
- Don't install `build-essential` package until further notice, it is apparently not needed.
- Upgrade `pip` prior to installing other Python packages.
- Add detailed section about image sizes to documentation.

#### CI
- Adjust caching within OCI build configuration, to avoid eventual collisions.
