### PR TITLE
Dependencies: Remove `future` package, the code supports Python 3 only

### DIFF
--- a/mqttwarn/services/emoncms.py
+++ b/mqttwarn/services/emoncms.py
@@ -5,10 +5,6 @@ __author__    = 'Ben Jones <ben.jones12()gmail.com>'
 __copyright__ = 'Copyright 2014 Ben Jones'
 __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
-
 import urllib.request, urllib.parse, urllib.error
 
 try:

--- a/mqttwarn/services/freeswitch.py
+++ b/mqttwarn/services/freeswitch.py
@@ -5,9 +5,6 @@ __author__    = 'Ben Jones <ben.jones12()gmail.com>'
 __copyright__ = 'Copyright 2014 Ben Jones'
 __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
-from future import standard_library
-standard_library.install_aliases()
-
 from xmlrpc.client import ServerProxy
 import urllib.request, urllib.parse, urllib.error
 

--- a/mqttwarn/services/ionic.py
+++ b/mqttwarn/services/ionic.py
@@ -5,8 +5,6 @@ __author__ = 'hubble2webb <hubble2webb@users.noreply.github.com>'
 __copyright__ = 'Copyright 2015 hubble2webb'
 __license__ = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 
 import urllib.request, urllib.error, urllib.parse

--- a/mqttwarn/services/mqtt.py
+++ b/mqttwarn/services/mqtt.py
@@ -6,8 +6,6 @@ __copyright__ = 'Copyright 2014 Jan-Piet Mens'
 __license__ = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
 from six import string_types
-from future import standard_library
-standard_library.install_aliases()
 
 import configparser
 import paho.mqtt.publish as mqtt

--- a/mqttwarn/services/mythtv.py
+++ b/mqttwarn/services/mythtv.py
@@ -7,9 +7,6 @@ __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/ep
 
 from ssl import SSLError
 
-from future import standard_library
-standard_library.install_aliases()
-
 import http.client, urllib.request, urllib.parse, urllib.error
 
 

--- a/mqttwarn/services/thingspeak.py
+++ b/mqttwarn/services/thingspeak.py
@@ -6,9 +6,6 @@ __author__ = 'Marcel Verpaalen'
 __copyright__ = 'Copyright 2015 Marcel Verpaalen'
 __license__ = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
-from future import standard_library
-standard_library.install_aliases()
-
 from builtins import str
 from urllib.parse import urlencode
 from http.client import HTTPSConnection, HTTPException

--- a/mqttwarn/services/xbmc.py
+++ b/mqttwarn/services/xbmc.py
@@ -5,9 +5,6 @@ __author__    = 'Ben Jones <ben.jones12()gmail.com>'
 __copyright__ = 'Copyright 2014 Ben Jones'
 __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
-from future import standard_library
-standard_library.install_aliases()
-
 import urllib.request, urllib.parse, urllib.error
 import base64
 try:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ requires = [
     "attrs<23",
     "docopt<1",
     "funcy<3",
-    "future>=0.18.0,<1",
     "importlib-metadata; python_version<'3.8'",
     "importlib-resources; python_version<'3.9'",
     "jinja2<4",


### PR DESCRIPTION
The imports have no effect on Python 3.
https://pypi.org/project/future/
- GH-591