### PR TITLE
Linter: Migrate from `mypy` to `ty`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,7 +71,7 @@ jobs:
         pip install --editable=.[test,develop]
 
     - name: Check code style
-      if: matrix.python-version != '3.6'
+      if: matrix.python-version != '3.7' && matrix.python-version != '3.8' && matrix.python-version != '3.9'
       run: |
         poe lint
 

--- a/contrib/amqp-puka-get.py
+++ b/contrib/amqp-puka-get.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function
 import sys
-import puka
+import puka  # ty: ignore[unresolved-import, unused-ignore-comment, unused-ignore-comment]
 import json
 
 exchange = 'mqttwarn'

--- a/examples/hiveeyes/hiveeyes.py
+++ b/examples/hiveeyes/hiveeyes.py
@@ -5,10 +5,11 @@ from builtins import object
 from builtins import str
 import re
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from pprint import pformat
 from collections import deque, defaultdict
 
+from mqttwarn.util import load_module_from_file
 
 # ------------------------------------------
 #                  Synopsis
@@ -100,13 +101,15 @@ def hiveeyes_topic_to_topology(topic):
     enriching transformation data inside mqttwarn.
     """
     if type(topic) == str:
+        topology = {}
         try:
             pattern = r"^(?P<realm>.+?)/(?P<network>.+?)/(?P<gateway>.+?)/(?P<node>.+?)/(?P<field>.+?)$"
             p = re.compile(pattern)
             m = p.match(topic)
-            topology = m.groupdict()
+            if m:
+                topology = m.groupdict()
         except:
-            topology = {}
+            pass
         return topology
     return None
 
@@ -199,7 +202,7 @@ def hiveeyes_schwarmalarm_filter(topic, message):
     origin = "{realm}/{network}/{gateway}/{node}".format(**tdata)
 
     # Data-loss bookkeeping
-    hdata.moments[origin] = datetime.utcnow()
+    hdata.moments[origin] = datetime.now(timezone.utc)
 
     # Get most recent measurement from series
     try:
@@ -215,7 +218,7 @@ def hiveeyes_schwarmalarm_filter(topic, message):
 
         # Read current value and appropriate threshold
         current = tdata[field]
-        threshold = monitoring_rules[field]["threshold"]
+        threshold = float(monitoring_rules[field]["threshold"])
 
         # Compare current with former value and set
         # semaphore if delta is greater threshold
@@ -269,7 +272,7 @@ def hiveeyes_dataloss_monitor(srv):
     # Get hold of mqttwarn method to dispatch notification messages on data loss events
     send_to_targets = srv.mwcore["send_to_targets"]
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     # List of all seen data origins (devices).
     # The identifiers are made of essential parts of the MQTT topic.
@@ -309,25 +312,6 @@ def hiveeyes_dataloss_monitor(srv):
     # srv.mqttc.publish('data-loss-topic'.format(**locals()), 'data-loss')
 
 
-# ------------------------------------------
-#                   Setup
-# ------------------------------------------
-# Duplicate of mqttwarn helper method for loading service plugins
-# http://code.davidjanes.com/blog/2008/11/27/how-to-dynamically-load-python-code/
-def load_module(path):
-    import imp
-    import hashlib
-
-    try:
-        fp = open(path, "rb")
-        return imp.load_source(hashlib.md5(path).hexdigest(), path, fp)
-    finally:
-        try:
-            fp.close()
-        except:
-            pass
-
-
 # Mitigate "AttributeError: '_ssl._SSLSocket' object has no attribute 'issuer'"
-service_xmpp = load_module("services/xmpp.py")
+service_xmpp = load_module_from_file("services/xmpp.py")
 service_xmpp.xmpppy_monkeypatch_ssl()

--- a/examples/homie/homie.py
+++ b/examples/homie/homie.py
@@ -23,12 +23,14 @@ def decode_homie_topic(topic):
     enriching transformation data inside mqttwarn.
     """
     if type(topic) == str:
+        topology = {}
         try:
             pattern = r"^(?P<realm>.+?)/(?P<device>.+?)/(?P<node>.+?)/(?P<property>.+?)$"
             p = re.compile(pattern)
             m = p.match(topic)
-            topology = m.groupdict()
+            if m:
+                topology = m.groupdict()
         except:
-            topology = {}
+            pass
         return topology
     return None

--- a/mqttwarn/__init__.py
+++ b/mqttwarn/__init__.py
@@ -8,6 +8,6 @@ __license__ = "Eclipse Public License - v 2.0 (http://www.eclipse.org/legal/epl-
 try:
     from importlib.metadata import version
 except ImportError:  # pragma: nocover
-    from importlib_metadata import version  # type: ignore[no-redef]
+    from importlib_metadata import version  # ty: ignore[unresolved-import]
 
 __version__ = version("mqttwarn")

--- a/mqttwarn/commands.py
+++ b/mqttwarn/commands.py
@@ -56,7 +56,7 @@ def run():
     """
 
     # Use generic commandline options schema and amend with current program name
-    commandline_schema = run.__doc__.format(program=APP_NAME)
+    commandline_schema = t.cast(str, run.__doc__).format(program=APP_NAME)
 
     # Read commandline options
     options = docopt(commandline_schema, version=APP_NAME + " " + __version__)

--- a/mqttwarn/configuration.py
+++ b/mqttwarn/configuration.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 # (c) 2014-2023 The mqttwarn developers
 import ast
-import codecs
 import logging
 import os
 import re
 import sys
 import typing as t
 from configparser import Interpolation, NoOptionError, NoSectionError, RawConfigParser
+from pathlib import Path
 
 from mqttwarn.util import load_functions
 
@@ -62,7 +62,7 @@ def expand_vars(input: str, sources: t.Dict[str, t.Callable[[str], str]]) -> str
 class VariableInterpolation(Interpolation):
     def __init__(self, configuration_path):
         self.configuration_path = configuration_path
-        self.sources = {
+        self.sources: t.Dict[str, t.Callable[[str], str]] = {
             "ENV": self.get_env_variable,
             "FILE": self.get_file_contents,
         }
@@ -94,7 +94,7 @@ class Config(RawConfigParser):
         "NONE": None,
     }
 
-    def __init__(self, configuration_file: t.Optional[str] = None, defaults: t.Optional[t.Dict] = None):
+    def __init__(self, configuration_file: t.Optional[t.Union[str, Path]] = None, defaults: t.Optional[t.Dict] = None):
         defaults = defaults or {}
 
         self.configuration_path = None
@@ -102,7 +102,7 @@ class Config(RawConfigParser):
         configuration_path = os.path.dirname(configuration_file) if configuration_file else None
         RawConfigParser.__init__(self, interpolation=VariableInterpolation(configuration_path))
         if configuration_file is not None:
-            f = codecs.open(configuration_file, "r", encoding="utf-8")
+            f = open(configuration_file, "r", encoding="utf-8")
             self.read_file(f)
             f.close()
 
@@ -116,6 +116,7 @@ class Config(RawConfigParser):
         self.clientid = None
         self.lwt = None
         self.lwt_alive = None
+        self.lwt_dead = None
         self.skipretained = False
         self.cleansession = False
         self.protocol = 3
@@ -249,11 +250,12 @@ class Config(RawConfigParser):
                 raise KeyError(f"Configuration section does not exist: {section}")
 
 
-def load_configuration(configfile: t.Optional[str] = None, name: str = "mqttwarn") -> Config:
+def load_configuration(configfile: t.Optional[t.Union[str, Path]] = None, name: str = "mqttwarn") -> Config:
     if configfile is None:
         configfile = str(os.getenv(name.upper() + "INI", name + ".ini"))
 
-    if not os.path.exists(configfile):
+    configfile = Path(configfile)
+    if not configfile.exists():
         raise FileNotFoundError('Configuration file "{}" does not exist'.format(configfile))
 
     # TODO: There should be a factory method which creates a `Config` instance,

--- a/mqttwarn/context.py
+++ b/mqttwarn/context.py
@@ -21,7 +21,7 @@ class RuntimeContext:
     """
 
     config: Config = attr.ib()
-    invoker: "FunctionInvoker" = attr.ib()
+    invoker: t.Optional["FunctionInvoker"] = attr.ib()
 
     def get_sections(self) -> t.List[str]:
         sections = []
@@ -72,6 +72,7 @@ class RuntimeContext:
     def is_filtered(self, section: str, topic: str, payload: t.AnyStr) -> bool:
         if self.config.has_option(section, "filter"):
             try:
+                assert self.invoker
                 name = sanitize_function_name(self.config.get(section, "filter"))
                 return self.invoker.filter(name, topic, payload, section)
             except Exception as e:
@@ -81,6 +82,7 @@ class RuntimeContext:
     def get_topic_data(self, section: str, data: TdataType) -> t.Optional[TdataType]:
         if self.config.has_option(section, "datamap"):
             try:
+                assert self.invoker
                 name = sanitize_function_name(self.config.get(section, "datamap"))
                 return self.invoker.datamap(name, data)
             except Exception as e:
@@ -90,6 +92,7 @@ class RuntimeContext:
     def get_all_data(self, section: str, topic: str, data: TdataType) -> t.Optional[TdataType]:
         if self.config.has_option(section, "alldata"):
             try:
+                assert self.invoker
                 name = sanitize_function_name(self.config.get(section, "alldata"))
                 return self.invoker.alldata(name, topic, data)
             except Exception as e:
@@ -102,6 +105,7 @@ class RuntimeContext:
         """
         if self.config.has_option(section, "targets"):
             try:
+                assert self.invoker
                 name = sanitize_function_name(self.config.get(section, "targets"))
                 return self.invoker.topic_target_list(name, topic, data)
             except Exception as ex:
@@ -142,7 +146,7 @@ class FunctionInvoker:
     """
 
     config: Config = attr.ib()
-    srv: Service = attr.ib()
+    srv: t.Optional[Service] = attr.ib()
 
     def datamap(self, name: str, data: TdataType) -> TdataType:
         """
@@ -152,8 +156,6 @@ class FunctionInvoker:
         :param data:    Data to pass to the invoked function
         :return:        Return value of function invocation
         """
-
-        val = None
 
         try:
             func = load_function(name=name, py_mod=self.config.functions)

--- a/mqttwarn/core.py
+++ b/mqttwarn/core.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 # (c) 2014-2023 The mqttwarn developers
+from pathlib import Path
+
 try:
-    from importlib.resources import files as resource_files  # type: ignore[attr-defined]
+    from importlib.resources import files as resource_files
 except ImportError:
-    from importlib_resources import files as resource_files  # type: ignore[no-redef]
+    from importlib_resources import files as resource_files  # ty: ignore[unresolved-import]
 
 import logging
 import os
@@ -13,7 +15,7 @@ import threading
 import time
 import typing as t
 from builtins import chr, str
-from datetime import datetime
+from datetime import datetime, timezone
 from queue import Queue
 
 import paho.mqtt.client as paho
@@ -40,7 +42,7 @@ from mqttwarn.topic import TopicTimeout
 try:
     import json
 except ImportError:  # pragma: nocover
-    import simplejson as json  # type: ignore
+    import simplejson as json
 
 
 HAVE_JINJA = True
@@ -60,15 +62,15 @@ SCRIPTNAME = "mqttwarn"
 
 # Global runtime context object
 context: RuntimeContext
-context = None  # type: ignore[assignment]
+context = None  # ty: ignore[invalid-assignment]
 
 # Global configuration object
 cf: mqttwarn.configuration.Config
