### PR TITLE
Introduce a warning timeout for MQTT topics

### DIFF
--- a/mqttwarn/context.py
+++ b/mqttwarn/context.py
@@ -57,6 +57,12 @@ class RuntimeContext:
             timeout = int(self.config.get(section, "timeout"))
         return timeout
 
+    def get_notify_only_on_timeout(self, section: str) -> int:
+        notify_only_on_timeout = False
+        if self.config.has_option(section, "notify_only_on_timeout"):
+            notify_only_on_timeout = bool(self.config.get(section, "notify_only_on_timeout"))
+        return notify_only_on_timeout
+
     def get_config(self, section: str, name: str) -> t.Any:
         value = None
         if self.config.has_option(section, name):

--- a/mqttwarn/context.py
+++ b/mqttwarn/context.py
@@ -51,6 +51,12 @@ class RuntimeContext:
             qos = int(self.config.get(section, "qos"))
         return qos
 
+    def get_timeout(self, section: str) -> int:
+        timeout = -1
+        if self.config.has_option(section, "timeout"):
+            timeout = int(self.config.get(section, "timeout"))
+        return timeout
+
     def get_config(self, section: str, name: str) -> t.Any:
         value = None
         if self.config.has_option(section, name):

--- a/mqttwarn/core.py
+++ b/mqttwarn/core.py
@@ -211,6 +211,7 @@ def on_message_handler(mosq: MqttClient, userdata: t.Dict[str, str], msg: MQTTMe
         if paho.topic_matches_sub(match_topic, topic):
             logger.debug("Message received, restarting timeout on %s" % match_topic)
             topic_timeout_list[match_topic].restart()
+            # Sometimes it is only relevant if a timeout is reached or not
             if topic_timeout_list[match_topic].notify_only_on_timeout:
                 return
 

--- a/mqttwarn/core.py
+++ b/mqttwarn/core.py
@@ -207,11 +207,12 @@ def on_message_handler(mosq: MqttClient, userdata: t.Dict[str, str], msg: MQTTMe
             logger.debug("Skipping retained message on %s" % topic)
             return
 
-    if topic in topic_timeout_list:
-        logger.debug("Message received, restarting timeout on %s" % topic)
-        topic_timeout_list[topic].restart()
-        if topic_timeout_list[topic].notify_only_on_timeout:
-            return
+    for match_topic in topic_timeout_list:
+        if paho.topic_matches_sub(match_topic, topic):
+            logger.debug("Message received, restarting timeout on %s" % match_topic)
+            topic_timeout_list[match_topic].restart()
+            if topic_timeout_list[match_topic].notify_only_on_timeout:
+                return
 
     # Try to find matching settings for this topic
     for section in context.get_sections():

--- a/mqttwarn/topic.py
+++ b/mqttwarn/topic.py
@@ -1,0 +1,58 @@
+# (c) 2014-2023 The mqttwarn developers
+
+import logging
+import threading
+import time
+import typing as t
+
+logger = logging.getLogger(__name__)
+
+
+class TopicTimeout(threading.Thread):
+    """
+    A thread handling timeouts on mqtt topics
+    """
+
+    def __init__(
+        self,
+        topic: t.Optional[str] = None,
+        timeout: t.Optional[int] = 1,
+        on_timeout: t.Optional[t.Callable] = None
+    ):
+        threading.Thread.__init__(self)
+        self.topic = topic
+        self._timeout = timeout
+        self._on_timeout = on_timeout
+        self._restart_event = threading.Event();
+        self._stop_event = threading.Event()
+
+    def run(self):
+        # The outer loop runs until the thread receives a stop signal
+        # See: https://stackoverflow.com/questions/323972/is-there-any-way-to-kill-a-thread
+        # The outer loop is used to reset the timeout after a message was received
+        while not self._stop_event.is_set():
+            timeout = self._timeout
+            # The inner loop runs until a stop signal is received or a message is received
+            # It uses the same logic as the outer loop for the signal handling
+            while True:
+                if self._stop_event.is_set():
+                    break
+                if self._restart_event.is_set():
+                    self._restart_event = threading.Event();
+                    break
+                time.sleep(1)
+                timeout = timeout - 1;
+                logger.debug("%s waiting... %i" % (self.name, timeout))
+                if timeout == 0:
+                    logger.info("%s Timeout!!!" % self.name)
+                    message = "Timeout for topic %s after %i" % (self.topic, self._timeout)
+                    self._on_timeout(self.topic, message.encode('UTF-8'))
+                    break
+
+    def restart(self):
+        logger.debug("Restarting timeout thread for %s (timeout %i)" % (self.topic, self._timeout))
+        self._restart_event.set()
+
+    def stop(self):
+        logger.debug("Stopping timeout thread for %s" % (self.topic))
+        self._stop_event.set()

--- a/mqttwarn/topic.py
+++ b/mqttwarn/topic.py
@@ -17,11 +17,15 @@ class TopicTimeout(threading.Thread):
         self,
         topic: t.Optional[str] = None,
         timeout: t.Optional[int] = 1,
+        section: t.Optional[str] = None,
+        notify_only_on_timeout: t.Optional[bool] = False,
         on_timeout: t.Optional[t.Callable] = None
     ):
         threading.Thread.__init__(self)
         self.topic = topic
         self.timeout = timeout
+        self.section = section
+        self.notify_only_on_timeout = notify_only_on_timeout
         self._on_timeout = on_timeout
         self._restart_event = threading.Event();
         self._stop_event = threading.Event()
@@ -43,11 +47,11 @@ class TopicTimeout(threading.Thread):
                     break
                 logger.debug("%s waiting... %i" % (self.name, timeout))
                 time.sleep(1)
-                timeout = timeout - 1;
+                timeout = timeout - 1
                 if timeout == 0:
                     logger.debug("%s timeout for topic %s" % (self.name, self.topic))
                     message = "Timeout for topic %s after %i" % (self.topic, self.timeout)
-                    self._on_timeout(self.topic, message.encode('UTF-8'))
+                    self._on_timeout(self.section, self.topic, message.encode('UTF-8'))
                     break
 
     def restart(self):

--- a/mqttwarn/topic.py
+++ b/mqttwarn/topic.py
@@ -26,7 +26,7 @@ class TopicTimeout(threading.Thread):
         self.timeout = timeout
         self.section = section
         self.notify_only_on_timeout = notify_only_on_timeout
-        self.last_state_timeout = False
+        self._last_state_timeout = True
         self._on_timeout = on_timeout
         self._restart_event = threading.Event();
         self._stop_event = threading.Event()
@@ -50,10 +50,10 @@ class TopicTimeout(threading.Thread):
                     # If the topic notifies only about timeout / no timeout and the last state was timeout
                     # a notification for the OK state should be published, otherwise just restart the thread
                     # and the received message will be handled by mqttwarn.
-                    if self.last_state_timeout and self.notify_only_on_timeout:
+                    if self.notify_only_on_timeout and self._last_state_timeout:
                         logger.debug("%s received message for topic %s before timeout" % (self.name, self.topic))
                         message = "Message received for topic %s within %i" % (self.topic, self.timeout)
-                        self.last_state_timeout = False
+                        self._last_state_timeout = False
                         self._on_timeout(self.section, self.topic, message.encode('UTF-8'))
                     self._restart_event = threading.Event()
                     break
@@ -63,7 +63,7 @@ class TopicTimeout(threading.Thread):
                 if timeout == 0:
                     logger.debug("%s timeout for topic %s" % (self.name, self.topic))
                     message = "Timeout for topic %s after %i" % (self.topic, self.timeout)
-                    self.last_state_timeout = True
+                    self._last_state_timeout = True
                     self._on_timeout(self.section, self.topic, message.encode('UTF-8'))
                     break
 


### PR DESCRIPTION
The feature allows to define a parameter 'timeout' for each topic. The timeout is specified in seconds.

Instead of notifying targets when a message arrives for a topic, mqttwarn will trigger the targets if no message is received on the topic for the specified period of time.

That's the first version of this feature, so any feedback is welcome.