### PR TITLE
Documentation: Improve README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,8 +19,15 @@
 .. image:: https://pepy.tech/badge/mqttwarn/month
     :target: https://pepy.tech/project/mqttwarn
 
-.. image:: https://cloud.githubusercontent.com/assets/2345521/6320105/4dd7a826-bade-11e4-9a61-72aa163a40a9.png
+`GitHub <https://github.com/jpmens/mqttwarn>`_
+| `PyPI <https://pypi.org/project/mqttwarn/>`_
+| `Documentation <https://mqttwarn.readthedocs.io>`_
+| `Issues <https://github.com/jpmens/mqttwarn/issues>`_
+| `Changelog <https://github.com/jpmens/mqttwarn/blob/main/CHANGES.rst>`_
 
+|
+
+.. image:: https://cloud.githubusercontent.com/assets/2345521/6320105/4dd7a826-bade-11e4-9a61-72aa163a40a9.png
 
 ########
 mqttwarn
@@ -123,8 +130,8 @@ section about the `mqttwarn configuration`_.
 Usage
 *****
 
-Running interactively
-=====================
+Interactive service
+===================
 Just launch ``mqttwarn``::
 
     # Run mqttwarn
@@ -150,13 +157,14 @@ for systemd, traditional init, OpenRC, and Supervisor_ in the ``etc`` directory
 of this repository, for example `supervisor.ini`_ (Supervisor) and
 `mqttwarn.service`_ (systemd).
 
-Running in a development sandbox
-================================
 Standalone
 ==========
 
 In order to directly invoke notification plugins from custom programs, or for
 debugging them, see `Running notification plugins standalone`_.
+
+Development sandbox
+===================
 
 For hacking on mqttwarn, please install it in development mode, using a
 `mqttwarn development sandbox`_ installation.
@@ -180,7 +188,7 @@ Requirements
 You will need at least the following components:
 
 * Python 3.x or PyPy 3.x.
-* An MQTT broker. We recommend `Mosquitto`_.
+* An MQTT broker. We recommend `Eclipse Mosquitto`_.
 * For invoking specific service plugins, additional Python modules may be required.
   See ``setup.py`` file.
 
@@ -231,9 +239,8 @@ way or another. You know who you are.
 
 Legal stuff
 ===========
-"MQTT" is a trademark of the OASIS open standards consortium, which publishes
-the MQTT specifications.
-
+"MQTT" is a trademark of the OASIS open standards consortium, which publishes the
+MQTT specifications. "Eclipse Mosquitto" is a trademark of the Eclipse Foundation.
 
 ----
 
@@ -243,13 +250,13 @@ Have fun!
 .. _Apprise: https://github.com/caronc/apprise
 .. _Apprise notification services: https://github.com/caronc/apprise/wiki#notification-services
 .. _backlog: https://github.com/jpmens/mqttwarn/blob/main/doc/backlog.rst
+.. _Eclipse Mosquitto: https://mosquitto.org
 .. _EPL-2.0: https://www.eclipse.org/legal/epl-2.0/
 .. _hacking: https://github.com/jpmens/mqttwarn/blob/main/doc/hacking.rst
 .. _How do your servers talk to you?: https://jpmens.net/2014/04/03/how-do-your-servers-talk-to-you/
 .. _Installing mqttwarn with pip: https://mqttwarn.readthedocs.io/en/latest/usage/pip.html
 .. _issue: https://github.com/jpmens/mqttwarn/issues/new
 .. _LICENSE: https://github.com/jpmens/mqttwarn/blob/main/LICENSE
-.. _Mosquitto: https://mosquitto.org
 .. _MQTTwarn\: Ein Rundum-Sorglos-Notifier: https://web.archive.org/web/20140611040637/http://jaxenter.de/news/MQTTwarn-Ein-Rundum-Sorglos-Notifier-171312
 .. _mqttwarn configuration: https://mqttwarn.readthedocs.io/en/latest/configure/
 .. _mqttwarn development sandbox: https://mqttwarn.readthedocs.io/en/latest/workbench/sandbox.html