-cf = None  # type: ignore[assignment]
+cf = None  # ty: ignore[invalid-assignment]
 
 # Global handle to MQTT client
 mqttc: paho.Client
-mqttc = None  # type: ignore[assignment]
+mqttc = None  # ty: ignore[invalid-assignment]
 
 # Initialize processor queue
 q_in: Queue = Queue(maxsize=0)
@@ -84,7 +86,7 @@ topic_timeout_list: t.Dict[str, TopicTimeout] = {}
 service_plugins: t.Dict[str, t.Dict[str, t.Any]] = dict()
 
 
-def make_service(mqttc: paho.Client = None, name: t.Optional[str] = None) -> Service:
+def make_service(name: str, mqttc: t.Optional[paho.Client] = None) -> Service:
     """
     Service object factory.
     Prepare service object for plugin.
@@ -147,8 +149,8 @@ def on_connect(mosq: MqttClient, userdata: t.Dict[str, str], flags: t.Dict[str, 
             if topic_timeout > 0:
                 logger.debug("Setting up timeout thread for %s (timeout=%d)" % (topic, topic_timeout))
                 topic_timeout_list[topic] = TopicTimeout(
-                    timeout=topic_timeout,
                     topic=topic,
+                    timeout=topic_timeout,
                     section=section,
                     notify_only_on_timeout=notify_only_on_timeout,
                     on_timeout=send_to_targets,
@@ -187,10 +189,11 @@ def on_disconnect(mosq: MqttClient, userdata: t.Dict[str, str], result_code: int
         time.sleep(5)
 
 
-def on_message(mosq: MqttClient, userdata: t.Dict[str, str], msg: MQTTMessage):
+def on_message(mosq: MqttClient, userdata: t.Optional[t.Dict[str, str]], msg: MQTTMessage):
     """
     Dispatch message received from the MQTT broker to mqttwarn's handler machinery.
     """
+    userdata = userdata or {}
     try:
         return on_message_handler(mosq, userdata, msg)
     except:
@@ -264,9 +267,11 @@ def send_to_targets(section: str, topic: str, payload: t.AnyStr):
         pass
     dispatcher_dict = cf.getdict(section, "targets")
 
+    targetlist: t.List[str]
+
     # `targets` is a function symbol.
     if function_name is not None:
-        targetlist = context.get_topic_targets(section, topic, data)
+        targetlist = t.cast(t.List[str], context.get_topic_targets(section, topic, data))
 
         # Make sure the function returned a target _list_ of elements.
         if not isinstance(targetlist, list):
@@ -299,7 +304,7 @@ def send_to_targets(section: str, topic: str, payload: t.AnyStr):
         for match_topic, targets in sorted_dispatcher:
             if paho.topic_matches_sub(match_topic, topic):
                 # hocus pocus, let targets become a list
-                targetlist = targets if isinstance(targets, list) else [targets]
+                targetlist = t.cast(t.List[str], targets if isinstance(targets, list) else [targets])
                 logger.debug("Most specific match %s dispatched to %s" % (match_topic, targets))
                 # first most specific topic matches then stops processing
                 break
@@ -309,7 +314,7 @@ def send_to_targets(section: str, topic: str, payload: t.AnyStr):
             return
 
     else:
-        targetlist = cf.getlist(section, "targets")
+        targetlist = t.cast(t.List[str], cf.getlist(section, "targets"))
 
         # Make sure targets are actually a _list_ of elements.
         # TODO: Not tested yet. How can this code be reached?
@@ -385,7 +390,7 @@ def builtin_transform_data(topic: str, payload: t.Union[str, bytes]) -> TdataTyp
     tdata["topic"] = topic
     tdata["payload"] = payload
     tdata["_dtepoch"] = int(time.time())  # 1392628581
-    tdata["_dtiso"] = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")  # 2014-02-17T10:38:43.910691Z
+    tdata["_dtiso"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")  # 2014-02-17T10:38:43.910691Z
     tdata["_ltiso"] = datetime.now().isoformat()  # local time in iso format
     tdata["_dthhmm"] = dt.strftime("%H:%M")  # 10:16
     tdata["_dthhmmss"] = dt.strftime("%H:%M:%S")  # hhmmss=10:16:21
@@ -410,6 +415,7 @@ def xform(function: str, orig_value: t.Any, transform_data: TdataType) -> t.Unio
         try:
             function_name = sanitize_function_name(function)
             try:
+                assert context.invoker
                 res = context.invoker.datamap(function_name, transform_data)
                 return res
             except:
@@ -544,7 +550,9 @@ def process_job(job, worker_id=None):
         item["message"] = xform(context.get_config(section, "format"), job.payload, transform_data)
 
         try:
-            item["priority"] = int(xform(context.get_config(section, "priority"), 0, transform_data))
+            item["priority"] = int(
+                xform(context.get_config(section, "priority"), 0, transform_data)  # ty: ignore[invalid-argument-type]
+            )
         except:
             item["priority"] = 0
             logger.exception("Failed to determine the priority, defaulting to zero")
@@ -562,7 +570,8 @@ def process_job(job, worker_id=None):
                 except:
                     logger.exception(f"Rendering template failed: {template}")
 
-        if item.get("message") is not None and len(item.get("message")) > 0:
+        msg = item.get("message")
+        if msg is not None and len(t.cast(str, msg)) > 0:
             st = Struct(**item)
             notified = False
             logger.info("Invoking service plugin for `%s'" % service)
@@ -600,12 +609,14 @@ def load_services(services):
         module = cf.g("config:" + service, "module", service)
 
         # Load external service from file.
-        modulefile_candidates = []
+        modulefile_candidates: t.List[Path] = []
         if module.endswith(".py"):
+            if cf.configuration_path is None:
+                raise RuntimeError("cf.configuration_path is not defined")
             # Add two candidates: a) Use the file as given and b) treat the file as relative to
             # the directory of the configuration file. That retains backward compatibility.
             modulefile_candidates.append(module)
-            modulefile_candidates.append(os.path.join(cf.configuration_path, module))
+            modulefile_candidates.append(Path(cf.configuration_path) / module)
 
         # Load external service with module specification.
         elif "." in module:
@@ -624,7 +635,7 @@ def load_services(services):
                 module = "http_urllib"
             logger.debug('Trying to load built-in service "{}" from "{}"'.format(service, module))
             service_filename = module + ".py"
-            service_filepath = resource_files("mqttwarn.services") / service_filename
+            service_filepath = t.cast(Path, resource_files("mqttwarn.services") / service_filename)
             modulefile_candidates = [service_filepath]
 
         success = False
@@ -698,6 +709,8 @@ def connect():
         sys.exit(2)
 
     # Update our runtime context (used by functions etc) now we have a connected MQTT client
+    if not context.invoker or not context.invoker.srv:
+        raise RuntimeError("Cannot connect to MQTT broker")
     context.invoker.srv.mqttc = mqttc
 
     # Publish status information to `mqttwarn/$SYS` topic.
@@ -747,7 +760,7 @@ def publish_status_information():
       mqttwarn/$SYS/python/version 3.9.7
 
     """
-    if cf.has_option("defaults", "status_publish") and cf.status_publish:
+    if cf.has_option("defaults", "status_publish") and cf.status_publish:  # ty: ignore[unresolved-attribute]
         status_topic = cf.g("defaults", "status_topic", "mqttwarn/$SYS")
         logger.info(f"Publishing status information to {status_topic}")
 
@@ -788,7 +801,7 @@ def start_workers():
                 continue
 
             cron_options = parse_cron_options(val)
