### PR TITLE
Dependencies: Update `requests-toolbelt` for compatibility w. urllib3 2.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ extras["test"] = [
     "pytest-mqtt<1",
     "tox<4",
     'dataclasses; python_version<"3.7"',
-    "requests-toolbelt>=0.9.1,<1",
+    "requests-toolbelt>=1,<2",
     "responses>=0.13.3,<1",
     "pyfakefs>=4.5,<5",
 ] + extras["all"]


### PR DESCRIPTION
What the title says. I think the update to urllib3 2.x, which has been released just recently, is responsible for this error. It has been revealed at the CI run of GH-649.

```python
/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/_pytest/assertion/rewrite.py:172: in exec_module
    exec(co, module.__dict__)
tests/services/test_pushover.py:8: in <module>
    from requests_toolbelt import MultipartDecoder
/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/requests_toolbelt/__init__.py:12: in <module>
    from .adapters import SSLAdapter, SourceAddressAdapter
/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/requests_toolbelt/adapters/__init__.py:12: in <module>
    from .ssl import SSLAdapter
/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/requests_toolbelt/adapters/ssl.py:16: in <module>
    from .._compat import poolmanager
/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/requests_toolbelt/_compat.py:50: in <module>
    from urllib3.contrib import appengine as gaecontrib
E   ImportError: cannot import name 'appengine' from 'urllib3.contrib' (/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/urllib3/contrib/__init__.py)
```
-- https://github.com/jpmens/mqttwarn/actions/runs/4896318706/jobs/8742985944?pr=649#step:7:60