### PR TITLE
[udf] Unlock Lua for user-defined functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ mqttwarn changelog
 in progress
 ===========
 - [udf] Unlock JavaScript for user-defined functions. Thanks, @extremeheat.
+- [udf] Unlock Lua for user-defined functions. Thanks, @scoder.
 
 - CI: Validated on Python 3.14
 - OCI: Updated to Python 3.14

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN --mount=type=cache,id=pip,target=/root/.cache/pip \
     true \
     && pip install --upgrade pip \
     && pip install --prefer-binary versioningit wheel \
-    && pip install --use-pep517 --prefer-binary '/src[javascript]'
+    && pip install --use-pep517 --prefer-binary '/src[javascript,lua]'
 
 # Uninstall build prerequisites again.
 RUN apt-get --yes remove --purge git && apt-get --yes autoremove

--- a/docs/configure/transformation.md
+++ b/docs/configure/transformation.md
@@ -447,6 +447,19 @@ export its main entry point symbol, configure mqttwarn to use `functions = myclo
 and adjust its settings to use your MQTT broker endpoint at the beginning of the data
 pipeline, invoke mqttwarn, and turn off Kafka. It works!
 
+On the next day, after investigating if you need to migrate any other system components,
+you realize that there is an Nginx instance, which receives a certain share of telemetry
+traffic using HTTP, and processes it using Lua. One quick `mosquitto_pub` later, you are
+sure those telemetry messages are _also_ available on the MQTT bus already. Another set
+of transformation rules written in Lua was quickly identified, and, after applying the
+same procedure of inlining it into a single-file version, and configuring another mqttwarn
+instance with `functions = mycloud.lua`, you are ready to turn off your whole cloud
+infrastructure, and save valuable resources.
+
+After a while, you are able to hire back half of your previous engineering team, and,
+based on the new architecture, you will happily start contributing back to mqttwarn,
+both in terms of maintenance, and by adding new features.
+
 :::{note}
 Rest assured we are overexaggerating a bit, and [Kafka] can only be compared to [MQTT]
 if you are also willing to compare apples with oranges, but you will get the point that
@@ -467,6 +480,15 @@ available [OCI images](#using-oci-image).
 You can find an example implementation for a `filter` function written in JavaScript
 at the [OwnTracks-to-ntfy example tutorial](#owntracks-ntfy-variants-udf).
 
+#### Lua
+
+For running user-defined functions code written in Lua, mqttwarn uses the excellent
+[lupa] package. For adding JavaScript support to mqttwarn, install it using pip like
+`pip install --upgrade 'mqttwarn[lua]'`, or use one of the available
+[OCI images](#using-oci-image).
+
+You can find an example implementation for a `filter` function written in Lua
+at the [OwnTracks-to-ntfy example tutorial](#owntracks-ntfy-variants-udf).
 
 
 ## User-defined function examples
@@ -707,6 +729,7 @@ weather,topic=tasmota/temp/ds/1 temperature=19.7 1517525319000
 [Jinja2 templates]: https://jinja.palletsprojects.com/templates/
 [JSPyBridge]: https://pypi.org/project/javascript/
 [Kafka]: https://en.wikipedia.org/wiki/Apache_Kafka
+[lupa]: https://github.com/scoder/lupa
 [MQTT]: https://en.wikipedia.org/wiki/MQTT
 [Node.js]: https://en.wikipedia.org/wiki/Node.js
 [OwnTracks]: https://owntracks.org

--- a/docs/usage/pip.md
+++ b/docs/usage/pip.md
@@ -11,9 +11,9 @@ that.
 pip install --upgrade mqttwarn
 ```
 
-Add JavaScript support for user-defined functions.
+Add JavaScript and Lua support for user-defined functions.
 ```bash
-pip install --upgrade 'mqttwarn[javascript]'
+pip install --upgrade 'mqttwarn[javascript,lua]'
 ```
 
 You can also add support for a specific service plugin.