-            interval = cron_options["interval"]
+            interval = float(cron_options["interval"])
             logger.info(
                 "Scheduling periodic task '{name}' to run each "
                 "{interval} seconds via [cron] section".format(name=name, interval=interval)
@@ -829,18 +842,18 @@ def cleanup(signum=None, frame=None):
     sys.exit(signum)
 
 
-def bootstrap(config=None, scriptname=None):
+def bootstrap(config, scriptname=None):
     # FIXME: Remove global variables
     global context, cf, SCRIPTNAME
     # NOTE: this is called before we connect to the MQTT broker, so mqttc is not initialised yet
-    invoker = FunctionInvoker(config=config, srv=make_service(mqttc=None, name="mqttwarn.context"))
+    invoker = FunctionInvoker(config=config, srv=make_service(name="mqttwarn.context"))
     context = RuntimeContext(config=config, invoker=invoker)
     cf = config
     if scriptname is not None:
         SCRIPTNAME = scriptname
 
 
-def run_plugin(config=None, name=None, options=None, data=None, message=None):
+def run_plugin(config, name: str, options=None, data=None, message=None):
     """
     Run service plugins directly without the
     dispatching and transformation machinery.
@@ -865,17 +878,17 @@ def run_plugin(config=None, name=None, options=None, data=None, message=None):
         service_logger_name = name
     else:
         service_logger_name = "mqttwarn.services.{}".format(name)
-    srv = make_service(mqttc=None, name=service_logger_name)
+    srv = make_service(name=service_logger_name)
 
     # Build a mimikry item instance for feeding to the service plugin
     item = Struct(**options or {})
     # TODO: Read configuration optionally from data.
-    item.config = config.config("config:" + name)
-    item.service = srv
-    item.target = "mqttwarn"
-    item.data = data or {}
+    item.config = config.config("config:" + name)  # ty: ignore[unresolved-attribute]
+    item.service = srv  # ty: ignore[unresolved-attribute]
+    item.target = "mqttwarn"  # ty: ignore[unresolved-attribute]
+    item.data = data or {}  # ty: ignore[unresolved-attribute]
     if not hasattr(item, "message"):
-        item.message = message
+        item.message = message  # ty: ignore[invalid-assignment]
 
     # Launch plugin
     module = service_plugins[name]["module"]

--- a/mqttwarn/cron.py
+++ b/mqttwarn/cron.py
@@ -19,7 +19,7 @@ class PeriodicThread:
     def __init__(
         self,
         callback: t.Optional[t.Callable] = None,
-        period: t.Optional[int] = 1,
+        period: float = 1.0,
         name: t.Optional[str] = None,
         srv: t.Optional[Service] = None,
         now: t.Optional[bool] = False,
@@ -92,4 +92,5 @@ class PeriodicThread:
         """
         Mimics Thread standard join method
         """
-        self.current_timer.join()
+        if self.current_timer is not None:
+            self.current_timer.join()

--- a/mqttwarn/services/apprise_multi.py
+++ b/mqttwarn/services/apprise_multi.py
@@ -28,8 +28,8 @@ def plugin(srv, item):
 
         # Disable the Apprise rate limiting subsystem.
         try:
-            from apprise.plugins.NotifyBase import NotifyBase
-            NotifyBase.request_rate_per_sec = 0
+            from apprise import NotifyBase
+            setattr(NotifyBase, "request_rate_per_sec", 0)
         except ImportError:
             pass
 

--- a/mqttwarn/services/apprise_single.py
+++ b/mqttwarn/services/apprise_single.py
@@ -32,8 +32,8 @@ def plugin(srv, item):
 
         # Disable the Apprise rate limiting subsystem.
         try:
-            from apprise.plugins.NotifyBase import NotifyBase
-            NotifyBase.request_rate_per_sec = 0
+            from apprise import NotifyBase
+            setattr(NotifyBase, "request_rate_per_sec", 0)
         except ImportError:
             pass
 

--- a/mqttwarn/services/carbon.py
+++ b/mqttwarn/services/carbon.py
@@ -60,7 +60,7 @@ def plugin(srv, item):
     try:
         sock = socket.socket()
         sock.connect((carbon_host, carbon_port))
-        sock.sendall(carbon_msg)
+        sock.sendall(carbon_msg.encode("utf-8"))
         sock.close()
     except Exception as e:
         srv.logging.warning("Cannot send to carbon service %s:%d: %s" % (carbon_host, carbon_port, e))

--- a/mqttwarn/services/dbus.py
+++ b/mqttwarn/services/dbus.py
@@ -5,7 +5,7 @@ __author__    = 'Fabian Affolter <fabian()affolter-engineering.ch>'
 __copyright__ = 'Copyright 2014 Fabian Affolter'
 __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
-import dbus
+import dbus  # ty: ignore[unresolved-import]
 
 
 def plugin(srv, item):

--- a/mqttwarn/services/desktopnotify.py
+++ b/mqttwarn/services/desktopnotify.py
@@ -45,10 +45,12 @@ def plugin(srv: Service, item: ProcessorItem):
        }
 
     srv.logging.debug("Sending desktop notification")
+    message = str(data.get('message', ''))
+    title = str(data.get('title', ''))
     try:
         # Synchronous Notification (allows no callbacks in OSX)
         # Asynchronous would require asyncio and require some changes to the plugin handler
-        notify.send_sync(message=data['message'], title=data['title'],sound=playSound)
+        notify.send_sync(message=message, title=title, sound=playSound)
 
     except Exception as e:
         srv.logging.warning("Invoking desktop notifier failed: %s" % e)

--- a/mqttwarn/services/dnsupdate.py
+++ b/mqttwarn/services/dnsupdate.py
@@ -9,6 +9,7 @@ __license__ = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-
 
 import dns.update
 import dns.query
+import dns.rcode
 import dns.tsigkeyring
 
 

--- a/mqttwarn/services/gss2.py
+++ b/mqttwarn/services/gss2.py
@@ -68,7 +68,7 @@ def plugin(srv, item):
                     (client_secrets_filename, oauth2_code, e))
                 return False
             except oauth2client.client.FlowExchangeError as e:
-                if 'invalid_grantCode' in e.message:
+                if 'invalid_grantCode' in str(e):
                     srv.logging.error("It seems you need to start over: Clear the "
                         "'oauth2_code'-field and restart mqttwarn.")
                     return False

--- a/mqttwarn/services/http_urllib.py
+++ b/mqttwarn/services/http_urllib.py
@@ -10,9 +10,9 @@ try:
     from urllib.request import urlopen, Request
     from urllib.error import HTTPError
 except ImportError:
-    from urlparse import urlparse  # type: ignore[no-redef]
-    from urllib import urlencode, urljoin  # type: ignore[no-redef,attr-defined]
-    from urllib2 import urlopen, Request, HTTPError  # type: ignore[no-redef]
+    from urlparse import urlparse  # ty: ignore[unresolved-import]
+    from urllib import urlencode, urljoin  # ty: ignore[unresolved-import]
+    from urllib2 import urlopen, Request, HTTPError  # ty: ignore[unresolved-import]
 
 import base64
 

--- a/mqttwarn/services/icinga2.py
+++ b/mqttwarn/services/icinga2.py
@@ -5,6 +5,8 @@ __author__ = 'Ben Jones <ben.jones12()gmail.com>'
 __copyright__ = 'Copyright 2016 Ben Jones'
 __license__ = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
+from typing import Dict, Any
+
 import requests
 from requests.auth import HTTPBasicAuth
 
@@ -61,7 +63,7 @@ def plugin(srv, item):
         "Accept": "application/json"
     }
 
-    kwargs = {
+    kwargs: Dict[str, Any] = {
         "headers": headers,
         "auth": HTTPBasicAuth(username, password),
         "json": payload

--- a/mqttwarn/services/linuxnotify.py
+++ b/mqttwarn/services/linuxnotify.py
@@ -5,7 +5,7 @@ __author__    = 'Fabian Affolter <fabian()affolter-engineering.ch>'
 __copyright__ = 'Copyright 2014 Fabian Affolter'
 __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
-from gi.repository import Notify
+from gi.repository import Notify  # ty: ignore[unresolved-import]
 
 
 def plugin(srv, item):

--- a/mqttwarn/services/mqtt.py
+++ b/mqttwarn/services/mqtt.py
@@ -17,7 +17,7 @@ def conf(ini_file, params):
     try:
         c = configparser.ConfigParser()
         f = open(ini_file, 'r')
-        c.readfp(f)
+        c.read_file(f)
         f.close()
     except Exception as e:
         raise

--- a/mqttwarn/services/mqtt_filter.py
+++ b/mqttwarn/services/mqtt_filter.py
@@ -7,7 +7,7 @@ __license__   = """Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/
 
 import subprocess
 import json
-from pipes import quote
+from shlex import quote
 from six import string_types
 
 def plugin(srv, item):
@@ -26,7 +26,7 @@ def plugin(srv, item):
 
         if type(args) is list:
             args=tuple([ quote(v) for v  in args ]) #escape the shell args
-        elif type(args) is str or type(args) is unicode:
+        elif type(args) is str or isinstance(args, bytes):
             args=(quote(args),)
 
     # parse topic
@@ -40,7 +40,7 @@ def plugin(srv, item):
     retain         = item.addrs[2]
     addrs          = item.addrs[3:]
 
-    cmd = None
+    cmd = []
     if addrs is not None:
         cmd = [i.format(args=args, full_topic=quote(item.topic),topic=topic) for i in addrs]
 

--- a/mqttwarn/services/mysql.py
+++ b/mqttwarn/services/mysql.py
@@ -5,7 +5,7 @@ __author__ = 'Jan-Piet Mens <jpmens()gmail.com>'
 __copyright__ = 'Copyright 2014 Jan-Piet Mens'
 __license__ = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
-import MySQLdb
+import MySQLdb  # ty: ignore[unresolved-import, unused-ignore-comment, unused-ignore-comment]
 
 
 # https://mail.python.org/pipermail/tutor/2010-December/080701.html

--- a/mqttwarn/services/mysql_dynamic.py
+++ b/mqttwarn/services/mysql_dynamic.py
@@ -13,7 +13,7 @@ from builtins import str
 import re
 import time
 import traceback
-import MySQLdb
+import MySQLdb  # ty: ignore[unresolved-import, unused-ignore-comment, unused-ignore-comment]
 
 
 def add_row(srv, cursor, index_table_name, table_name, rowdict, ignorekeys):
@@ -60,7 +60,7 @@ def add_row(srv, cursor, index_table_name, table_name, rowdict, ignorekeys):
 
             columns += " " + keys[i]['clean']
             values_template += " %s"
-            values += (MySQLdb.escape_string(str(rowdict[keys[i]['ori']])),)
+            values += (MySQLdb._mysql.escape_string(str(rowdict[keys[i]['ori']])),)
 
         sql = "insert into %s (%s) values (%s)" % (table_name, columns, values_template)
 

--- a/mqttwarn/services/mysql_remap.py
+++ b/mqttwarn/services/mysql_remap.py
@@ -5,7 +5,7 @@ __author__    = 'Halacs <halacs87()gmail.com>'
 __copyright__ = 'Copyright 2018 Halacs'
 __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
-import MySQLdb
+import MySQLdb  # ty: ignore[unresolved-import, unused-ignore-comment, unused-ignore-comment]
 
 
 # https://mail.python.org/pipermail/tutor/2010-December/080701.html

--- a/mqttwarn/services/mythtv.py
+++ b/mqttwarn/services/mythtv.py
@@ -5,6 +5,8 @@ __author__    = 'Stefan Roellin <stefan()roellin-baumann.ch>'
 __copyright__ = 'Copyright 2015 Stefan Roellin'
 __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
+from ssl import SSLError
+
 from future import standard_library
 standard_library.install_aliases()
 
@@ -30,7 +32,7 @@ def plugin(srv, item):
         http_handler.request("POST", 'Myth/SendNotification',
                              headers={'Content-type': "application/x-www-form-urlencoded", "Accept": "text/plain"},
                              body=urllib.parse.urlencode(data))
-    except (SSLError, HTTPException) as e:
+    except (SSLError, http.client.HTTPException) as e:
         srv.logging.warn("mythtv notification failed: %s" % e)
         return False            
 

--- a/mqttwarn/services/nntp.py
+++ b/mqttwarn/services/nntp.py
@@ -47,7 +47,7 @@ def plugin(srv, item):
         srv.logging.debug(nntp.getwelcome())
         nntp.set_debuglevel(0)
 
-        nntp.post(msg_file)
+        nntp.post(msg_file.read().encode("utf-8"))
         nntp.quit()
     except Exception as e:
         srv.logging.warn("Cannot post to %s newsgroup: %s" % (newsgroup, e))

--- a/mqttwarn/services/noop.py
+++ b/mqttwarn/services/noop.py
@@ -5,7 +5,7 @@ def plugin(srv: Service, item: ProcessorItem) -> bool:
     """
     An mqttwarn plugin with little overhead, suitable for unit- and integration-testing.
     """
-    if hasattr(item, "message") and item.message and "fail" in item.message:
+    if hasattr(item, "message") and item.message is not None and "fail" in str(item.message):
         srv.logging.error("Failed sending message using noop")
         return False
     else:

--- a/mqttwarn/services/ntfy.py
+++ b/mqttwarn/services/ntfy.py
@@ -238,7 +238,7 @@ def obtain_ntfy_fields(item: ProcessorItem) -> DataDict:
     fields_config = item.config and project(item.config, NTFY_FIELD_NAMES) or {}
     fields: DataDict = OrderedDict()
     fields.update(fields_config)
-    fields.update(fields_addrs)
+    fields.update(fields_addrs)  # ty: ignore[no-matching-overload]
     fields.update(fields_data)
 
     # Run an interpolation step also on the outbound ntfy option

--- a/mqttwarn/services/osxsay.py
+++ b/mqttwarn/services/osxsay.py
@@ -24,6 +24,9 @@ def plugin(srv, item):
         srv.logging.warn("Cannot create osxsay pipe: %s" % e)
         return False
 
+    if proc.stdin is None:
+        raise ValueError("Cannot operate without stdin")
+
     try:
         proc.stdin.write(text)
     except IOError as e:

--- a/mqttwarn/services/pipe.py
+++ b/mqttwarn/services/pipe.py
@@ -29,7 +29,8 @@ def plugin(srv, item):
         return False
 
     try:
-        proc.stdin.write(text.encode('utf-8'))
+        if proc.stdin:
+            proc.stdin.write(text.encode('utf-8'))
     except IOError as e:
         srv.logging.warn("Cannot write to pipe: errno %d" % (e.errno))
         return False
@@ -37,6 +38,7 @@ def plugin(srv, item):
         srv.logging.warn("Cannot write to pipe: %s" % e)
         return False
 
-    proc.stdin.close()
+    if proc.stdin:
+        proc.stdin.close()
     proc.wait()
     return True

--- a/mqttwarn/services/pushsafer.py
+++ b/mqttwarn/services/pushsafer.py
@@ -16,9 +16,9 @@ try:
     from urllib.request import urlopen, Request
     from urllib.error import HTTPError
 except ImportError:
-    from urlparse import urlparse  # type: ignore[no-redef]
-    from urllib import urlencode, urljoin  # type: ignore[no-redef,attr-defined]
-    from urllib2 import urlopen, Request, HTTPError  # type: ignore[no-redef]
+    from urlparse import urlparse  # ty: ignore[unresolved-import]
+    from urllib import urlencode, urljoin  # ty: ignore[unresolved-import]
+    from urllib2 import urlopen, Request, HTTPError  # ty: ignore[unresolved-import]
 
 import typing as t
 
@@ -96,7 +96,7 @@ class PushsaferParameterEncoder:
     def __init__(self, item: ProcessorItem):
         self.item = item
         self.private_key: t.Optional[str] = None
-        self.params: t.Dict[str, str] = {}
+        self.params: t.Dict[str, t.Any] = {}
 
     def encode(self):
         addrs = self.item.addrs
@@ -129,7 +129,7 @@ class PushsaferParameterEncoder:
         14 (if present) is the Pushsafer message will be repeated after specified time delay when not confirmed
         """
 
-        addrs = self.item.addrs
+        addrs = t.cast(t.List, self.item.addrs)
         title = self.item.title
 
         # Decode Private or Alias Key.
@@ -192,7 +192,7 @@ class PushsaferParameterEncoder:
         New-style configuration layout with named parameters for Pushsafer.
         """
 
-        addrs = self.item.addrs
+        addrs = t.cast(t.Dict, self.item.addrs)
         title = self.item.title
 
         # Decode Private or Alias Key.

--- a/mqttwarn/services/rrdtool.py
+++ b/mqttwarn/services/rrdtool.py
@@ -6,7 +6,7 @@ __copyright__ = 'Copyright 2015'
 __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
 import re
-import rrdtool
+import rrdtool  # ty: ignore[unresolved-import]
 
 
 def plugin(srv, item):

--- a/mqttwarn/services/serial.py
+++ b/mqttwarn/services/serial.py
@@ -40,14 +40,14 @@ def plugin(srv, item):
 
     # Append newline if config option is set
     if type(config) == dict and 'append_newline' in config and config['append_newline']:
-        text = text + "\n"
+        text = text + b"\n"
 
     try:
         try:
             if callable(getattr(_serialport, "is_open", None)):
-                _serialport.is_open
+                _serialport.is_open  # ty: ignore[unresolved-attribute]
             else:
-                _serialport.isOpen
+                _serialport.isOpen  # ty: ignore[unresolved-attribute]
             srv.logging.debug("%s already open", comName)
         except:
             #Open port for first use
@@ -55,7 +55,8 @@ def plugin(srv, item):
             _serialport = serial.serial_for_url(comName)
             _serialport.baudrate = comBaudRate
 
-        _serialport.write(text.encode('utf-8'))
+        if _serialport is not None and text is not None:
+            _serialport.write(text)
 
     except serial.SerialException as e:
         srv.logging.warning("Cannot write to com port `%s': %s" % (comName, e))

--- a/mqttwarn/services/slack.py
+++ b/mqttwarn/services/slack.py
@@ -5,6 +5,8 @@ __author__    = 'Jan-Piet Mens <jpmens()gmail.com>'
 __copyright__ = 'Copyright 2014 Jan-Piet Mens'
 __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
+from typing import Optional, Any, IO, cast
+
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
@@ -52,8 +54,8 @@ def plugin(srv, item):
 
     # check if there is an image contained in a JSON payload
     # (support either an image URL or base64 encoded image)
+    image: Optional[bytes] = None
     try:
-        image = None
         if 'imageurl' in item.data:
             imageurl = item.data['imageurl']
             srv.logging.debug("Image url detected - %s" % imageurl)
@@ -64,11 +66,11 @@ def plugin(srv, item):
                 authuser = item.data['user']
                 authpass = item.data['password']
                 if authtype == 'digest':
-                    image = requests.get(imageurl, stream=True,auth=HTTPDigestAuth(authuser, authpass)).raw
+                    image = cast(bytes, requests.get(imageurl, stream=True,auth=HTTPDigestAuth(authuser, authpass)).raw)
                 else:
-                    image = requests.get(imageurl, stream=True,auth=HTTPBasicAuth(authuser, authpass)).raw
+                    image = cast(bytes, requests.get(imageurl, stream=True,auth=HTTPBasicAuth(authuser, authpass)).raw)
             else:
-                image = requests.get(imageurl, stream=True).raw
+                image = cast(bytes, requests.get(imageurl, stream=True).raw)
             
         elif 'imagebase64' in item.data:
             imagebase64 = item.data['imagebase64']

--- a/mqttwarn/services/slixmpp.py
+++ b/mqttwarn/services/slixmpp.py
@@ -44,7 +44,7 @@ def plugin(srv, item):
         for target in xmpp_addresses:
             xmpp = send_msg_bot(sender, password, target, text, loop)
             xmpp.connect()
-            xmpp.process(forever=False)
+            xmpp.process(forever=False)  # ty: ignore[unresolved-attribute]
         srv.logging.debug("Successfully sent message")
     except Exception as e:
         srv.logging.error("Error sending message to %s: %s" % (item.target, e))

--- a/mqttwarn/services/ssh.py
+++ b/mqttwarn/services/ssh.py
@@ -8,7 +8,7 @@ __license__ = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-
 import os
 import json
 import paramiko
-from pipes import quote
+from shlex import quote
 
 
 def credentials(host, user=None, pwd=None, port=22):
@@ -23,7 +23,7 @@ def credentials(host, user=None, pwd=None, port=22):
         if type(ident) is list:
             ident = ident[0]
         if 'port' not in o:
-            o['port'] = port
+            o['port'] = str(port)
         c = {'hostname': o['hostname'], 'port': int(o['port']), 'username': o['user'], 'key_filename': ident}
     else:
         c = {'hostname': host, 'port': port, 'username': user, 'password': pwd}

--- a/mqttwarn/services/twilio.py
+++ b/mqttwarn/services/twilio.py
@@ -5,8 +5,7 @@ __author__    = 'Jan-Piet Mens <jpmens()gmail.com>'
 __copyright__ = 'Copyright 2014 Jan-Piet Mens'
 __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
-from twilio.rest import TwilioRestClient
-
+from twilio.rest import Client
 
 def plugin(srv, item):
     """ expects (accountSID, authToken, from, to) in addrs"""
@@ -22,7 +21,7 @@ def plugin(srv, item):
     text = item.message
 
     try:
-        client = TwilioRestClient(account_sid, auth_token)
+        client = Client(account_sid, auth_token)
         message = client.messages.create(
                     body=text,
                     to=to_nr,

--- a/mqttwarn/services/xmpp.py
+++ b/mqttwarn/services/xmpp.py
@@ -5,6 +5,8 @@ __author__    = 'Fabian Affolter <fabian()affolter-engineering.ch>'
 __copyright__ = 'Copyright 2014 Fabian Affolter'
 __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
+from ssl import SSLContext
+
 import xmpp
 
 
@@ -30,7 +32,7 @@ def plugin(srv, item):
             connection = xmpp.Client(jid.getDomain(),debug=[])
             connection.connect()
             connection.auth(jid.getNode(), password, resource=jid.getResource())
-            connection.send(xmpp.protocol.Message(target, text))
+            connection.send(xmpp.protocol.Message(target, text))  # ty: ignore[unresolved-attribute]
         srv.logging.debug("Successfully sent message")
     except Exception as e:
         srv.logging.error("Error sending message to %s: %s" % (item.target, e))
@@ -52,11 +54,11 @@ def xmpppy_monkeypatch_ssl():
         """ Immidiatedly switch socket to TLS mode. Used internally."""
         """ Here we should switch pending_data to hint mode."""
         tcpsock=self._owner.Connection
-        tcpsock._sslObj    = ssl.wrap_socket(tcpsock._sock, None, None)
-        tcpsock._sslIssuer = tcpsock._sslObj.getpeercert().get('issuer')
-        tcpsock._sslServer = tcpsock._sslObj.getpeercert().get('server')
-        tcpsock._recv = tcpsock._sslObj.read
-        tcpsock._send = tcpsock._sslObj.write
+        tcpsock._sslObj    = ssl.wrap_socket(tcpsock._sock, None, None)  # ty: ignore[deprecated, unresolved-attribute, unused-ignore-comment, unused-ignore-comment]
+        tcpsock._sslIssuer = tcpsock._sslObj.getpeercert().get('issuer')  # ty: ignore[unresolved-attribute, unused-ignore-comment, unused-ignore-comment]
+        tcpsock._sslServer = tcpsock._sslObj.getpeercert().get('server')  # ty: ignore[unresolved-attribute, unused-ignore-comment, unused-ignore-comment]
+        tcpsock._recv = tcpsock._sslObj.recv
+        tcpsock._send = tcpsock._sslObj.send
 
         tcpsock._seen_data=1
         self._tcpsock=tcpsock

--- a/mqttwarn/topic.py
+++ b/mqttwarn/topic.py
@@ -15,11 +15,11 @@ class TopicTimeout(threading.Thread):
 
     def __init__(
         self,
-        topic: t.Optional[str] = None,
-        timeout: t.Optional[int] = 1,
-        section: t.Optional[str] = None,
+        topic: str,
+        timeout: int,
+        section: str,
+        on_timeout: t.Callable,
         notify_only_on_timeout: t.Optional[bool] = False,
-        on_timeout: t.Optional[t.Callable] = None,
     ):
         threading.Thread.__init__(self)
         self.topic = topic
@@ -54,7 +54,7 @@ class TopicTimeout(threading.Thread):
                         logger.debug("%s received message for topic %s before timeout" % (self.name, self.topic))
                         message = "Message received for topic %s within %i" % (self.topic, self.timeout)
                         self._last_state_timeout = False
-                        self._on_timeout(self.section, self.topic, message.encode("UTF-8"))
+                        self._on_timeout(self.section, self.topic, message.encode("utf-8"))
                     self._restart_event = threading.Event()
                     break
                 logger.debug("%s waiting... %i" % (self.name, timeout))
@@ -64,7 +64,7 @@ class TopicTimeout(threading.Thread):
                     logger.debug("%s timeout for topic %s" % (self.name, self.topic))
                     message = "Timeout for topic %s after %i" % (self.topic, self.timeout)
                     self._last_state_timeout = True
-                    self._on_timeout(self.section, self.topic, message.encode("UTF-8"))
+                    self._on_timeout(self.section, self.topic, message.encode("utf-8"))
                     break
 
     def restart(self):

--- a/mqttwarn/util.py
+++ b/mqttwarn/util.py
@@ -3,9 +3,9 @@ import functools
 import importlib.machinery
 
 try:
-    from importlib.resources import files as resource_files  # type: ignore[attr-defined]
+    from importlib.resources import files as resource_files
 except ImportError:
-    from importlib_resources import files as resource_files  # type: ignore[no-redef]
+    from importlib_resources import files as resource_files  # ty: ignore[unresolved-import]
 
 import importlib.util
 import json
@@ -33,7 +33,7 @@ class Formatter(string.Formatter):
     - https://docs.python.org/2/library/string.html#custom-string-formatting
     """
 
-    def convert_field(self, value: str, conversion: str) -> str:
+    def convert_field(self, value, conversion):
         """
         The conversion field causes a type coercion before formatting.
         By default, two conversion flags are supported: '!s' which calls
@@ -89,7 +89,7 @@ def parse_cron_options(argstring: str) -> t.Dict[str, t.Union[str, float]]:
 
 
 # http://code.activestate.com/recipes/473878-timeout-function-using-threading/
-def timeout(func: t.Callable, args=(), kwargs={}, timeout_secs: int = 10, default: bool = False) -> t.Any:
+def timeout(func: t.Callable, args=(), kwargs={}, timeout_secs: float = 10.0, default: bool = False) -> t.Any:
     import threading
 
     class InterruptableThread(threading.Thread):
@@ -120,14 +120,14 @@ def timeout(func: t.Callable, args=(), kwargs={}, timeout_secs: int = 10, defaul
         return it.result
 
 
-def sanitize_function_name(name: str) -> str:
+def sanitize_function_name(name: t.Optional[t.Union[str, int]]) -> str:
     if name is None:
         raise ValueError(f"Empty function name: {name}")
-
+    name = str(name)
     try:
         valid = re.match(r"^[\w]+\(\)", name)
         if valid is not None:
-            return re.sub("[()]", "", name)
+            return re.sub(r"[()]", "", name)
     except:
         pass
     raise ValueError(f"Invalid function name: {name}")
@@ -207,8 +207,10 @@ def import_symbol(name: str, parent: t.Optional[types.ModuleType] = None) -> typ
     module = importlib.util.module_from_spec(spec)
 
     # Actually load the module.
-    loader: FileLoader = module.__loader__
-    loader.exec_module(module)
+    loader: FileLoader = (  # ty: ignore[invalid-assignment, unused-ignore-comment, unused-ignore-comment]
+        module.__loader__
+    )
+    loader.exec_module(module)  # ty: ignore[unresolved-attribute, unused-ignore-comment, unused-ignore-comment]
 
     if remaining_names is None:
         return module

--- a/mqttwarn/vendor/ZabbixSender.py
+++ b/mqttwarn/vendor/ZabbixSender.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from builtins import str
 import socket
 import struct
+from typing import Dict, Any
 
 # Single file, imported from https://github.com/BlueSkyDetector/code-snippet/tree/master/ZabbixSender
 # Lincense: DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
@@ -22,8 +23,8 @@ class ZabbixSender:
     
     zbx_header = b'ZBXD'
     zbx_version = 1
-    zbx_sender_data = {'request': 'sender data', 'data': []}
-    send_data = ''
+    zbx_sender_data: Dict[str, Any] = {'request': 'sender data', 'data': []}
+    send_data = b''
     
     def __init__(self, server_host, server_port = 10051):
         self.server_ip = socket.gethostbyname(server_host)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,17 +65,10 @@ extend-exclude = [
   "mqttwarn/vendor",
 ]
 
-[tool.mypy]
-ignore_missing_imports = true
-exclude = [
-  "tests/etc/functions_bad.py",
-]
-files = [
-  "examples/**/*.py",
-  "mqttwarn/**/*.py",
-  "tests/acme/**/*.py",
-  "tests/fixtures/**/*.py",
-  "tests/services/**/*.py",
+[tool.ty]
+src.exclude = [
+  "tests/etc/functions_bad.py",  # Invalid syntax.
+  "mqttwarn/services/syslog.py",  # Module `syslog` has no member `LOG_KERN` on Windows.
 ]
 
 
@@ -121,7 +114,7 @@ format = [
 lint = [
   { cmd = "ruff ." },
   { cmd = "black --check ." },
-  { cmd = "mypy --install-types --non-interactive" },
+  { cmd = "ty check" },
 ]
 test = [
   { cmd="pytest" },

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import platform
 import sys
 
 from setuptools import find_packages, setup
-from versioningit import get_cmdclasses
+from versioningit import get_cmdclasses  # ty: ignore[unresolved-import, unused-ignore-comment, unused-ignore-comment]
 
 here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, "README.rst")).read()
@@ -55,13 +55,13 @@ extras = {
         "oauth2client>=4.1.2",
     ],
     "mysql": [
-        "mysql",
-    ],
-    "mysql_dynamic": [
-        "mysqlclient",
+        "mysqlclient<2",
     ],
     "nsca": [
         "pynsca>=1.6",
+    ],
+    "nntp": [
+        "standard-nntplib<4",
     ],
     "desktopnotify": [
         "desktop-notifier<4",
@@ -98,7 +98,7 @@ extras = {
         "Mastodon.py>=1.2.2",
     ],
     "twilio": [
-        "twilio>=6.11.0",
+        "twilio>=6.11.0,<10",
     ],
     "twitter": [
         "python-twitter>=3.4.1",
@@ -131,7 +131,7 @@ for extra, packages in extras.items():
         continue
 
     # FIXME: `mysqlclient` needs MySQL or MariaDB client libraries.
-    if extra in ["mysql_dynamic"] and sys.platform in ["darwin", "win32"]:
+    if extra in ["mysql"] and sys.platform in ["darwin", "win32"]:
         continue
 
     # FIXME: Skip specific packages on specific platforms,
@@ -144,10 +144,6 @@ for extra, packages in extras.items():
     #        of time to build, so let's mask them to improve build times significantly.
     #        Examples: `cryptography`, `aiohttp`, `frozenlist`, `multidict`, `yarl`.
     if machine in ["armv7l"] and extra in ["apprise", "twilio"]:
-        continue
-
-    # FIXME: aiohttp (needed by twilio) is not available for Python 3.12 yet.
-    if sys.version_info >= (3, 12) and extra in ["twilio"]:
         continue
 
     for package in packages:
@@ -173,10 +169,10 @@ extras["test"] = [
 extras["develop"] = [
     "black<24",
     "build<1",
-    "mypy<1.10",
     "poethepoet<1",
     "ruff==0.0.254; python_version>='3.7'",
     "sphinx-autobuild",
+    "ty==0.0.58; python_version>='3.8'",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ requires = [
     "jinja2<4",
     "paho-mqtt<2",
     "requests<3",
+    "simplejson<5",
     "six<2",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ extras_all = []
 for extra, packages in extras.items():
     # FIXME: Skip specific packages having build issues.
     # https://github.com/commx/python-rrdtool/issues/36
-    if extra in ["mysql", "rrdtool"]:
+    if extra in ["rrdtool"]:
         continue
 
     # FIXME: `mysqlclient` needs MySQL or MariaDB client libraries.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ def without_jinja():
     # Emulate removal of `jinja2` package.
     # https://stackoverflow.com/a/65163627
     backup = sys.modules["jinja2"]
-    sys.modules["jinja2"] = None
+    sys.modules["jinja2"] = None  # ty: ignore[invalid-assignment]
     importlib.reload(sys.modules["mqttwarn.core"])
 
     yield
@@ -47,7 +47,7 @@ def without_ssl():
     # Emulate removal of `ssl` package.
     # https://stackoverflow.com/a/65163627
     backup = sys.modules["ssl"]
-    sys.modules["ssl"] = None
+    sys.modules["ssl"] = None  # ty: ignore[invalid-assignment]
     importlib.reload(sys.modules["mqttwarn.configuration"])
 
     yield

--- a/tests/services/pushsafer/test_pushsafer_common.py
+++ b/tests/services/pushsafer/test_pushsafer_common.py
@@ -29,7 +29,7 @@ def test_pushsafer_configuration_invalid_failure(srv, caplog, mock_urlopen_succe
     """
 
     module = load_module_from_file("mqttwarn/services/pushsafer.py")
-    item = Item(addrs=42, message="⚽ Notification message ⚽")
+    item = Item(addrs=42, message="⚽ Notification message ⚽")  # ty: ignore[invalid-argument-type]
     with pytest.raises(ValueError) as ex:
         module.plugin(srv, item)
     assert ex.match("Pushsafer configuration layout empty or invalid. type=int")

--- a/tests/services/pushsafer/util.py
+++ b/tests/services/pushsafer/util.py
@@ -19,7 +19,7 @@ def assert_request(request: urllib.request.Request, reference_data: t.Dict[str, 
     if isinstance(request.data, bytes):
         payload = request.data
     elif hasattr(request.data, "read"):
-        payload = request.data.read()  # type: ignore[union-attr]
+        payload = request.data.read()  # ty: ignore[call-non-callable]
     else:
         raise ValueError(f"Something went wrong. Could not decode `request.data`: {request.data}")
     actual_data = dict(parse_qsl(payload.decode("utf-8"), keep_blank_values=True))

--- a/tests/services/test_amqp.py
+++ b/tests/services/test_amqp.py
@@ -55,7 +55,11 @@ def test_amqp_failure(srv, mocker, caplog):
         message="⚽ Notification message ⚽",
     )
 
-    mock_connection = Mock(**{"basic_publish.side_effect": Exception("something failed")})
+    mock_connection = Mock(
+        **{  # ty: ignore[invalid-argument-type, unused-ignore-comment, unused-ignore-comment]
+            "basic_publish.side_effect": Exception("something failed")
+        }
+    )
     mock_client = mocker.patch("puka.Client", side_effect=[mock_connection], create=True)
 
     outcome = module.plugin(srv, item)

--- a/tests/services/test_apns.py
+++ b/tests/services/test_apns.py
@@ -8,7 +8,9 @@ import pytest
 from mqttwarn.model import ProcessorItem as Item
 from mqttwarn.util import load_module_from_file
 
-pytest.skip(reason="The `apns` package is not ready for Python3", allow_module_level=True)
+pytest.skip(
+    reason="The `apns` package is not ready for Python3", allow_module_level=True  # ty: ignore[unknown-argument]
+)
 
 
 @mock.patch("apns.APNs", create=True)

--- a/tests/services/test_asterisk.py
+++ b/tests/services/test_asterisk.py
@@ -9,7 +9,12 @@ from mqttwarn.util import load_module_from_file
 
 @mock.patch("asterisk.manager.Manager", create=True)
 def test_asterisk_success(asterisk_mock, srv, caplog):
-    asterisk_mock.return_value = Mock(**{"login.return_value": 42, "originate.return_value": 42})
+    asterisk_mock.return_value = Mock(
+        **{  # ty: ignore[invalid-argument-type, unused-ignore-comment, unused-ignore-comment]
+            "login.return_value": 42,
+            "originate.return_value": 42,
+        }
+    )
 
     module = load_module_from_file("mqttwarn/services/asterisk.py")
 
@@ -65,7 +70,11 @@ class ManagerException(Exception):
 @mock.patch("asterisk.manager.Manager", create=True)
 @mock.patch("asterisk.manager.ManagerSocketException", ManagerSocketException, create=True)
 def test_asterisk_failure_no_connection(asterisk_mock, srv, caplog):
-    asterisk_mock.return_value = Mock(**{"connect.side_effect": ManagerSocketException("something failed")})
+    asterisk_mock.return_value = Mock(
+        **{  # ty: ignore[invalid-argument-type, unused-ignore-comment, unused-ignore-comment]
+            "connect.side_effect": ManagerSocketException("something failed")
+        }
+    )
 
     module = load_module_from_file("mqttwarn/services/asterisk.py")
 
@@ -99,7 +108,11 @@ def test_asterisk_failure_no_connection(asterisk_mock, srv, caplog):
 @mock.patch("asterisk.manager.ManagerSocketException", ManagerSocketException, create=True)
 @mock.patch("asterisk.manager.ManagerAuthException", ManagerAuthException, create=True)
 def test_asterisk_failure_login_invalid(asterisk_mock, srv, caplog):
-    asterisk_mock.return_value = Mock(**{"login.side_effect": ManagerAuthException("something failed")})
+    asterisk_mock.return_value = Mock(
+        **{  # ty: ignore[invalid-argument-type, unused-ignore-comment, unused-ignore-comment]
+            "login.side_effect": ManagerAuthException("something failed")
+        }
+    )
 
     module = load_module_from_file("mqttwarn/services/asterisk.py")
 
@@ -139,7 +152,9 @@ def test_asterisk_failure_originate_croaks(asterisk_mock, srv, caplog):
         "login.return_value": 42,
         "originate.side_effect": ManagerException("something failed"),
     }
-    asterisk_mock.return_value = Mock(**attrs)
+    asterisk_mock.return_value = Mock(
+        **attrs  # ty: ignore[invalid-argument-type, unused-ignore-comment, unused-ignore-comment]
+    )
 
     module = load_module_from_file("mqttwarn/services/asterisk.py")
 
@@ -188,7 +203,9 @@ def test_asterisk_success_with_broken_close(asterisk_mock, srv, caplog):
         "originate.return_value": 42,
         "close.side_effect": ManagerSocketException("something failed"),
     }
-    asterisk_mock.return_value = Mock(**attrs)
+    asterisk_mock.return_value = Mock(
+        **attrs  # ty: ignore[invalid-argument-type, unused-ignore-comment, unused-ignore-comment]
+    )
 
     module = load_module_from_file("mqttwarn/services/asterisk.py")
 

--- a/tests/services/test_carbon.py
+++ b/tests/services/test_carbon.py
@@ -23,7 +23,7 @@ def test_carbon_success_metric_value_timestamp(mocker, srv, caplog):
     assert socket_mock.mock_calls == [
         call(),
         call().connect(("localhost", 2003)),
-        call().sendall("foo 42.42 1623887596\n"),
+        call().sendall(b"foo 42.42 1623887596\n"),
         call().close(),
     ]
 
@@ -168,7 +168,11 @@ def test_carbon_failure_connect(mocker, srv, caplog):
     socket_mock = mocker.patch("socket.socket")
 
     # Inject exception to be raised on `socket.connect`.
-    socket_mock.return_value = Mock(**{"connect.side_effect": Exception("something failed")})
+    socket_mock.return_value = Mock(
+        **{  # ty: ignore[invalid-argument-type, unused-ignore-comment, unused-ignore-comment]
+            "connect.side_effect": Exception("something failed")
+        }
+    )
 
     outcome = module.plugin(srv, item)
     assert socket_mock.mock_calls == [call(), call().connect(("localhost", 2003))]

--- a/tests/services/test_desktopnotify.py
+++ b/tests/services/test_desktopnotify.py
@@ -54,7 +54,13 @@ def test_desktopnotify_vanilla_failure(desktop_notifier_mock, mocker, srv: Servi
 
     # Make the `send_sync` method fail.
     notifier_mock: Mock = mocker.patch.object(
-        module, "notify", Mock(**{"send_sync.side_effect": Exception("Something failed")})
+        module,
+        "notify",
+        Mock(
+            **{  # ty: ignore[invalid-argument-type, unused-ignore-comment, unused-ignore-comment]
+                "send_sync.side_effect": Exception("Something failed")
+            }
+        ),
     )
 
     outcome = module.plugin(srv, item)

--- a/tests/services/test_irccat.py
+++ b/tests/services/test_irccat.py
@@ -118,7 +118,11 @@ def test_irccat_connect_fails(mocker, srv, caplog):
     module = load_module_from_file("mqttwarn/services/irccat.py")
 
     # Make the call to `socket.connect` raise an exception.
-    mock_connection = Mock(**{"connect.side_effect": Exception("something failed")})
+    mock_connection = Mock(
+        **{  # ty: ignore[invalid-argument-type, unused-ignore-comment, unused-ignore-comment]
+            "connect.side_effect": Exception("something failed")
+        }
+    )
     socket_mock = mocker.patch("socket.socket", side_effect=[mock_connection], create=True)
 
     outcome = module.plugin(srv, item)

--- a/tests/services/test_ntfy.py
+++ b/tests/services/test_ntfy.py
@@ -15,6 +15,7 @@ from mqttwarn.services.ntfy import (
     dict_with_titles,
     encode_rfc2047,
     obtain_ntfy_fields,
+    DataDict,
 )
 from mqttwarn.util import load_module_by_name
 
@@ -57,7 +58,7 @@ def test_ntfy_decode_jobitem_attachment_success(attachment_dummy):
     assert ntfy_request.options["url"] == "http://localhost:9999/testdrive"
     assert ntfy_request.options["file"] == attachment_dummy.name
     assert ntfy_request.fields["filename"] == Path(attachment_dummy.name).name
-    assert ntfy_request.attachment_data.read() == b"foo"
+    assert ntfy_request.attachment_data.read() == b"foo"  # ty: ignore[unresolved-attribute]
 
 
 def test_ntfy_decode_jobitem_attachment_not_found_failure(caplog):
@@ -119,7 +120,7 @@ def test_ntfy_decode_jobitem_attachment_with_filename_success(attachment_dummy):
     assert ntfy_request.options["url"] == "http://localhost:9999/testdrive"
     assert ntfy_request.options["file"] == attachment_dummy.name
     assert ntfy_request.fields["filename"] == "testdrive.txt"
-    assert ntfy_request.attachment_data.read() == b"foo"
+    assert ntfy_request.attachment_data.read() == b"foo"  # ty: ignore[unresolved-attribute]
 
 
 def test_ntfy_decode_jobitem_with_url_only_success():
@@ -145,7 +146,7 @@ def test_ntfy_decode_jobitem_with_invalid_target_address_descriptor():
         decode_jobitem(item)
     assert ex.match(re.escape("Unable to handle `targets` address descriptor data type `NoneType`: None"))
 
-    item = Item(addrs=42.42)
+    item = Item(addrs=42.42)  # ty: ignore[invalid-argument-type]
     with pytest.raises(TypeError) as ex:
         decode_jobitem(item)
     assert ex.match(re.escape("Unable to handle `targets` address descriptor data type `float`: 42.42"))
@@ -213,7 +214,7 @@ def test_ntfy_dict_ascii_clean():
     """
     Test the `dict_ascii_clean` helper function.
     """
-    indata = {"message": "⚽ Notification message ⚽", "foobar": "äöü"}
+    indata: DataDict = {"message": "⚽ Notification message ⚽", "foobar": "äöü"}
     outdata = dict_ascii_clean(indata)
     assert outdata["message"] == "? Notification message ?"
     assert outdata["foobar"] == "???"
@@ -242,7 +243,7 @@ def test_ntfy_ascii_clean_failure():
     Test the `ascii_clean` helper function.
     """
     with pytest.raises(TypeError) as ex:
-        ascii_clean(None)
+        ascii_clean(None)  # ty: ignore[invalid-argument-type]
     assert ex.match(re.escape("Unknown data type to compute ASCII-clean variant: NoneType"))
 
 
@@ -292,7 +293,7 @@ def test_ntfy_plugin_attachment(srv, caplog, attachment_dummy):
         == "view, Adjust temperature ?, https://example.org/home-automation/temperature, body='{\"temperature\": 18}'"  # noqa: E501
     )
 
-    assert response.response.status_code == 200
+    assert response.response.status_code == 200  # ty: ignore[unresolved-attribute]
 
     assert "Successfully sent message using ntfy" in caplog.messages
 
@@ -345,7 +346,7 @@ def test_ntfy_plugin_newline(srv, caplog, attachment_dummy):
         == "view, Adjust temperature ?, https://example.org/home-automation/temperature, body='{\"temperature\": 18}'"
     )
 
-    assert response.response.status_code == 200
+    assert response.response.status_code == 200  # ty: ignore[unresolved-attribute]
 
     assert "Successfully sent message using ntfy" in caplog.messages
 
@@ -399,7 +400,7 @@ def test_ntfy_plugin_attachment_and_newline(srv, caplog, attachment_dummy):
         == "view, Adjust temperature ?, https://example.org/home-automation/temperature, body='{\"temperature\": 18}'"  # noqa: E501
     )
 
-    assert response.response.status_code == 200
+    assert response.response.status_code == 200  # ty: ignore[unresolved-attribute]
 
     assert "Successfully sent message using ntfy" in caplog.messages
 

--- a/tests/services/test_ntfy_integration.py
+++ b/tests/services/test_ntfy_integration.py
@@ -9,7 +9,10 @@ from mqttwarn.model import ProcessorItem as Item
 from mqttwarn.util import load_module_by_name
 
 if os.getenv("GITHUB_ACTIONS") == "true" and sys.platform != "linux":
-    raise pytest.skip(msg="On GHA, ntfy via Docker is only available on Linux", allow_module_level=True)
+    raise pytest.skip(
+        reason="On GHA, ntfy via Docker is only available on Linux",  # ty: ignore[unknown-argument, unused-ignore-comment, unused-ignore-comment]  # noqa: E501
+        allow_module_level=True,
+    )
 
 
 @pytest.fixture

--- a/tests/services/test_pushbullet.py
+++ b/tests/services/test_pushbullet.py
@@ -68,8 +68,8 @@ def test_pushbullet_modern_email_success(srv, caplog):
     assert response.request.headers["User-Agent"] == "mqttwarn"
     assert response.request.headers["Access-Token"] == "a6FJVAA0LVJKrT8k"
 
-    assert response.response.status_code == 200
-    assert response.response.json() == pushbullet_api_response
+    assert response.response.status_code == 200  # ty: ignore[unresolved-attribute]
+    assert response.response.json() == pushbullet_api_response  # ty: ignore[unresolved-attribute]
 
 
 @responses.activate
@@ -281,7 +281,7 @@ def test_pushbullet_tad_wrong_type_failure(srv, caplog):
     module = load_module_by_name("mqttwarn.services.pushbullet")
 
     item = Item(
-        addrs=42.42,
+        addrs=42.42,  # ty: ignore[invalid-argument-type]
         title="⚽ Message title ⚽",
         message="⚽ Notification message ⚽",
         target="foo",
@@ -320,7 +320,7 @@ def test_pushbullet_api_failure(srv, caplog, mocker):
     def raise_exception(*args, **kwargs):
         raise Exception("Something failed")
 
-    module.send_note = raise_exception
+    module.send_note = raise_exception  # ty: ignore[unresolved-attribute]
 
     outcome = module.plugin(srv, item)
     assert outcome is False

--- a/tests/services/test_pushover.py
+++ b/tests/services/test_pushover.py
@@ -52,8 +52,8 @@ def test_pushover_success(srv, caplog):
     )
     assert responses.calls[0].request.headers["User-Agent"] == "mqttwarn"
 
-    assert responses.calls[0].response.status_code == 200
-    assert responses.calls[0].response.text == '{"status": 1}'
+    assert responses.calls[0].response.status_code == 200  # ty: ignore[unresolved-attribute]
+    assert responses.calls[0].response.text == '{"status": 1}'  # ty: ignore[unresolved-attribute]
 
     assert outcome is True
     assert "Sending pushover notification to test" in caplog.text
@@ -85,8 +85,8 @@ def test_pushover_success_with_credentials_from_environment(srv, mocker, caplog)
     )
     assert responses.calls[0].request.headers["User-Agent"] == "mqttwarn"
 
-    assert responses.calls[0].response.status_code == 200
-    assert responses.calls[0].response.text == '{"status": 1}'
+    assert responses.calls[0].response.status_code == 200  # ty: ignore[unresolved-attribute]
+    assert responses.calls[0].response.text == '{"status": 1}'  # ty: ignore[unresolved-attribute]
 
     assert outcome is True
     assert "Sending pushover notification to test" in caplog.text
@@ -113,8 +113,8 @@ def test_pushover_success_with_sound(srv, caplog):
         "sound=sound1&message=%E2%9A%BD+Notification+message+%E2%9A%BD"
     )
 
-    assert responses.calls[0].response.status_code == 200
-    assert responses.calls[0].response.text == '{"status": 1}'
+    assert responses.calls[0].response.status_code == 200  # ty: ignore[unresolved-attribute]
+    assert responses.calls[0].response.text == '{"status": 1}'  # ty: ignore[unresolved-attribute]
 
     assert outcome is True
     assert "Sending pushover notification to test" in caplog.text
@@ -147,8 +147,8 @@ def test_pushover_success_with_html_and_url_and_url_title(srv, caplog):
         "&url_title=Notification+group+%27foo%27"
     )
 
-    assert responses.calls[0].response.status_code == 200
-    assert responses.calls[0].response.text == '{"status": 1}'
+    assert responses.calls[0].response.status_code == 200  # ty: ignore[unresolved-attribute]
+    assert responses.calls[0].response.text == '{"status": 1}'  # ty: ignore[unresolved-attribute]
 
     assert outcome is True
     assert "Sending pushover notification to test" in caplog.text
@@ -277,8 +277,8 @@ def test_pushover_success_with_devices(srv, caplog):
         "devices=cellphone1%2Ccellphone2&message=%E2%9A%BD+Notification+message+%E2%9A%BD"
     )
 
-    assert responses.calls[0].response.status_code == 200
-    assert responses.calls[0].response.text == '{"status": 1}'
+    assert responses.calls[0].response.status_code == 200  # ty: ignore[unresolved-attribute]
+    assert responses.calls[0].response.text == '{"status": 1}'  # ty: ignore[unresolved-attribute]
 
     assert outcome is True
     assert "Sending pushover notification to test" in caplog.text
@@ -309,8 +309,8 @@ def test_pushover_success_with_callback_and_title_and_priority_and_alternative_m
         "message=%E2%9A%BD+Alternative+notification+message+%E2%9A%BD"
     )
 
-    assert responses.calls[0].response.status_code == 200
-    assert responses.calls[0].response.text == '{"status": 1}'
+    assert responses.calls[0].response.status_code == 200  # ty: ignore[unresolved-attribute]
+    assert responses.calls[0].response.text == '{"status": 1}'  # ty: ignore[unresolved-attribute]
 
     assert outcome is True
     assert "Sending pushover notification to test" in caplog.text
@@ -343,8 +343,8 @@ def test_pushover_success_with_imageurl(srv, caplog):
     outcome = module.plugin(srv, item)
 
     # Check response status.
-    assert responses.calls[1].response.status_code == 200
-    assert responses.calls[1].response.text == '{"status": 1}'
+    assert responses.calls[1].response.status_code == 200  # ty: ignore[unresolved-attribute]
+    assert responses.calls[1].response.text == '{"status": 1}'  # ty: ignore[unresolved-attribute]
 
     # Decode multipart request.
     request = responses.calls[1].request
@@ -419,8 +419,8 @@ def test_pushover_success_with_imageurl_and_basic_authentication(srv, caplog):
     assert responses.calls[0].request.headers["Authorization"] == "Basic Zm9vOmJhcg=="
 
     # Check response status.
-    assert responses.calls[1].response.status_code == 200
-    assert responses.calls[1].response.text == '{"status": 1}'
+    assert responses.calls[1].response.status_code == 200  # ty: ignore[unresolved-attribute]
+    assert responses.calls[1].response.text == '{"status": 1}'  # ty: ignore[unresolved-attribute]
 
     assert outcome is True
     assert "Sending pushover notification to test" in caplog.text
@@ -465,8 +465,8 @@ def test_pushover_success_with_imageurl_and_digest_authentication(srv, caplog):
     # )
 
     # Check response status.
-    assert responses.calls[1].response.status_code == 200
-    assert responses.calls[1].response.text == '{"status": 1}'
+    assert responses.calls[1].response.status_code == 200  # ty: ignore[unresolved-attribute]
+    assert responses.calls[1].response.text == '{"status": 1}'  # ty: ignore[unresolved-attribute]
 
     assert outcome is True
     assert "Sending pushover notification to test" in caplog.text
@@ -490,8 +490,8 @@ def test_pushover_success_with_imagebase64(srv, caplog):
     outcome = module.plugin(srv, item)
 
     # Check response status.
-    assert responses.calls[0].response.status_code == 200
-    assert responses.calls[0].response.text == '{"status": 1}'
+    assert responses.calls[0].response.status_code == 200  # ty: ignore[unresolved-attribute]
+    assert responses.calls[0].response.text == '{"status": 1}'  # ty: ignore[unresolved-attribute]
 
     # Decode multipart request.
     request = responses.calls[0].request
@@ -609,8 +609,8 @@ def test_pushover_failure_response_error(srv, caplog):
     )
     assert responses.calls[0].request.headers["User-Agent"] == "mqttwarn"
 
-    assert responses.calls[0].response.status_code == 400
-    assert responses.calls[0].response.text == '{"status": 999}'
+    assert responses.calls[0].response.status_code == 400  # ty: ignore[unresolved-attribute]
+    assert responses.calls[0].response.text == '{"status": 999}'  # ty: ignore[unresolved-attribute]
 
     assert outcome is False
     assert "Sending pushover notification to test" in caplog.text

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) 2018-2022 The mqttwarn developers
-import os
+import subprocess
 import sys
 from unittest import mock
 from unittest.mock import Mock, patch
