### PR TITLE
Clarify filter suppression semantics

### DIFF
--- a/docs/configure/transformation.md
+++ b/docs/configure/transformation.md
@@ -487,6 +487,12 @@ process the message.
 The filter function should return `True` if the message should be suppressed, 
 or `False` if the message should be processed. This is a basic but working
 example for such a filter function.
+
+| Callback result | Outcome |
+| --- | --- |
+| `True` | Message is filtered out; notification is skipped |
+| `False` | Message proceeds to the configured targets |
+
 ```python
 from mqttwarn.model import Service
 

--- a/mqttwarn/context.py
+++ b/mqttwarn/context.py
@@ -211,12 +211,15 @@ class FunctionInvoker:
     def filter(self, name: str, topic: str, payload: t.AnyStr, section: t.Optional[str] = None) -> bool:  # noqa:A003
         """
         Invoke function "name" loaded from the "functions" Python module.
-        Return that function's True/False.
+        Return whether the outbound notification should be suppressed.
+
+        ``True`` suppresses the notification; ``False`` continues normal
+        notification processing.
 
         :param name:    Function name to invoke
         :param topic:   Topic to pass to the invoked function
         :param payload: Payload to pass to the invoked function
-        :return:        Return value of function invocation
+        :return:        Whether to suppress the outbound notification
         """
 
         # Filtering currently only works on text.

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -132,3 +132,10 @@ def test_runtime_context_get_service_targets(runtime_ini_file):
     context = RuntimeContext(config=config, invoker=None)
     assert context.get_service_targets("foo") == {"abc": "def"}
     assert context.get_service_targets("unknown") == [None]
+
+
+def test_filter_docstring_describes_suppression_contract():
+    """Verify the filter callback's inverted suppression semantics are explicit."""
+    docstring = FunctionInvoker.filter.__doc__ or ""
+    assert "``True`` suppresses" in docstring
+    assert "``False`` continues" in docstring


### PR DESCRIPTION
Closes #637

Clarifies that filter callbacks are suppression predicates: `True` skips a notification and `False` continues delivery. The user guide now includes a truth table, and the API docstring has regression coverage for the same contract.

Validation: focused contract regression (fails without the docstring fix, passes with it), Ruff, Black, Python compilation, and both diff gates passed.