--- a/README.rst
+++ b/README.rst
@@ -142,48 +142,8 @@ To supply a different configuration file or log file, optionally use::
     # Run mqttwarn
     mqttwarn
 
-
-Running notification plugins
-============================
-For debugging, or other purposes, you might want to directly run an individual
-notification plugin without the dispatching and transformation machinery of
-*mqttwarn*.
-
-We have you covered. To launch a plugin standalone, those commands will give
-you an idea how to pass relevant information on the command line using JSON::
-
-    # Launch "log" service plugin
-    mqttwarn --plugin=log --options='{"message": "Hello world", "addrs": ["crit"]}'
-
-    # Launch "file" service plugin
-    mqttwarn --plugin=file --options='{"message": "Hello world\n", "addrs": ["/tmp/mqttwarn.err"]}'
-
-    # Launch "pushover" service plugin
-    mqttwarn --plugin=pushover --options='{"title": "About", "message": "Hello world", "addrs": ["userkey", "token"], "priority": 6}'
-
-    # Launch "ntfy" service plugin
-    mqttwarn --plugin=ntfy --options='{"addrs": {"url": "http://localhost:5555/testdrive"}, "title": "Example notification", "message": "Hello world"}' --data='{"tags": "foo,bar,äöü", "priority": "high"}'
-
-    # Launch "ntfy" service plugin, and add remote attachment
-    mqttwarn --plugin=ntfy --options='{"addrs": {"url": "http://localhost:5555/testdrive"}, "title": "Example notification", "message": "Hello world"}' --data='{"attach": "https://unsplash.com/photos/spdQ1dVuIHw/download?w=320", "filename": "goat.jpg"}'
-
-    # Launch "ntfy" service plugin, and add attachment from local filesystem
-    mqttwarn --plugin=ntfy --options='{"addrs": {"url": "http://localhost:5555/testdrive", "file": "goat.jpg"}, "title": "Example notification", "message": "Hello world"}'
-
-    # Launch "ssh" service plugin
-    mqttwarn --plugin=ssh --config='{"host": "ssh.example.org", "port": 22, "user": "foo", "password": "bar"}' --options='{"addrs": ["command with substitution %s"], "payload": "{\"args\": \"192.168.0.1\"}"}'
-
-    # Launch "cloudflare_zone" service plugin from "mqttwarn-contrib"
-    pip install mqttwarn-contrib
-    mqttwarn --plugin=mqttwarn_contrib.services.cloudflare_zone --config='{"auth-email": "foo", "auth-key": "bar"}' --options='{"addrs": ["0815", "www.example.org", ""], "message": "192.168.0.1"}'
-
-
-Also, the ``--config-file`` parameter can be used to optionally specify the
-path to a configuration file.
-
-
-Running as system daemon
-========================
+System daemon
+=============
 
 There are different ways to run mqttwarn as a system daemon. There are examples
 for systemd, traditional init, OpenRC, and Supervisor_ in the ``etc`` directory
@@ -192,6 +152,11 @@ of this repository, for example `supervisor.ini`_ (Supervisor) and
 
 Running in a development sandbox
 ================================
+Standalone
+==========
+
+In order to directly invoke notification plugins from custom programs, or for
+debugging them, see `Running notification plugins standalone`_.
 
 For hacking on mqttwarn, please install it in development mode, using a
 `mqttwarn development sandbox`_ installation.
@@ -292,6 +257,7 @@ Have fun!
 .. _mqttwarn notifier catalog: https://mqttwarn.readthedocs.io/en/latest/notifier-catalog.html
 .. _mqttwarn.service: https://github.com/jpmens/mqttwarn/blob/main/etc/mqttwarn.service
 .. _opening an issue on GitHub: https://github.com/jpmens/mqttwarn/issues/new
+.. _Running notification plugins standalone: https://mqttwarn.readthedocs.io/en/latest/usage/standalone.html
 .. _Schwarmalarm using mqttwarn: https://hiveeyes.org/docs/system/schwarmalarm-mqttwarn.html
 .. _Supervisor: https://jpmens.net/2014/02/13/in-my-toolbox-supervisord/
 .. _supervisor.ini: https://github.com/jpmens/mqttwarn/blob/main/etc/supervisor.ini

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -64,3 +64,4 @@ or::
    pip
    oci
    freebsd