@@ -81,10 +81,10 @@ def test_command_dump_config(mqttwarn_bin, capfd):
     Verify that `mqttwarn make-config` works as expected.
     """
 
-    command = f"{mqttwarn_bin} make-config"
+    command = [mqttwarn_bin, "make-config"]
     stdout, stderr = invoke_command(capfd, command)
 
-    os.system(command)
+    subprocess.check_call(command)
     stdout = capfd.readouterr().out
 
     assert 'mqttwarn example configuration file "mqttwarn.ini"' in stdout, stdout
@@ -95,11 +95,11 @@ def test_command_dump_udf(mqttwarn_bin, capfd):
     Verify that `mqttwarn make-udf` works as expected.
     """
 
-    command = f"{mqttwarn_bin} make-udf"
+    command = [mqttwarn_bin, "make-udf"]
     stdout, stderr = invoke_command(capfd, command)
     assert "# mqttwarn example function extensions" in stdout, stdout
 
-    os.system(command)
+    subprocess.check_call(command)
     stdout = capfd.readouterr().out
 
     assert "# mqttwarn example function extensions" in stdout, stdout
@@ -112,7 +112,9 @@ def test_command_standalone_plugin(mqttwarn_bin, capfd, caplog):
 
     # FIXME: Make it work on Windows.
     if sys.platform.startswith("win"):
