### PR TITLE
Modernize Desktop-Notifier

### DIFF
--- a/mqttwarn/core.py
+++ b/mqttwarn/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (c) 2014-2023 The mqttwarn developers
+# (c) 2014-2026 The mqttwarn developers
 try:
     from importlib.resources import files as resource_files  # type: ignore[attr-defined]
 except ImportError:
@@ -382,7 +382,7 @@ def xform(function: str, orig_value: t.Any, transform_data: TdataType) -> t.Unio
     if function is not None:
         try:
             function_name = sanitize_function_name(function)
-            try:
+            try:                
                 res = context.invoker.datamap(function_name, transform_data)
                 return res
             except:
@@ -455,6 +455,22 @@ def processor(worker_id=None):
             q_in.task_done()
     logger.debug("Worker thread exiting")
 
+def get_option_value(option: str, section: str,service: str, target: str, default: str = None) -> str:    
+    opt = context.get_config(section, (service +":" + target + "." + option))    
+    
+    if opt is None:        
+        opt = context.get_config(section, (service + "." + option))            
+
+    if opt is None:
+        opt = context.get_config(section, (target + "." + option))
+
+    if opt is None:
+        opt = context.get_config(section,option)        
+
+    if opt is not None:
+        return opt
+    
+    return default
 
 def process_job(job, worker_id=None):
     """
@@ -512,10 +528,11 @@ def process_job(job, worker_id=None):
         transform_data = job.data
         item["data"] = dict(list(transform_data.items()))
 
-        origin_title = "{}: {}".format(SCRIPTNAME, topic)
-        item["title"] = xform(context.get_config(section, "title"), origin_title, transform_data)
-        item["image"] = xform(context.get_config(section, "image"), "", transform_data)
-        item["message"] = xform(context.get_config(section, "format"), job.payload, transform_data)
+        origin_title = "{}: {}".format(SCRIPTNAME, topic)        
+        
+        item["title"] = xform(get_option_value( "title",section, service, target, origin_title),origin_title, transform_data)        
+        item["image"] = xform(get_option_value("image",section,  service, target, ""), "", transform_data)                        
+        item["message"] = xform(get_option_value("format", section, service, target, "{payload}"), job.payload, transform_data)
 
         try:
             item["priority"] = int(xform(context.get_config(section, "priority"), 0, transform_data))

--- a/mqttwarn/services/desktopnotify.py
+++ b/mqttwarn/services/desktopnotify.py
@@ -8,6 +8,7 @@ __license__   = 'Eclipse Public License - v 2.0 - https://www.eclipse.org/legal/
 
 import json
 import typing as t
+import asyncio
 
 from desktop_notifier import DesktopNotifier, Urgency, Button, ReplyField
 
@@ -20,7 +21,12 @@ def is_json(msg: t.Union[str, bytes]) -> bool:
      json.loads(msg)
    except ValueError as e:
      return False
+   except TypeError as e:
+      return False
    return True
+
+async def send_notification(message,title,sound=True):
+   await notify.send(message=message, title=title,sound=sound)
 
 def plugin(srv: Service, item: ProcessorItem):
     # Log
@@ -30,25 +36,28 @@ def plugin(srv: Service, item: ProcessorItem):
     config = item.config
 
     # Play Sound ?
-    playSound = True
+    playSound = False
     if isinstance(config, dict):
-       playSound = config.get('sound', True)
+       playSound = config.get('sound', False)
 
     # Get Message
-    message = item.message
+    message = item.message   
     if message and is_json(message):
        data = json.loads(message)
-    else:
+    else:       
+       try:
+          msg = message.get('message', str(message))
+       except:
+          msg = str(message)
        data = {
          "title"  : item.get('title', item.topic),
-         "message": message
+         "message": msg
        }
 
     srv.logging.debug("Sending desktop notification")
     try:
-        # Synchronous Notification (allows no callbacks in OSX)
-        # Asynchronous would require asyncio and require some changes to the plugin handler
-        notify.send_sync(message=data['message'], title=data['title'],sound=playSound)
+        # TODO: Fix issue where this keeps running until the notification is closed.
+        asyncio.run(send_notification(message=data['message'], title=data['title'],sound=False))       
 
     except Exception as e:
         srv.logging.warning("Invoking desktop notifier failed: %s" % e)


### PR DESCRIPTION
## About
- Desktop-Notifier no longer supports sync calls.
- Permit working with non-string data (i.e. dictionaries).

## References
- GH-706