--- a/examples/owntracks-ntfy/mqttwarn-owntracks.lua
+++ b/examples/owntracks-ntfy/mqttwarn-owntracks.lua
@@ -1,0 +1,28 @@
+--[[
+Forward OwnTracks low-battery warnings to ntfy.
+https://mqttwarn.readthedocs.io/en/latest/examples/owntracks-battery/readme.html
+--]]
+
+-- mqttwarn filter function, returning true if the message should be ignored.
+-- In this case, ignore all battery level telemetry values above a certain threshold.
+function owntracks_batteryfilter(topic, message)
+    local ignore = true
+
+    -- Decode inbound message.
+    local data = json.decode(message)
+
+    -- Evaluate filtering rule.
+    if data ~= nil and data.batt ~= nil then
+        ignore = tonumber(data.batt) > 20
+    end
+
+    return ignore
+end
+
+-- Status message.
+print("Loaded Lua module.")
+
+-- Export symbols.
+return {
+    owntracks_batteryfilter = owntracks_batteryfilter,
+}

--- a/examples/owntracks-ntfy/readme-variants.md
+++ b/examples/owntracks-ntfy/readme-variants.md
@@ -50,9 +50,9 @@ targets   = {'testdrive': 'http://localhost:5555/testdrive'}
 
 ### JavaScript
 