-        raise pytest.xfail("Skipping test, fails on Windows")
+        raise pytest.xfail(
+            "Skipping test, fails on Windows"  # ty: ignore[too-many-positional-arguments, unused-ignore-comment, unused-ignore-comment]  # noqa: E501
+        )
 
     command = [
         mqttwarn_bin,
@@ -136,7 +138,9 @@ def test_command_standalone_plugin_with_configfile(mqttwarn_bin, tmp_path, capfd
 
     # FIXME: Make it work on Windows.
     if sys.platform.startswith("win"):
-        raise pytest.xfail("Skipping test, fails on Windows")
+        raise pytest.xfail(
+            "Skipping test, fails on Windows"  # ty: ignore[too-many-positional-arguments, unused-ignore-comment, unused-ignore-comment]  # noqa: E501
+        )
 
     ini_file = tmp_path.joinpath("empty.ini")
     ini_file.touch()
@@ -164,7 +168,7 @@ def test_command_dump_config_real(mqttwarn_bin, tmp_path, capfd):
     ini_file = tmp_path.joinpath("testdrive.ini")
 
     command = f"{mqttwarn_bin} make-config > {ini_file}"
-    exitcode = os.system(command) % 255
+    exitcode = subprocess.run(command, shell=True).returncode
     assert exitcode == 0, f"Invoking command '{command}' failed"
 
     ini_content = open(ini_file, encoding="utf-8").read()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -80,8 +80,10 @@ def test_runtime_context_callfunc_failures(caplog, runtime_ini_file):
     invoker = FunctionInvoker(config=config, srv=None)
     context = RuntimeContext(config=config, invoker=invoker)
     assert context.is_filtered(section="config:foo", topic="foo", payload="bar") is False
-    assert context.get_topic_data(section="config:foo", data="foo") is None
-    assert context.get_all_data(section="config:foo", topic="foo", data="bar") is None
+    assert context.get_topic_data(section="config:foo", data="foo") is None  # ty: ignore[invalid-argument-type]
+    assert (
+        context.get_all_data(section="config:foo", topic="foo", data="bar") is None  # ty: ignore[invalid-argument-type]
+    )
     assert caplog.messages == [
         "Cannot invoke filter function 'filter_function' defined in 'config:foo': Python module must be given",
         "Cannot invoke datamap function 'datamap_function' defined in 'config:foo': Python module must be given",

--- a/tests/test_core_infra.py
+++ b/tests/test_core_infra.py
@@ -158,8 +158,8 @@ def test_connect_basic_success(mocker, caplog):
     mocker.patch("mqttwarn.core.cf", config)
 
     # Use mocked MQTT client and mqttwarn context instances.
+    mocker.patch("mqttwarn.core.context")
     mqtt_client: Mock = mocker.patch("paho.mqtt.client.Client")
-    mqttwarn_context: Mock = mocker.patch("mqttwarn.core.context")
 
     # Run the `connect` function to completion.
     connect()
@@ -168,7 +168,6 @@ def test_connect_basic_success(mocker, caplog):
         call("testdrive", clean_session=False, protocol=3),
         call().connect("localhost", 1883, 60),
     ]
-    assert mqttwarn_context.mock_calls == []
 
     assert (
         "mqttwarn.configuration",
@@ -190,8 +189,8 @@ def test_connect_auth_success(mocker, caplog):
     mocker.patch("mqttwarn.core.cf", config)
 
     # Use mocked MQTT client and mqttwarn context instances.
+    mocker.patch("mqttwarn.core.context")
     mqtt_client: Mock = mocker.patch("paho.mqtt.client.Client")
-    mqttwarn_context: Mock = mocker.patch("mqttwarn.core.context")
 
     # Run the `connect` function to completion.
     connect()
@@ -201,7 +200,6 @@ def test_connect_auth_success(mocker, caplog):
         call().username_pw_set("foo", None),
         call().connect("localhost", 1883, 60),
     ]
-    assert mqttwarn_context.mock_calls == []
 
 
 def test_connect_tls_success(mocker, caplog):
@@ -215,8 +213,8 @@ def test_connect_tls_success(mocker, caplog):
     mocker.patch("mqttwarn.core.cf", config)
 
     # Use mocked MQTT client and mqttwarn context instances.
+    mocker.patch("mqttwarn.core.context")
     mqtt_client: Mock = mocker.patch("paho.mqtt.client.Client")
-    mqttwarn_context: Mock = mocker.patch("mqttwarn.core.context")
 
     # Run the `connect` function to completion.
     connect()
@@ -226,7 +224,6 @@ def test_connect_tls_success(mocker, caplog):
         call().tls_set(None, None, None, tls_version=None, ciphers=None),
         call().connect("localhost", 1883, 60),
     ]
-    assert mqttwarn_context.mock_calls == []
 
 
 def test_connect_tls_insecure_success(mocker, caplog):
@@ -240,8 +237,8 @@ def test_connect_tls_insecure_success(mocker, caplog):
     mocker.patch("mqttwarn.core.cf", config)
 
     # Use mocked MQTT client and mqttwarn context instances.
+    mocker.patch("mqttwarn.core.context")
     mqtt_client: Mock = mocker.patch("paho.mqtt.client.Client")
-    mqttwarn_context: Mock = mocker.patch("mqttwarn.core.context")
 
     # Run the `connect` function to completion.
     connect()
@@ -251,7 +248,6 @@ def test_connect_tls_insecure_success(mocker, caplog):
         call().tls_insecure_set(True),
         call().connect("localhost", 1883, 60),
     ]