+   standalone

--- a/docs/usage/standalone.md
+++ b/docs/usage/standalone.md
@@ -1,0 +1,82 @@
+(using-standalone)=
+# Running notification plugins standalone
+
+
+## About
+
+Using the `mqttwarn` command, you can invoke an individual notification plugin
+directly, without the dispatching and transformation machinery, and without
+needing to start it as a service.
+
+This can be used for custom notification programs, and for debugging them,
+without needing to exercise a full end-to-end MQTT publishing workflow.
+
+
+## Details
+
+To launch a plugin standalone, the commands in the next sections will give you an
+idea how to pass relevant information on the command line. Please note that all
+configuration options are obtained as strings in JSON format.
+
+Many plugins will work without a configuration, and only need an `--options`
+parameter. Others will need an additional baseline configuration, obtained per
+`--config` parameter. Alternatively, a path to the configuration file can be
+specified using the `--config-file` parameter.
+
+
+## Synopsis
+
+Launch `log` service plugin with a few target address descriptor options.
+```shell
+mqttwarn --plugin=log --options='{"message": "Hello world", "addrs": ["crit"]}'
+```
+
+:::{tip}
+For producing JSON with command line / script programs, you can use the excellent
+[jo] program, so you will not have to fiddle with curly braces and quotes too much.
+```shell
+mqttwarn --plugin=log --options="$(jo message="Hello world" addrs=$(jo -a crit))"
+```
+:::
+
+
+## Examples
+
+The best way to learn about this feature, is on behalf of a few more example invocations.
+
+Invoke plugins that do not need a configuration, like `log`, `file`, or `pushover`.
+```shell
+# Launch "file" service plugin
+mqttwarn --plugin=file --options='{"message": "Hello world\n", "addrs": ["/tmp/mqttwarn.err"]}'
+
+# Launch "pushover" service plugin
+mqttwarn --plugin=pushover --options='{"title": "About", "message": "Hello world", "addrs": ["userkey", "token"], "priority": 6}'
+```
+
+Invoke plugins that require a configuration, like `ssh`.
+```shell
+# Launch "ssh" service plugin
+mqttwarn --plugin=ssh --config='{"host": "ssh.example.org", "port": 22, "user": "foo", "password": "bar"}' --options='{"addrs": ["command with substitution %s"], "payload": "{\"args\": \"192.168.0.1\"}"}'
+```
+
+Invoke `ntfy` plugin.
+```shell
+# Launch "ntfy" service plugin
+mqttwarn --plugin=ntfy --options='{"addrs": {"url": "http://localhost:5555/testdrive"}, "title": "Example notification", "message": "Hello world"}' --data='{"tags": "foo,bar,äöü", "priority": "high"}'
+
+# Launch "ntfy" service plugin, and add remote attachment
+mqttwarn --plugin=ntfy --options='{"addrs": {"url": "http://localhost:5555/testdrive"}, "title": "Example notification", "message": "Hello world"}' --data='{"attach": "https://unsplash.com/photos/spdQ1dVuIHw/download?w=320", "filename": "goat.jpg"}'
+
+# Launch "ntfy" service plugin, and add attachment from local filesystem
+mqttwarn --plugin=ntfy --options='{"addrs": {"url": "http://localhost:5555/testdrive", "file": "goat.jpg"}, "title": "Example notification", "message": "Hello world"}'
+```
+
+Invoke external plugin.
+```shell
+# Launch "cloudflare_zone" service plugin from "mqttwarn-contrib"
+pip install mqttwarn-contrib
+mqttwarn --plugin=mqttwarn_contrib.services.cloudflare_zone --config='{"auth-email": "foo", "auth-key": "bar"}' --options='{"addrs": ["0815", "www.example.org", ""], "message": "192.168.0.1"}'
+```
+
+
+[jo]: https://github.com/jpmens/jo


### PR DESCRIPTION
- Refactor documentation about "standalone" invocation options to separate section. Within the main README, it was too distracting.
- Improve README layout, header, titles, and crosslinking.