-In order to try that on the OwnTracks-to-ntfy example, use the alternative
-`mqttwarn-owntracks.js` implementation by adjusting the `functions` setting within the
-`[defaults]` section of your configuration file, and restart mqttwarn.
+In order to explore JavaScript user-defined functions using the OwnTracks-to-ntfy recipe,
+use the alternative `mqttwarn-owntracks.js` implementation by adjusting the `functions`
+setting within the `[defaults]` section of your configuration file, and restart mqttwarn.
 ```ini
 [defaults]
 functions = mqttwarn-owntracks.js
@@ -67,5 +67,27 @@ previous one, which was written in Python.
 
 :::{attention}
 The feature to run JavaScript code is currently considered to be experimental.
+Please use it responsibly.
+:::
+
+### Lua
+
+In order to explore Lua user-defined functions using the OwnTracks-to-ntfy recipe,
+use the alternative `mqttwarn-owntracks.lua` implementation by adjusting the `functions`
+setting within the `[defaults]` section of your configuration file, and restart mqttwarn.
+```ini
+[defaults]
+functions = mqttwarn-owntracks.lua
+```
+
+The Lua function `owntracks_batteryfilter()` implements the same rule as the
+previous ones, which was written in Python and JavaScript.
+
+:::{literalinclude} mqttwarn-owntracks.lua
+:language: lua
+:::
+
+:::{attention}
+The feature to run Lua code is currently considered to be experimental.
 Please use it responsibly.
 :::

--- a/mqttwarn/util.py
+++ b/mqttwarn/util.py
@@ -13,6 +13,7 @@ import logging
 import os
 import re
 import string
+import sys
 import threading
 import types
 import typing as t
@@ -150,6 +151,8 @@ def load_module_from_file(path: t.Union[str, Path]) -> types.ModuleType:
         loader = importlib.machinery.SourcelessFileLoader(fullname=name, path=str(path))
     elif path.suffix in [".js", ".javascript"]:
         return load_source_js(name, str(path))
+    elif path.suffix == ".lua":
+        return load_source_lua(name, str(path))
     else:
         raise ImportError(f"Loading file type failed (only .py, .pyc, .js, .javascript): {path}")
     spec = importlib.util.spec_from_loader(loader.name, loader)
@@ -316,3 +319,41 @@ def load_source_js(mod_name, filepath):
     javascript.eval_js(js_code)
     threading.Event().wait(0.01)
     return module_factory(mod_name, module["exports"])
+
+
+class LuaJsonAdapter:
+    """
+    Support Lua as if it had its `json` module.
+
+    Wasn't able to make Lua's `json` module work, so this provides minimal functionality
+    instead. It will be injected into the Lua context's global `json` symbol.
+    """
+
+    @staticmethod
+    def decode(data):
+        if data is None:
+            return None
+        return json.loads(data)
+
+
+def load_source_lua(mod_name, filepath):
+    """
+    Load a Lua module, and import its exported symbols into a synthetic Python module.
+    """
+    import lupa
+
+    lua = lupa.LuaRuntime(unpack_returned_tuples=True)
+
+    # Lua modules want to be loaded without suffix, but the interpreter would like to know about their path.
+    modfile = Path(filepath).with_suffix("").name
+    modpath = Path(filepath).parent
+    # Yeah, Windows.
+    if sys.platform == "win32":
+        modpath = str(modpath).replace("\\", "\\\\")
+    lua.execute(rf'package.path = package.path .. ";{str(modpath)}/?.lua"')
+
+    logger.info(f"Loading Lua module {modfile} from path {modpath}")
+    module, filepath = lua.require(modfile)
+    # FIXME: Add support for common modules, as long as they are not available natively.
+    lua.globals()["json"] = LuaJsonAdapter
+    return module_factory(mod_name, module)

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,9 @@ extras = {
     "javascript": [
         "javascript==1!1.0.1; python_version>='3.7'",
     ],
+    "lua": [
+        "lupa<3; python_version>='3.8'",
+    ],
     "mysql": [
         "mysql",
     ],
@@ -205,6 +208,9 @@ setup(
         "Operating System :: MacOS",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: JavaScript",
+        "Programming Language :: Lua",
+        "Programming Language :: Other",
+        "Programming Language :: Other Scripting Engines",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -201,37 +201,42 @@ def test_load_functions_javascript_runtime_failure(tmp_path):
     assert ex.match("ReferenceError: bar is not defined")
 
 
-def test_load_function():
->>>>>>> 0fd8700 ([udf] Unlock JavaScript for user-defined functions)
-
-
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="JavaScript support only works on Python >= 3.7")
-def test_load_functions_javascript_compile_failure(tmp_path):
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="Lua support only works on Python >= 3.8")
+def test_load_functions_lua_success(tmp_path):
     """
-    Verify that JavaScript module loading, including symbol exporting and invocation, works well.
+    Verify that Lua module loading, including symbol exporting and invocation, works well.
     """
-    from javascript.errors import JavaScriptError
-
-    jsfile = tmp_path / "test.js"
-    jsfile.write_text("Hotzenplotz")
-    with pytest.raises(JavaScriptError) as ex:
-        load_functions(jsfile)
-    assert ex.match("ReferenceError: Hotzenplotz is not defined")
+    luafile = tmp_path / "test.lua"
+    luafile.write_text("return { forty_two = function() return 42 end }")
+    luamod = load_functions(luafile)
+    assert luamod.forty_two() == 42
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="JavaScript support only works on Python >= 3.7")
-def test_load_functions_javascript_runtime_failure(tmp_path):
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="Lua support only works on Python >= 3.8")
+def test_load_functions_lua_compile_failure(tmp_path):
     """
-    Verify that JavaScript module loading, including symbol exporting and invocation, works well.
+    Verify that Lua module loading, including symbol exporting and invocation, works well.
     """
-    from javascript.errors import JavaScriptError
+    luafile = tmp_path / "test.lua"
+    luafile.write_text("Hotzenplotz")
+    with pytest.raises(Exception) as ex:
+        load_functions(luafile)
+    assert ex.typename == "LuaError"
+    assert ex.match("syntax error near <eof>")
 
-    jsfile = tmp_path / "test.js"
-    jsfile.write_text("module.exports = { foo: function() { bar(); } };")
-    jsmod = load_functions(jsfile)
-    with pytest.raises(JavaScriptError) as ex:
-        jsmod.foo()
-    assert ex.match("ReferenceError: bar is not defined")
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="Lua support only works on Python >= 3.8")
+def test_load_functions_lua_runtime_failure(tmp_path):
+    """
+    Verify that Lua module loading, including symbol exporting and invocation, works well.
+    """
+    luafile = tmp_path / "test.lua"
+    luafile.write_text("return { foo = function() bar() end }")
+    luamod = load_functions(luafile)
+    with pytest.raises(Exception) as ex:
+        luamod.foo()
+    assert ex.typename == "LuaError"
+    assert ex.match(re.escape("attempt to call a nil value (global 'bar')"))
 
 
 def test_load_function():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -202,6 +202,39 @@ def test_load_functions_javascript_runtime_failure(tmp_path):
 
 
 def test_load_function():
+>>>>>>> 0fd8700 ([udf] Unlock JavaScript for user-defined functions)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="JavaScript support only works on Python >= 3.7")
+def test_load_functions_javascript_compile_failure(tmp_path):
+    """
+    Verify that JavaScript module loading, including symbol exporting and invocation, works well.
+    """
+    from javascript.errors import JavaScriptError
+
+    jsfile = tmp_path / "test.js"
+    jsfile.write_text("Hotzenplotz")
+    with pytest.raises(JavaScriptError) as ex:
+        load_functions(jsfile)
+    assert ex.match("ReferenceError: Hotzenplotz is not defined")
+
+
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="JavaScript support only works on Python >= 3.7")
+def test_load_functions_javascript_runtime_failure(tmp_path):
+    """
+    Verify that JavaScript module loading, including symbol exporting and invocation, works well.
+    """
+    from javascript.errors import JavaScriptError
+
+    jsfile = tmp_path / "test.js"
+    jsfile.write_text("module.exports = { foo: function() { bar(); } };")
+    jsmod = load_functions(jsfile)
+    with pytest.raises(JavaScriptError) as ex:
+        jsmod.foo()
+    assert ex.match("ReferenceError: bar is not defined")
+
+
+def test_load_function():
     # Load valid functions file
     py_mod = load_functions(filepath=funcfile_good)
     assert py_mod is not None


### PR DESCRIPTION
Hi again,

similar to what [Webscript](https://webscript.io/) has been doing for HTTP, and @progrium explored on behalf of [Airscript](https://github.com/airscript/airscript-engine) the other day, this patch explores the feasibility of "using Lua for MQTT scripting".

Thanks to the excellent [`lupa`](https://github.com/scoder/lupa) package by @scoder 💯, the patch is ridiculously small again, similar to the other one GH-667, which brings in JavaScript for the same reasons. Both patches are making mqttwarn a host for other languages, effectively bringing together the MQTT protocol, mqttwarn's transformation engine, and now, more languages than just Python, into a small-scale framework it is so much fun to fiddle with.

I think in the current era of [serverless computing] and [FaaS] systems, often operated by large cloud service vendors, it is so important to have open source alternatives around, which, more often than not, can do things more efficiently and conveniently in terms of development efforts, and also don't have several layers of indirection between caller and callee, omitting all the dynamic scaling and throttling aspects usually present in large application container / language host infrastructures, which I found to have a _significant_ cost, both mentally and operationally.

Maybe it works well when it's deployed well, but well, long story short, I prefer [personal computing](https://en.wikipedia.org/wiki/Personal_computing) over needing to wrap my head around how to invoke services/programs/functions on 3rd-party infrastructure, which is mostly not completely transparent, or impossible to run on a personal computer at all.

My motivation is mainly but not exclusively driven by my bad experiences in the past when I have been sucked into analyzing subtle errors on shared cloud infrastructure. It's ridiculous, and I am so happy to have learned how to operate my own machines for hosting and publishing digital goods. Enjoy reading! [^1]

- https://github.com/confluentinc/librdkafka/issues/3109

The documentation of the new feature reflects my experiences, and its preview is available here:

- https://mqttwarn--669.org.readthedocs.build/en/669/configure/transformation.html#using-other-languages
- https://mqttwarn--669.org.readthedocs.build/en/669/examples/owntracks-ntfy/readme-variants.html#lua

With kind regards,
Andreas.

[FaaS]: https://en.wikipedia.org/wiki/Cloud_computing#Serverless_computing_or_Function-as-a-Service_(FaaS)
[serverless computing]: https://en.wikipedia.org/wiki/Serverless_computing

[^1]: And no offense to the Azure and Kafka authors, engineers and users, I know I am comparing apples with oranges here, you are doing an excellent job, and nobody would want to professionally run Kafka on personal computers anyway ;]. It's all just my personal idea of a small-scale FaaS framework with an adapter to a message bus system - here, MQTT.