-    assert mqttwarn_context.mock_calls == []
 
 
 def test_connect_connection_failure(mocker, caplog):
@@ -309,7 +305,7 @@ def test_on_connect_success(tmp_path, mocker, caplog):
     mocker.patch("mqttwarn.core.context", context)
     mqttc = mocker.patch("mqttwarn.core.mqttc")
 
-    on_connect(mosq=None, userdata=None, flags=None, result_code=0)
+    on_connect(mosq=None, userdata=None, flags=None, result_code=0)  # ty: ignore[invalid-argument-type]
 
     assert ("mqttwarn.core", 10, "Connected to MQTT broker, subscribing to topics") in caplog.record_tuples
     assert ("mqttwarn.core", 10, "Subscribing to test/foo (qos=0)") in caplog.record_tuples
@@ -324,7 +320,7 @@ def test_on_connect_failures(caplog):
     """
     result_codes = list(range(1, 6)) + [999]
     for result_code in result_codes:
-        on_connect(mosq=None, userdata=None, flags=None, result_code=result_code)
+        on_connect(mosq=None, userdata=None, flags=None, result_code=result_code)  # ty: ignore[invalid-argument-type]
     assert caplog.record_tuples == [
         ("mqttwarn.core", 40, "Connection refused - unacceptable protocol version"),
         ("mqttwarn.core", 40, "Connection refused - identifier rejected"),
@@ -339,7 +335,7 @@ def test_on_disconnect_success(caplog):
     """
     Verify that the `on_disconnect` event handler works as intended on the happy path.
     """
-    on_disconnect(mosq=None, userdata=None, result_code=0)
+    on_disconnect(mosq=None, userdata=None, result_code=0)  # ty: ignore[invalid-argument-type]
     assert caplog.record_tuples == [
         ("mqttwarn.core", 20, "Clean disconnection from broker"),
     ]
@@ -352,7 +348,7 @@ def test_on_disconnect_failure(mocker, caplog):
     send_failover: Mock = mocker.patch("mqttwarn.core.send_failover")
     mocker.patch("mqttwarn.core.time.sleep")
 
-    on_disconnect(mosq=None, userdata=None, result_code=999)
+    on_disconnect(mosq=None, userdata=None, result_code=999)  # ty: ignore[invalid-argument-type]
     assert caplog.record_tuples == []
     send_failover.assert_called_once_with(
         "brokerdisconnected", b"Broker connection lost. Will attempt to reconnect in 5s"
@@ -398,7 +394,9 @@ def test_subscribe_forever_success(caplog, mocker):
 
     # FIXME: Make it work on Windows.
     if sys.platform.startswith("win"):
-        raise pytest.xfail("Skipping test, fails on Windows")
+        raise pytest.xfail(
+            "Skipping test, fails on Windows"  # ty: ignore[too-many-positional-arguments, unused-ignore-comment, unused-ignore-comment]  # noqa: E501
+        )
 
     # Adjust plumbing to speed up test case.
     mocker.patch("time.sleep", lambda _: delay(0.05))
@@ -427,7 +425,11 @@ def test_subscribe_forever_fails_socket_error(caplog, mocker):
 
     # Invoke `subscribe_forever` and terminate right away using `exit_flag`.
     connect = mocker.patch("mqttwarn.core.connect")
-    connect.return_value = Mock(**{"loop_forever.side_effect": socket.error("Something failed")})
+    connect.return_value = Mock(
+        **{  # ty: ignore[invalid-argument-type, unused-ignore-comment, unused-ignore-comment]
+            "loop_forever.side_effect": socket.error("Something failed")
+        }
+    )
     t = threading.Thread(target=subscribe_forever)
     t.start()
     mocker.patch("mqttwarn.core.exit_flag", True)
@@ -456,7 +458,11 @@ def test_subscribe_forever_fails_unknown_error(caplog, mocker):
 
     # Invoke `subscribe_forever` and terminate right away using `exit_flag`.
     connect = mocker.patch("mqttwarn.core.connect")
-    connect.return_value = Mock(**{"loop_forever.side_effect": ValueError("Something failed")})
+    connect.return_value = Mock(
+        **{  # ty: ignore[invalid-argument-type, unused-ignore-comment, unused-ignore-comment]
+            "loop_forever.side_effect": ValueError("Something failed")
+        }
+    )
 
     # Invoke `subscribe_forever` in a different thread, but get hold of its exception through a `Future`.
     with ThreadPoolExecutor() as executor:
@@ -613,7 +619,7 @@ def test_xform():
     """
     Evaluates certain behaviors of `test_xform`.
     """
-    assert xform(None, None, None) is None
+    assert xform(None, None, None) is None  # ty: ignore[invalid-argument-type]
 
 
 def test_publish_status_information_success(mocker, caplog):
@@ -624,8 +630,8 @@ def test_publish_status_information_success(mocker, caplog):
     # Use a real configuration object.
     config = Config()
     config.add_section("defaults")
-    config.set("defaults", "status_publish", True)
-    config.status_publish = True
+    config.set("defaults", "status_publish", "True")
+    config.status_publish = True  # ty: ignore[unresolved-attribute]
     mocker.patch("mqttwarn.core.cf", config)
 
     # Mock the MQTT client instance.
@@ -652,8 +658,8 @@ def test_publish_status_information_failure(mocker, caplog):
     # Use a real configuration object.
     config = Config()
     config.add_section("defaults")
-    config.set("defaults", "status_publish", True)
-    config.status_publish = True
+    config.set("defaults", "status_publish", "True")
+    config.status_publish = True  # ty: ignore[unresolved-attribute]
     mocker.patch("mqttwarn.core.cf", config)
 
     # Mock the MQTT client instance.

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -9,7 +9,14 @@ def test_periodic_thread_success_now():
     Proof that the `cron.PeriodicThread` implementation works as intended.
     """
     callback = Mock()
-    pt = PeriodicThread(callback=callback, period=0.05, name="foo", srv="SRVDUMMY", now=True, options={"foo": "bar"})
+    pt = PeriodicThread(
+        callback=callback,
+        period=0.05,
+        name="foo",
+        srv="SRVDUMMY",  # ty: ignore[invalid-argument-type]
+        now=True,
+        options={"foo": "bar"},
+    )
     pt.start()
     delay(0.35)
     pt.cancel()
@@ -27,7 +34,14 @@ def test_periodic_thread_success_not_now():
     Proof that the `cron.PeriodicThread` implementation works as intended.
     """
     callback = Mock()
-    pt = PeriodicThread(callback=callback, period=0.05, name="foo", srv="SRVDUMMY", now=False, options={"foo": "bar"})
+    pt = PeriodicThread(
+        callback=callback,
+        period=0.05,
+        name="foo",
+        srv="SRVDUMMY",  # ty: ignore[invalid-argument-type]
+        now=False,
+        options={"foo": "bar"},
+    )
     pt.start()
     delay(0.35)
     pt.cancel()
@@ -51,7 +65,14 @@ def test_periodic_thread_failure(caplog):
         assert kwargs == {"options": {"foo": "bar"}}
         raise ValueError("Something failed")
 
-    pt = PeriodicThread(callback=callback, period=0.005, name="foo", srv="SRVDUMMY", now=True, options={"foo": "bar"})
+    pt = PeriodicThread(
+        callback=callback,
+        period=0.005,
+        name="foo",
+        srv="SRVDUMMY",  # ty: ignore[invalid-argument-type]
+        now=True,
+        options={"foo": "bar"},
+    )
     pt.start()
     delay(0.0125)
     pt.cancel()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -17,7 +17,10 @@ from tests import configfile_no_functions
 from tests.util import delay, mqtt_process
 
 if os.getenv("GITHUB_ACTIONS") == "true" and sys.platform != "linux":
-    raise pytest.skip(msg="On GHA, Mosquitto via Docker is only available on Linux", allow_module_level=True)
+    raise pytest.skip(
+        reason="On GHA, Mosquitto via Docker is only available on Linux",  # ty: ignore[unknown-argument, unused-ignore-comment, unused-ignore-comment]  # noqa: E501
+        allow_module_level=True,
+    )
 
 
 # Mark all test case functions within this module with `e2e`.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -55,7 +55,7 @@ def test_job_ordering_by_priority():
 def test_struct():
     data = {"hello": "world"}
     struct = Struct(**data)
-    assert struct.hello == "world"
+    assert struct.hello == "world"  # ty: ignore[unresolved-attribute]
     assert struct.get("hello") == "world"
     assert struct.get("unknown", default=42) == 42
     assert repr(struct) == "<hello: 'world'>"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -71,7 +71,7 @@ def test_timeout():
     # FIXME: Better catch and report the exception?
     # FIXME: Derive "timeout_secs" from "duration"
     with pytest.raises(ValueError) as excinfo:
-        timeout(errfunc, timeout_secs=0.1, default="foobar")
+        timeout(errfunc, timeout_secs=0.1, default="foobar")  # ty: ignore[invalid-argument-type]
 
     assert str(excinfo.value) == "Something went wrong"
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -5,10 +5,10 @@ import threading
 import time
 from unittest.mock import patch
 
-import paho
+import paho.mqtt.client
 from paho.mqtt.client import MQTTMessage
 
-import mqttwarn
+import mqttwarn.core
 from mqttwarn.commands import run as run_command
 from mqttwarn.configuration import load_configuration
 from mqttwarn.core import bootstrap, load_services, on_message, start_workers
@@ -38,15 +38,20 @@ def core_bootstrap(configfile=None):
 
 
 def send_message(topic=None, payload=None, retain=False):
+    if topic:
+        topic = topic.encode("utf-8")
+    if payload:
+        payload = payload.encode("utf-8")
+
     # Mock an instance of an Eclipse Paho MQTTMessage
-    message = MQTTMessage(mid=42, topic=topic.encode("utf-8"))
+    message = MQTTMessage(mid=42, topic=topic)
     if payload is not None:
-        message.payload = payload.encode("utf-8")
+        message.payload = payload
     if retain:
         message.retain = True
 
     # Signal the message to the machinery
-    on_message(None, None, message)
+    on_message(None, None, message)  # ty: ignore[invalid-argument-type]
 
     # Give the machinery some time to process the message
     delay()


### PR DESCRIPTION
Development sandbox performance improvements, along the lines of some functional correctness fixes still coming from Python 2 ages.

- GH-336